### PR TITLE
fix: secret-lookup tests changed to use organization where github app is not installed

### DIFF
--- a/pkg/clients/github/git.go
+++ b/pkg/clients/github/git.go
@@ -59,3 +59,49 @@ func (g *Github) ExistsRef(repository, branchName string) (bool, error) {
 	}
 	return true, nil
 }
+
+func (g *Github) DeleteRefFromOrg(githubOrg, repository, branchName string) error {
+	_, err := g.client.Git.DeleteRef(context.Background(), githubOrg, repository, fmt.Sprintf(HEADS, branchName))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (g *Github) ExistsRefInOrg(githubOrg, repository, branchName string) (bool, error) {
+	_, _, err := g.client.Git.GetRef(context.Background(), githubOrg, repository, fmt.Sprintf(HEADS, branchName))
+	if err != nil {
+		if strings.Contains(err.Error(), "404 Not Found") {
+			return false, nil
+		} else {
+			return false, fmt.Errorf("error when getting the branch '%s' for the repo '%s': %+v", branchName, repository, err)
+		}
+	}
+	return true, nil
+}
+
+func (g *Github) CreateRefInOrg(githubOrg, repository, baseBranchName, sha, newBranchName string) error {
+	ctx := context.Background()
+	ref, _, err := g.client.Git.GetRef(ctx, githubOrg, repository, fmt.Sprintf(HEADS, baseBranchName))
+	if err != nil {
+		return fmt.Errorf("error when getting the base branch name '%s' for the repo '%s': %+v", baseBranchName, repository, err)
+	}
+
+	ref.Ref = github.String(fmt.Sprintf(HEADS, newBranchName))
+
+	if sha != "" {
+		ref.Object.SHA = &sha
+	}
+
+	_, _, err = g.client.Git.CreateRef(ctx, githubOrg, repository, ref)
+	if err != nil {
+		return fmt.Errorf("error when creating a new branch '%s' for the repo '%s': %+v", newBranchName, repository, err)
+	}
+	Eventually(func(gomega Gomega) {
+		exist, err := g.ExistsRefInOrg(githubOrg, repository, newBranchName)
+		gomega.Expect((err)).NotTo(HaveOccurred())
+		gomega.Expect(exist).To(BeTrue())
+
+	}, 2*time.Minute, 2*time.Second).Should(Succeed()) //Wait for the branch to actually exist
+	return nil
+}

--- a/tests/build/build.go
+++ b/tests/build/build.go
@@ -893,11 +893,11 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 			Expect(err).NotTo(HaveOccurred())
 
 			firstComponentBaseBranchName = fmt.Sprintf("component-one-base-%s", util.GenerateRandomString(6))
-			err = f.AsKubeAdmin.CommonController.Github.CreateRef(secretLookupGitSourceRepoOneName, secretLookupDefaultBranchOne, secretLookupGitRevisionOne, firstComponentBaseBranchName)
+			err = f.AsKubeAdmin.CommonController.Github.CreateRefInOrg(noAppOrgName, secretLookupGitSourceRepoOneName, secretLookupDefaultBranchOne, secretLookupGitRevisionOne, firstComponentBaseBranchName)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			secondComponentBaseBranchName = fmt.Sprintf("component-two-base-%s", util.GenerateRandomString(6))
-			err = f.AsKubeAdmin.CommonController.Github.CreateRef(secretLookupGitSourceRepoTwoName, secretLookupDefaultBranchTwo, secretLookupGitRevisionTwo, secondComponentBaseBranchName)
+			err = f.AsKubeAdmin.CommonController.Github.CreateRefInOrg(noAppOrgName, secretLookupGitSourceRepoTwoName, secretLookupDefaultBranchTwo, secretLookupGitRevisionTwo, secondComponentBaseBranchName)
 			Expect(err).ShouldNot(HaveOccurred())
 
 		})
@@ -909,22 +909,22 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 			}
 
 			// Delete new branches created by PaC
-			err = f.AsKubeAdmin.CommonController.Github.DeleteRef(secretLookupGitSourceRepoOneName, firstPacBranchName)
+			err = f.AsKubeAdmin.CommonController.Github.DeleteRefFromOrg(noAppOrgName, secretLookupGitSourceRepoOneName, firstPacBranchName)
 			if err != nil {
 				Expect(err.Error()).To(ContainSubstring("Reference does not exist"))
 			}
-			err = f.AsKubeAdmin.CommonController.Github.DeleteRef(secretLookupGitSourceRepoTwoName, secondPacBranchName)
+			err = f.AsKubeAdmin.CommonController.Github.DeleteRefFromOrg(noAppOrgName, secretLookupGitSourceRepoTwoName, secondPacBranchName)
 			if err != nil {
 				Expect(err.Error()).To(ContainSubstring("Reference does not exist"))
 			}
 
 			// Delete the created first component base branch
-			err = f.AsKubeAdmin.CommonController.Github.DeleteRef(secretLookupGitSourceRepoOneName, firstComponentBaseBranchName)
+			err = f.AsKubeAdmin.CommonController.Github.DeleteRefFromOrg(noAppOrgName, secretLookupGitSourceRepoOneName, firstComponentBaseBranchName)
 			if err != nil {
 				Expect(err.Error()).To(ContainSubstring("Reference does not exist"))
 			}
 			// Delete the created second component base branch
-			err = f.AsKubeAdmin.CommonController.Github.DeleteRef(secretLookupGitSourceRepoTwoName, secondComponentBaseBranchName)
+			err = f.AsKubeAdmin.CommonController.Github.DeleteRefFromOrg(noAppOrgName, secretLookupGitSourceRepoTwoName, secondComponentBaseBranchName)
 			if err != nil {
 				Expect(err.Error()).To(ContainSubstring("Reference does not exist"))
 			}
@@ -938,7 +938,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 				// create the correct build secret for second component
 				secretName1 := "build-secret-1"
 				secretAnnotations := map[string]string{
-					"appstudio.redhat.com/scm.repository": os.Getenv("MY_GITHUB_ORG") + "/" + secretLookupGitSourceRepoTwoName,
+					"appstudio.redhat.com/scm.repository": noAppOrgName + "/" + secretLookupGitSourceRepoTwoName,
 				}
 				token := os.Getenv("GITHUB_TOKEN")
 				err = createBuildSecret(f, secretName1, secretAnnotations, token)

--- a/tests/build/const.go
+++ b/tests/build/const.go
@@ -51,6 +51,8 @@ const (
 
 	//Logging related
 	buildStatusAnnotationValueLoggingFormat = "build status annotation value: %s\n"
+
+	noAppOrgName = "redhat-appstudio-qe-no-app"
 )
 
 var (
@@ -62,6 +64,6 @@ var (
 	multiComponentGitSourceURL      = fmt.Sprintf(githubUrlFormat, gihubOrg, multiComponentGitSourceRepoName)
 	multiComponentContextDirs       = []string{"go-component", "python-component"}
 
-	secretLookupComponentOneGitSourceURL = fmt.Sprintf(githubUrlFormat, gihubOrg, secretLookupGitSourceRepoOneName)
-	secretLookupComponentTwoGitSourceURL = fmt.Sprintf(githubUrlFormat, gihubOrg, secretLookupGitSourceRepoTwoName)
+	secretLookupComponentOneGitSourceURL = fmt.Sprintf(githubUrlFormat, noAppOrgName, secretLookupGitSourceRepoOneName)
+	secretLookupComponentTwoGitSourceURL = fmt.Sprintf(githubUrlFormat, noAppOrgName, secretLookupGitSourceRepoTwoName)
 )


### PR DESCRIPTION
# Description

secret-lookup tests changed to use organization where github app is not installed
Credits: https://github.com/konflux-ci/e2e-tests/pull/1200

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
