### PR TITLE
feat: allow pairing 3 repositories

### DIFF
--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -495,6 +495,11 @@ func setRequiredEnvVars() error {
 				os.Setenv(fmt.Sprintf("%s_PR_OWNER", envVarPrefix), pr.RemoteName)
 				os.Setenv(fmt.Sprintf("%s_PR_SHA", envVarPrefix), pr.CommitSHA)
 			}
+			// Allow pairing component repo PR + e2e-tests PR + infra-deployments PR
+			if isPRPairingRequired("infra-deployments") {
+				os.Setenv("INFRA_DEPLOYMENTS_ORG", pr.RemoteName)
+				os.Setenv("INFRA_DEPLOYMENTS_BRANCH", pr.BranchName)
+			}
 
 			os.Setenv("E2E_TEST_SUITE_LABEL", testSuiteLabel)
 


### PR DESCRIPTION
# Description

until now, PR pairing worked only for:
* component repo PR + e2e-tests PR
* e2e-tests PR + infra-deployments PR (and vice versa)

this change allows pairing `component repo PR (+ e2e-tests PR) + infra-deployments PR` (if all PRs were created from the same org + branch)

## Issue ticket number and link
N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

N/A
# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
