### PR TITLE
fix: ignore source correlated check in EC tests

### DIFF
--- a/tests/enterprise-contract/contract.go
+++ b/tests/enterprise-contract/contract.go
@@ -343,7 +343,15 @@ var _ = framework.EnterpriseContractSuiteDescribe("Enterprise Contract E2E tests
 					Expect(fwk.AsKubeAdmin.TektonController.CreateOrUpdateSigningSecret(goldenImagePublicKey, secretName, namespace)).To(Succeed())
 					generator.PublicKey = fmt.Sprintf("k8s://%s/%s", namespace, secretName)
 
-					policy := defaultECP.Spec
+					policy := contract.PolicySpecWithSourceConfig(
+						defaultECP.Spec,
+						ecp.SourceConfig{
+							Include: []string{"@slsa3"},
+							// This test validates an image via a floating tag (as designed). This makes
+							// it hard to provide the expected git commit. Here we just ignore that
+							// particular check.
+							Exclude: []string{"slsa_source_correlated.source_code_reference_provided"},
+						})
 					Expect(fwk.AsKubeAdmin.TektonController.CreateOrUpdatePolicyConfiguration(namespace, policy)).To(Succeed())
 
 					generator.WithComponentImage("quay.io/redhat-appstudio/ec-golden-image:latest")


### PR DESCRIPTION
# Description

Some of the EC tests validate images via floating tags (as designed). This makes it hard to provide the expected git commit. Here we just ignore that particular check.

## Issue ticket number and link

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
