### PR TITLE
refactor(RELEASE-920): release pipeline tests use new tag format

### DIFF
--- a/tests/release/pipelines/rh_advisories.go
+++ b/tests/release/pipelines/rh_advisories.go
@@ -246,6 +246,8 @@ func createADVSReleasePlanAdmission(advsRPAName string, managedFw framework.Fram
 				{
 					"name":       component.GetName(),
 					"repository": "quay.io/redhat-pending/rhtap----konflux-release-e2e",
+					"tags": []string{"latest", "latest-{{ timestamp }}", "testtag",
+						"testtag-{{ timestamp }}", "testtag2", "testtag2-{{ timestamp }}"},
 				},
 			},
 		},
@@ -260,13 +262,6 @@ func createADVSReleasePlanAdmission(advsRPAName string, managedFw framework.Fram
 			"product_stream":  "rhtas-tp1",
 			"product_version": "v1.0",
 			"type":            "RHSA",
-		},
-		"images": map[string]interface{}{
-			"defaultTag":      "latest",
-			"addGitShaTag":    false,
-			"addTimestampTag": false,
-			"addSourceShaTag": false,
-			"floatingTags":    []string{"testtag", "testtag2"},
 		},
 		"sign": map[string]interface{}{
 			"configMapName": "hacbs-signing-pipeline-config-redhatbeta2",

--- a/tests/release/pipelines/rh_push_to_redhat_io.go
+++ b/tests/release/pipelines/rh_push_to_redhat_io.go
@@ -239,19 +239,14 @@ func createRHIOReleasePlanAdmission(rhioRPAName string, managedFw framework.Fram
 				{
 					"name":       testComponent.GetName(),
 					"repository": "quay.io/redhat-pending/rhtap----konflux-release-e2e",
+					"tags": []string{"latest", "latest-{{ timestamp }}", "testtag",
+						"testtag-{{ timestamp }}", "testtag2", "testtag2-{{ timestamp }}"},
 				},
 			},
 		},
 		"pyxis": map[string]interface{}{
 			"server": "stage",
 			"secret": "pyxis",
-		},
-		"images": map[string]interface{}{
-			"defaultTag":      "latest",
-			"addGitShaTag":    false,
-			"addTimestampTag": false,
-			"addSourceShaTag": false,
-			"floatingTags":    []string{"testtag", "testtag2"},
 		},
 		"fileUpdates": []map[string]interface{}{
 			{


### PR DESCRIPTION
This commit refactors the release pipeline tests to use the new tag format and remove the old one.

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
