### PR TITLE
chore: migrate build-definitions redhat-appstudio images

### DIFF
--- a/tests/release/const.go
+++ b/tests/release/const.go
@@ -45,7 +45,7 @@ const (
 	// EC constants
 	EcPolicyLibPath     = "github.com/enterprise-contract/ec-policies//policy/lib"
 	EcPolicyReleasePath = "github.com/enterprise-contract/ec-policies//policy/release"
-	EcPolicyDataBundle  = "oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest"
+	EcPolicyDataBundle  = "oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest"
 	EcPolicyDataPath    = "github.com/release-engineering/rhtap-ec-policy//data"
 
 	// Service constants


### PR DESCRIPTION
[STONEBLD-2339](https://issues.redhat.com//browse/STONEBLD-2339)

All the images built in build-definitions CI now get released to the
quay.io/konflux-ci organization.

Replace the relevant redhat-appstudio[-tekton-catalog] references in
this repo with konflux-ci[/tekton-catalog] references.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>
