### PR TITLE
fix: checking CheckRuns conclusion in GitHub

### DIFF
--- a/pkg/clients/github/pull_request.go
+++ b/pkg/clients/github/pull_request.go
@@ -3,9 +3,12 @@ package github
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/go-github/v44/github"
+	"github.com/konflux-ci/e2e-tests/pkg/utils"
+	ginkgo "github.com/onsi/ginkgo/v2"
 )
 
 func (g *Github) GetPullRequest(repository string, id int) (*github.PullRequest, error) {
@@ -83,4 +86,53 @@ func (g *Github) GetPRDetails(ghRepo string, prID int) (string, string, error) {
 		return "", "", err
 	}
 	return *pullRequest.Head.Repo.CloneURL, *pullRequest.Head.Ref, nil
+}
+
+// GetCheckRunConclusion fetches a specific CheckRun within a given repo
+// by matching the CheckRun's name with the given checkRunName, and
+// then returns the CheckRun conclusion
+func (g *Github) GetCheckRunConclusion(checkRunName, repoName, prHeadSha string, prNumber int) (string, error) {
+	const checkrunStatusCompleted = "completed"
+	var errMsgSuffix = fmt.Sprintf("repository: %s, PR number: %d, PR head SHA: %s, checkRun name: %s\n", repoName, prNumber, prHeadSha, checkRunName)
+
+	var checkRun *github.CheckRun
+	var timeout time.Duration
+	var err error
+
+	timeout = time.Minute * 5
+
+	err = utils.WaitUntil(func() (done bool, err error) {
+		checkRuns, err := g.ListCheckRuns(repoName, prHeadSha)
+		if err != nil {
+			ginkgo.GinkgoWriter.Printf("got error when listing CheckRuns: %+v\n", err)
+			return false, nil
+		}
+		for _, cr := range checkRuns {
+			if strings.Contains(cr.GetName(), checkRunName) {
+				checkRun = cr
+				return true, nil
+			}
+		}
+		return false, nil
+	}, timeout)
+	if err != nil {
+		return "", fmt.Errorf("timed out when waiting for the PaC CheckRun to appear for %s", errMsgSuffix)
+	}
+	err = utils.WaitUntil(func() (done bool, err error) {
+		checkRun, err = g.GetCheckRun(repoName, checkRun.GetID())
+		if err != nil {
+			ginkgo.GinkgoWriter.Printf("got error when listing CheckRuns: %+v\n", errMsgSuffix, err)
+			return false, nil
+		}
+		currentCheckRunStatus := checkRun.GetStatus()
+		if currentCheckRunStatus != checkrunStatusCompleted {
+			ginkgo.GinkgoWriter.Printf("expecting CheckRun status %s, got: %s", checkrunStatusCompleted, currentCheckRunStatus)
+			return false, nil
+		}
+		return true, nil
+	}, timeout)
+	if err != nil {
+		return "", fmt.Errorf("timed out when waiting for the PaC CheckRun status to be '%s' for %s", checkrunStatusCompleted, errMsgSuffix)
+	}
+	return checkRun.GetConclusion(), nil
 }

--- a/pkg/clients/github/pull_request.go
+++ b/pkg/clients/github/pull_request.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/google/go-github/v44/github"
+	"github.com/konflux-ci/e2e-tests/pkg/constants"
 	"github.com/konflux-ci/e2e-tests/pkg/utils"
 	ginkgo "github.com/onsi/ginkgo/v2"
 )
@@ -92,7 +93,6 @@ func (g *Github) GetPRDetails(ghRepo string, prID int) (string, string, error) {
 // by matching the CheckRun's name with the given checkRunName, and
 // then returns the CheckRun conclusion
 func (g *Github) GetCheckRunConclusion(checkRunName, repoName, prHeadSha string, prNumber int) (string, error) {
-	const checkrunStatusCompleted = "completed"
 	var errMsgSuffix = fmt.Sprintf("repository: %s, PR number: %d, PR head SHA: %s, checkRun name: %s\n", repoName, prNumber, prHeadSha, checkRunName)
 
 	var checkRun *github.CheckRun
@@ -125,14 +125,14 @@ func (g *Github) GetCheckRunConclusion(checkRunName, repoName, prHeadSha string,
 			return false, nil
 		}
 		currentCheckRunStatus := checkRun.GetStatus()
-		if currentCheckRunStatus != checkrunStatusCompleted {
-			ginkgo.GinkgoWriter.Printf("expecting CheckRun status %s, got: %s", checkrunStatusCompleted, currentCheckRunStatus)
+		if currentCheckRunStatus != constants.CheckrunStatusCompleted {
+			ginkgo.GinkgoWriter.Printf("expecting CheckRun status %s, got: %s", constants.CheckrunStatusCompleted, currentCheckRunStatus)
 			return false, nil
 		}
 		return true, nil
 	}, timeout)
 	if err != nil {
-		return "", fmt.Errorf("timed out when waiting for the PaC CheckRun status to be '%s' for %s", checkrunStatusCompleted, errMsgSuffix)
+		return "", fmt.Errorf("timed out when waiting for the PaC CheckRun status to be '%s' for %s", constants.CheckrunStatusCompleted, errMsgSuffix)
 	}
 	return checkRun.GetConclusion(), nil
 }

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -211,6 +211,7 @@ const (
 
 	CheckrunConclusionSuccess = "success"
 	CheckrunConclusionFailure = "failure"
+	CheckrunStatusCompleted   = "completed"
 )
 
 var (

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -208,6 +208,9 @@ const (
 	PaCControllerRouteName = "pipelines-as-code-controller"
 
 	DockerFilePath = "docker/Dockerfile"
+
+	CheckrunConclusionSuccess = "success"
+	CheckrunConclusionFailure = "failure"
 )
 
 var (

--- a/tests/integration-service/status-reporting-to-pullrequest.go
+++ b/tests/integration-service/status-reporting-to-pullrequest.go
@@ -3,11 +3,9 @@ package integration
 import (
 	"fmt"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/devfile/library/v2/pkg/util"
-	"github.com/google/go-github/v44/github"
 	"github.com/konflux-ci/e2e-tests/pkg/clients/has"
 	"github.com/konflux-ci/e2e-tests/pkg/constants"
 	"github.com/konflux-ci/e2e-tests/pkg/framework"
@@ -148,7 +146,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Status Reporting of Integrati
 
 			It("eventually leads to the build PipelineRun's status reported at Checks tab", func() {
 				expectedCheckRunName := fmt.Sprintf("%s-%s", componentName, "on-pull-request")
-				validateCheckRun(*f, expectedCheckRunName, checkrunConclusionSuccess, componentRepoNameForStatusReporting, prHeadSha, prNumber)
+				Expect(f.AsKubeAdmin.CommonController.Github.GetCheckRunConclusion(expectedCheckRunName, componentRepoNameForStatusReporting, prHeadSha, prNumber)).To(Equal(constants.CheckrunConclusionSuccess))
 			})
 		})
 
@@ -197,42 +195,11 @@ var _ = framework.IntegrationServiceSuiteDescribe("Status Reporting of Integrati
 				}, time.Minute*3, time.Second*5).Should(BeTrue(), fmt.Sprintf("Timed out waiting for Snapshot to be marked as failed %s/%s", snapshot.GetNamespace(), snapshot.GetName()))
 			})
 			It("eventually leads to the status reported at Checks tab for the successful Integration PipelineRun", func() {
-				validateCheckRun(*f, integrationTestScenarioPass.Name, checkrunConclusionSuccess, componentRepoNameForStatusReporting, prHeadSha, prNumber)
+				Expect(f.AsKubeAdmin.CommonController.Github.GetCheckRunConclusion(integrationTestScenarioPass.Name, componentRepoNameForStatusReporting, prHeadSha, prNumber)).To(Equal(constants.CheckrunConclusionSuccess))
 			})
 			It("eventually leads to the status reported at Checks tab for the failed Integration PipelineRun", func() {
-				validateCheckRun(*f, integrationTestScenarioFail.Name, checkrunConclusionFailure, componentRepoNameForStatusReporting, prHeadSha, prNumber)
+				Expect(f.AsKubeAdmin.CommonController.Github.GetCheckRunConclusion(integrationTestScenarioFail.Name, componentRepoNameForStatusReporting, prHeadSha, prNumber)).To(Equal(constants.CheckrunConclusionFailure))
 			})
 		})
 	})
 })
-
-// validateCheckRun fetches a specific CheckRun within a given repo
-// by matching the CheckRun's name with the given checkRunName, and
-// then validates that it got completed and its conclusion is as expected
-func validateCheckRun(f framework.Framework, checkRunName, conclusion, repoName, prHeadSha string, prNumber int) {
-	var checkRun *github.CheckRun
-	var timeout, interval time.Duration
-	var err error
-
-	timeout = time.Minute * 10
-	interval = time.Second * 2
-
-	Eventually(func() *github.CheckRun {
-		checkRuns, err := f.AsKubeAdmin.CommonController.Github.ListCheckRuns(repoName, prHeadSha)
-		Expect(err).ShouldNot(HaveOccurred())
-		for _, cr := range checkRuns {
-			if strings.Contains(cr.GetName(), checkRunName) {
-				checkRun = cr
-				return cr
-			}
-		}
-		return nil
-	}, timeout, interval).ShouldNot(BeNil(), fmt.Sprintf("timed out when waiting for the PaC CheckRun, with `Name` field containing the substring %s, to appear in the PR #%d of the Component repo %s", checkRunName, prNumber, repoName))
-
-	Eventually(func() string {
-		checkRun, err = f.AsKubeAdmin.CommonController.Github.GetCheckRun(repoName, checkRun.GetID())
-		Expect(err).ShouldNot(HaveOccurred())
-		return checkRun.GetStatus()
-	}, timeout, interval).Should(Equal(checkrunStatusCompleted), fmt.Sprintf("timed out when waiting for the PaC Check suite status to be 'completed' in the Component repo %s in PR #%d", repoName, prNumber))
-	Expect(checkRun.GetConclusion()).To(Equal(conclusion), fmt.Sprintf("the PR %d in %s repo doesn't contain the expected conclusion (%s) of the CheckRun", prNumber, repoName, conclusion))
-}


### PR DESCRIPTION
# Description

* removal of [these lines](https://github.com/konflux-ci/e2e-tests/commit/a6ef178c8f0e0587f81ad893141977db17ece30c#diff-938ddf0d569d68c3df496d8b4065614ff56cc303c33555755621cffcec97ef74L66-L68) accidentally broke validating build PLR CheckRun's status - this PR fixes it and unifies the logic for getting CheckRun conclusion for build and integration-service tests

## Issue ticket number and link
https://issues.redhat.com/browse/KFLUXBUGS-20

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
```
ginkgo build ./cmd && ginkgo -p -v --label-filter='build-custom-branch,status-reporting' ./cmd/cmd.test
```

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
