### PR TITLE
chore(DEVHAS-651): Remove test code for deprecated controllers

### DIFF
--- a/tests/rhtap-demo/rhtap-demo.go
+++ b/tests/rhtap-demo/rhtap-demo.go
@@ -83,8 +83,6 @@ var _ = framework.RhtapDemoSuiteDescribe(func() {
 	var namespace string
 	var err error
 
-	// Initialize the application struct
-	application := &appservice.Application{}
 	snapshot := &appservice.Snapshot{}
 
 	fw := &framework.Framework{}
@@ -162,15 +160,6 @@ var _ = framework.RhtapDemoSuiteDescribe(func() {
 					Expect(err).NotTo(HaveOccurred())
 					Expect(createdApplication.Spec.DisplayName).To(Equal(appTest.ApplicationName))
 					Expect(createdApplication.Namespace).To(Equal(namespace))
-				})
-
-				It("checks if application is healthy", Label(devEnvTestLabel, stageEnvTestLabel), func() {
-					Eventually(func() string {
-						application, err = fw.AsKubeDeveloper.HasController.GetApplication(appTest.ApplicationName, namespace)
-						Expect(err).NotTo(HaveOccurred())
-
-						return application.Status.Devfile
-					}, 3*time.Minute, 100*time.Millisecond).Should(Not(BeEmpty()), fmt.Sprintf("timed out waiting for the %s application in %s namespace to be ready", appTest.ApplicationName, fw.UserNamespace))
 				})
 
 				for _, componentSpec := range appTest.Components {


### PR DESCRIPTION
# Description

Removes test code that is no longer needed as a result of the deprecation of the Application and Component controllers within HAS. 

As a result of the removal of the HAS controllers, HAS will no longer set the following fields in the status, and they can be removed:
- status.Devfile in the Application CR
- create/update status condition in the Application CR
- create/update status condition in the Component CR

## Issue ticket number and link
https://issues.redhat.com/browse/DEVHAS-651

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
