### PR TITLE
chore: Remove BuildPipelineSelector

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,6 +53,7 @@ require (
 	golang.org/x/crypto v0.22.0
 	golang.org/x/oauth2 v0.20.0
 	golang.org/x/tools v0.20.0
+	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.29.4
 	k8s.io/apimachinery v0.29.4
 	k8s.io/cli-runtime v0.28.5
@@ -332,7 +333,6 @@ require (
 	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.29.2 // indirect
 	k8s.io/apiserver v0.29.2 // indirect

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -389,7 +389,6 @@ func setRequiredEnvVars() error {
 
 				klog.Infof("going to override default Tekton bundle s2i-java task for the purpose of testing jvm-build-service PR")
 				var err error
-				var defaultBundleRef string
 				var tektonObj runtime.Object
 
 				tag := fmt.Sprintf("%d-%s", time.Now().Unix(), util.GenerateRandomString(4))
@@ -404,9 +403,10 @@ func setRequiredEnvVars() error {
 				if err = utils.CreateDockerConfigFile(os.Getenv("QUAY_TOKEN")); err != nil {
 					return fmt.Errorf("failed to create docker config file: %+v", err)
 				}
-				if defaultBundleRef, err = tekton.GetDefaultPipelineBundleRef(constants.BuildPipelineSelectorYamlURL, "Java"); err != nil {
-					return fmt.Errorf("failed to get the pipeline bundle ref: %+v", err)
-				}
+				// Since we do not include java builder in the default pipelines list, it's not possible
+				// to use GetDefaultPipelineBundleRef and get it from build pipeline config Config Map.
+				// Fallback to the latest dev version for now.
+				defaultBundleRef := "quay.io/konflux-ci/tekton-catalog/pipeline-java-builder:devel"
 				if tektonObj, err = tekton.ExtractTektonObjectFromBundle(defaultBundleRef, "pipeline", "java-builder"); err != nil {
 					return fmt.Errorf("failed to extract the Tekton Pipeline from bundle: %+v", err)
 				}
@@ -566,7 +566,7 @@ func SetupMultiPlatformTests() error {
 		if err = utils.CreateDockerConfigFile(os.Getenv("QUAY_TOKEN")); err != nil {
 			return fmt.Errorf("failed to create docker config file: %+v", err)
 		}
-		if defaultBundleRef, err = tekton.GetDefaultPipelineBundleRef(constants.BuildPipelineSelectorYamlURL, "Docker build"); err != nil {
+		if defaultBundleRef, err = tekton.GetDefaultPipelineBundleRef(constants.BuildPipelineConfigConfigMapYamlURL, "docker-build"); err != nil {
 			return fmt.Errorf("failed to get the pipeline bundle ref: %+v", err)
 		}
 		if tektonObj, err = tekton.ExtractTektonObjectFromBundle(defaultBundleRef, "pipeline", "docker-build"); err != nil {
@@ -638,7 +638,7 @@ func SetupSourceBuild() {
 	// 	klog.Errorf("failed to create docker config file: %+v", err)
 	// 	return
 	// }
-	if defaultBundleRef, err = tekton.GetDefaultPipelineBundleRef(constants.BuildPipelineSelectorYamlURL, "Docker build"); err != nil {
+	if defaultBundleRef, err = tekton.GetDefaultPipelineBundleRef(constants.BuildPipelineConfigConfigMapYamlURL, "docker-build"); err != nil {
 		klog.Errorf("failed to get the pipeline bundle ref: %+v", err)
 		return
 	}

--- a/pkg/clients/has/components.go
+++ b/pkg/clients/has/components.go
@@ -200,11 +200,8 @@ func (h *HasController) WaitForComponentPipelineToBeFinished(component *appservi
 
 // Universal method to create a component in the kubernetes clusters.
 func (h *HasController) CreateComponent(componentSpec appservice.ComponentSpec, namespace string, outputContainerImage string, secret string, applicationName string, skipInitialChecks bool, annotations map[string]string) (*appservice.Component, error) {
-
 	componentObject := &appservice.Component{
 		ObjectMeta: metav1.ObjectMeta{
-			// adding default label because of the BuildPipelineSelector in build test
-			Labels:    constants.ComponentDefaultLabel,
 			Name:      componentSpec.ComponentName,
 			Namespace: namespace,
 			Annotations: map[string]string{
@@ -531,36 +528,6 @@ func (h *HasController) StoreAllComponents(namespace string) error {
 		}
 	}
 	return nil
-}
-
-// specific for tests/remote-secret/image-repository-cr-image-pull-remote-secret.go
-func (h *HasController) CreateComponentWithoutGenerateAnnotation(componentSpec appservice.ComponentSpec, namespace string, secret string, applicationName string, skipInitialChecks bool) (*appservice.Component, error) {
-	componentObject := &appservice.Component{
-		ObjectMeta: metav1.ObjectMeta{
-			// adding default label because of the BuildPipelineSelector in build test
-			Labels:    constants.ComponentDefaultLabel,
-			Name:      componentSpec.ComponentName,
-			Namespace: namespace,
-			Annotations: map[string]string{
-				"skip-initial-checks": strconv.FormatBool(skipInitialChecks),
-			},
-		},
-		Spec: componentSpec,
-	}
-	componentObject.Spec.Secret = secret
-	componentObject.Spec.Application = applicationName
-
-	componentObject.Annotations = utils.MergeMaps(componentObject.Annotations, constants.DefaultDockerBuildPipelineBundle)
-
-	if componentObject.Spec.TargetPort == 0 {
-		componentObject.Spec.TargetPort = 8081
-	}
-
-	if err := h.KubeRest().Create(context.Background(), componentObject); err != nil {
-		return nil, err
-	}
-
-	return componentObject, nil
 }
 
 // UpdateComponent updates a component

--- a/pkg/clients/tekton/bundles.go
+++ b/pkg/clients/tekton/bundles.go
@@ -13,10 +13,8 @@ import (
 )
 
 type Bundles struct {
-	FBCBuilderBundle    string
-	DockerBuildBundle   string
-	JavaBuilderBundle   string
-	NodeJSBuilderBundle string
+	DockerBuildBundle string
+	FBCBuilderBundle  string
 }
 
 // NewBundles returns new Bundles.
@@ -44,10 +42,6 @@ func (t *TektonController) NewBundles() (*Bundles, error) {
 			bundles.DockerBuildBundle = pipeline.Bundle
 		case "fbc-builder":
 			bundles.FBCBuilderBundle = pipeline.Bundle
-		case "java-builder":
-			bundles.JavaBuilderBundle = pipeline.Bundle
-		case "nodejs-builder":
-			bundles.NodeJSBuilderBundle = pipeline.Bundle
 		}
 	}
 	return bundles, nil

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -85,13 +85,13 @@ const (
 	// Managed workspace for release pipelines tests
 	RELEASE_MANAGED_WORKSPACE_ENV = "RELEASE_MANAGED_WORKSPACE"
 
-	// Bundle ref for overriding the default Java build bundle specified in BuildPipelineSelectorYamlURL
+	// Bundle ref for overriding the default Java build bundle specified in BuildPipelineConfigConfigMapYamlURL
 	CUSTOM_JAVA_PIPELINE_BUILD_BUNDLE_ENV string = "CUSTOM_JAVA_PIPELINE_BUILD_BUNDLE"
 
 	// Bundle ref for a buildah-remote build
 	CUSTOM_BUILDAH_REMOTE_PIPELINE_BUILD_BUNDLE_ENV string = "CUSTOM_BUILDAH_REMOTE_PIPELINE_BUILD_BUNDLE"
 
-	//Bundle ref for custom source-build, format example: quay.io/redhat-appstudio-qe/test-images:pipeline-bundle-1715584704-fftb
+	// Bundle ref for custom source-build, format example: quay.io/redhat-appstudio-qe/test-images:pipeline-bundle-1715584704-fftb
 	CUSTOM_SOURCE_BUILD_PIPELINE_BUNDLE_ENV string = "CUSTOM_SOURCE_BUILD_PIPELINE_BUNDLE"
 
 	// QE slack bot token used for delivering messages about critical failures during CI runs
@@ -140,7 +140,7 @@ const (
 	JVMBuildImageSecretName = "jvm-build-image-secrets"
 	JBSConfigName           = "jvm-build-config"
 
-	BuildPipelineSelectorYamlURL = "https://raw.githubusercontent.com/redhat-appstudio/infra-deployments/main/components/build-service/base/build-pipeline-selectors/build-pipeline-selector.yaml"
+	BuildPipelineConfigConfigMapYamlURL = "https://raw.githubusercontent.com/redhat-appstudio/infra-deployments/main/components/build-service/base/build-pipeline-config/build-pipeline-config.yaml"
 
 	DefaultImagePushRepo         = "quay.io/" + DefaultQuayOrg + "/test-images"
 	DefaultReleasedImagePushRepo = "quay.io/" + DefaultQuayOrg + "/test-release-images"
@@ -215,7 +215,6 @@ const (
 )
 
 var (
-	ComponentDefaultLabel                       = map[string]string{"e2e-test": "true"}
 	ComponentPaCRequestAnnotation               = map[string]string{"build.appstudio.openshift.io/request": "configure-pac"}
 	ComponentTriggerSimpleBuildAnnotation       = map[string]string{"build.appstudio.openshift.io/request": "trigger-simple-build"}
 	ImageControllerAnnotationRequestPublicRepo  = map[string]string{"image.redhat.com/generate": `{"visibility": "public"}`}

--- a/pkg/utils/tekton/pipeline_extraction_test.go
+++ b/pkg/utils/tekton/pipeline_extraction_test.go
@@ -10,9 +10,9 @@ import (
 func TestPipelineExtraction(t *testing.T) {
 	var defaultBundleRef string
 	var err error
-	if defaultBundleRef, err = GetDefaultPipelineBundleRef(constants.BuildPipelineSelectorYamlURL, "Java"); err != nil {
+	if defaultBundleRef, err = GetDefaultPipelineBundleRef(constants.BuildPipelineConfigConfigMapYamlURL, "docker-build"); err != nil {
 		assert.Error(t, err, "failed to parse bundle ref")
 		panic(err)
 	}
-	assert.Contains(t, defaultBundleRef, "pipeline-java-builder", "failed to retrieve bundle ref")
+	assert.Contains(t, defaultBundleRef, "pipeline-docker-build", "failed to retrieve bundle ref")
 }

--- a/tests/build/build_templates.go
+++ b/tests/build/build_templates.go
@@ -1,7 +1,6 @@
 package build
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -25,12 +24,10 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/library-go/pkg/image/reference"
-	buildservice "github.com/redhat-appstudio/build-service/api/v1alpha1"
 
 	tektonpipeline "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/yaml"
 )
 
@@ -42,7 +39,6 @@ const pipelineCompletionRetries = 2
 
 // CreateComponent creates a component from a test repository URL and returns the component's name
 func CreateComponent(ctrl *has.HasController, gitUrl, revision, applicationName, componentName, namespace string) string {
-
 	componentObj := appservice.ComponentSpec{
 		ComponentName: componentName,
 		Source: appservice.ComponentSource{
@@ -55,7 +51,19 @@ func CreateComponent(ctrl *has.HasController, gitUrl, revision, applicationName,
 			},
 		},
 	}
-	c, err := ctrl.CreateComponent(componentObj, namespace, "", "", applicationName, false, constants.DefaultDockerBuildPipelineBundle)
+
+	var buildPipelineAnnotation map[string]string
+	if os.Getenv(constants.CUSTOM_SOURCE_BUILD_PIPELINE_BUNDLE_ENV) != "" {
+		customSourceBuildBundle := os.Getenv(constants.CUSTOM_SOURCE_BUILD_PIPELINE_BUNDLE_ENV)
+		Expect(customSourceBuildBundle).ShouldNot(BeEmpty())
+		buildPipelineAnnotation = map[string]string{
+			"build.appstudio.openshift.io/pipeline": fmt.Sprintf(`{"name":"java-builder", "bundle": "%s"}`, customSourceBuildBundle),
+		}
+	} else {
+		buildPipelineAnnotation = constants.DefaultDockerBuildPipelineBundle
+	}
+
+	c, err := ctrl.CreateComponent(componentObj, namespace, "", "", applicationName, false, buildPipelineAnnotation)
 	Expect(err).ShouldNot(HaveOccurred())
 	return c.Name
 }
@@ -117,13 +125,6 @@ var _ = framework.BuildSuiteDescribe("Build templates E2E test", Label("build", 
 				testNamespace = f.UserNamespace
 				Expect(f.UserNamespace).NotTo(BeNil())
 				kubeadminClient = f.AsKubeAdmin
-			}
-
-			// Update the build-pipeline-selector to use custom bundle if CUSTOM_SOURCE_BUILD_PIPELINE_BUNDLE_ENV is set
-			if os.Getenv(constants.CUSTOM_SOURCE_BUILD_PIPELINE_BUNDLE_ENV) != "" {
-				//support added for running the tests in build-templates-e2e namespace for now
-				err = updateBuildPipelineSelector(kubeadminClient, testNamespace)
-				Expect(err).ShouldNot(HaveOccurred())
 			}
 
 			_, err = kubeadminClient.HasController.GetApplication(applicationName, testNamespace)
@@ -612,48 +613,4 @@ func getImageWithDigest(c *framework.ControllerHub, componentName, applicationNa
 		return "", fmt.Errorf("IMAGE_DIGEST for component %q could not be found", componentName)
 	}
 	return fmt.Sprintf("%s@%s", url, digest), nil
-}
-
-func updateBuildPipelineSelector(kubeadminClient *framework.ControllerHub, testNamespace string) error {
-	//trueBool := true
-	customSourceBuildBundle := os.Getenv(constants.CUSTOM_SOURCE_BUILD_PIPELINE_BUNDLE_ENV)
-	Expect(customSourceBuildBundle).ShouldNot(BeEmpty())
-	if customSourceBuildBundle == "" {
-		return fmt.Errorf("source build bundle is empty")
-	}
-	bpsObj := &buildservice.BuildPipelineSelector{}
-	err := kubeadminClient.CommonController.KubeRest().Get(context.Background(), types.NamespacedName{Name: "build-pipeline-selector", Namespace: testNamespace}, bpsObj)
-	if err != nil {
-		return fmt.Errorf("error while getting build-pipeline-selector: %v", err)
-	}
-	found := false
-	selectorIndex := -1
-	paramIndex := -1
-	for i := range bpsObj.Spec.Selectors {
-		selector := &bpsObj.Spec.Selectors[i]
-		if selector.Name == "Docker build" {
-			selectorIndex = i
-			params := bpsObj.Spec.Selectors[i].PipelineRef.Params
-			for k, param := range params {
-				if param.Name == "bundle" {
-					paramIndex = k
-					found = true
-					break
-				}
-			}
-		}
-		if found {
-			selector.PipelineRef.Params[paramIndex].Value = *tektonpipeline.NewStructuredValues(customSourceBuildBundle)
-			break
-		}
-	}
-	if selectorIndex == -1 {
-		return fmt.Errorf("docker-build selector not found in build-pipeline-selector")
-	}
-
-	err = kubeadminClient.CommonController.KubeRest().Update(context.Background(), bpsObj)
-	if err != nil {
-		return fmt.Errorf("error while updating build pipeline selector: %v", err)
-	}
-	return nil
 }

--- a/tests/build/build_templates.go
+++ b/tests/build/build_templates.go
@@ -57,7 +57,7 @@ func CreateComponent(ctrl *has.HasController, gitUrl, revision, applicationName,
 		customSourceBuildBundle := os.Getenv(constants.CUSTOM_SOURCE_BUILD_PIPELINE_BUNDLE_ENV)
 		Expect(customSourceBuildBundle).ShouldNot(BeEmpty())
 		buildPipelineAnnotation = map[string]string{
-			"build.appstudio.openshift.io/pipeline": fmt.Sprintf(`{"name":"java-builder", "bundle": "%s"}`, customSourceBuildBundle),
+			"build.appstudio.openshift.io/pipeline": fmt.Sprintf(`{"name":"docker-build", "bundle": "%s"}`, customSourceBuildBundle),
 		}
 	} else {
 		buildPipelineAnnotation = constants.DefaultDockerBuildPipelineBundle

--- a/tests/build/multi-platform.go
+++ b/tests/build/multi-platform.go
@@ -427,7 +427,7 @@ func createApplicationAndComponent(f *framework.Framework, testNamespace, platfo
 	customBuildahRemotePipeline := os.Getenv(constants.CUSTOM_BUILDAH_REMOTE_PIPELINE_BUILD_BUNDLE_ENV + "_" + platform)
 	Expect(customBuildahRemotePipeline).ShouldNot(BeEmpty())
 	buildPipelineAnnotation := map[string]string{
-		"build.appstudio.openshift.io/pipeline": fmt.Sprintf(`{"name":"java-builder", "bundle": "%s"}`, customBuildahRemotePipeline),
+		"build.appstudio.openshift.io/pipeline": fmt.Sprintf(`{"name":"buildah-remote-pipeline", "bundle": "%s"}`, customBuildahRemotePipeline),
 	}
 
 	// Create a component with Git Source URL being defined

--- a/tests/build/multi-platform.go
+++ b/tests/build/multi-platform.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/konflux-ci/e2e-tests/pkg/clients/has"
-	"github.com/konflux-ci/e2e-tests/pkg/utils/tekton"
 	"golang.org/x/crypto/ssh"
 	v1 "k8s.io/api/core/v1"
 
@@ -21,9 +20,7 @@ import (
 	"github.com/konflux-ci/e2e-tests/pkg/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	buildservice "github.com/redhat-appstudio/build-service/api/v1alpha1"
 	pipeline "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -104,10 +101,7 @@ var _ = framework.MultiPlatformBuildSuiteDescribe("Multi Platform Controller E2E
 			err = createSecretForHostPool(f)
 			Expect(err).ShouldNot(HaveOccurred())
 
-			err = createBuildPipelineSelector(f, testNamespace, "ARM64")
-			Expect(err).ShouldNot(HaveOccurred())
-
-			component, applicationName, componentName = createApplicationAndComponent(f, testNamespace)
+			component, applicationName, componentName = createApplicationAndComponent(f, testNamespace, "ARM64")
 		})
 
 		When("the Component with multi-platform-build is created", func() {
@@ -227,10 +221,7 @@ var _ = framework.MultiPlatformBuildSuiteDescribe("Multi Platform Controller E2E
 			err = createSecretsForDynamicInstance(f)
 			Expect(err).ShouldNot(HaveOccurred())
 
-			err = createBuildPipelineSelector(f, testNamespace, "ARM64")
-			Expect(err).ShouldNot(HaveOccurred())
-
-			component, applicationName, componentName = createApplicationAndComponent(f, testNamespace)
+			component, applicationName, componentName = createApplicationAndComponent(f, testNamespace, "ARM64")
 		})
 
 		When("the Component with multi-platform-build is created", func() {
@@ -309,10 +300,7 @@ var _ = framework.MultiPlatformBuildSuiteDescribe("Multi Platform Controller E2E
 			err = createSecretsForIbmDynamicInstance(f)
 			Expect(err).ShouldNot(HaveOccurred())
 
-			err = createBuildPipelineSelector(f, testNamespace, "S390X")
-			Expect(err).ShouldNot(HaveOccurred())
-
-			component, applicationName, componentName = createApplicationAndComponent(f, testNamespace)
+			component, applicationName, componentName = createApplicationAndComponent(f, testNamespace, "S390X")
 		})
 
 		When("the Component with multi-platform-build is created", func() {
@@ -392,10 +380,7 @@ var _ = framework.MultiPlatformBuildSuiteDescribe("Multi Platform Controller E2E
 			err = createSecretsForIbmDynamicInstance(f)
 			Expect(err).ShouldNot(HaveOccurred())
 
-			err = createBuildPipelineSelector(f, testNamespace, "PPC64LE")
-			Expect(err).ShouldNot(HaveOccurred())
-
-			component, applicationName, componentName = createApplicationAndComponent(f, testNamespace)
+			component, applicationName, componentName = createApplicationAndComponent(f, testNamespace, "PPC64LE")
 		})
 
 		When("the Component with multi-platform-build is created", func() {
@@ -432,12 +417,18 @@ var _ = framework.MultiPlatformBuildSuiteDescribe("Multi Platform Controller E2E
 	})
 })
 
-func createApplicationAndComponent(f *framework.Framework, testNamespace string) (component *appservice.Component, applicationName, componentName string) {
+func createApplicationAndComponent(f *framework.Framework, testNamespace, platform string) (component *appservice.Component, applicationName, componentName string) {
 	applicationName = fmt.Sprintf("multi-platform-suite-application-%s", util.GenerateRandomString(4))
 	_, err := f.AsKubeAdmin.HasController.CreateApplication(applicationName, testNamespace)
 	Expect(err).NotTo(HaveOccurred())
 
 	componentName = fmt.Sprintf("multi-platform-suite-component-%s", util.GenerateRandomString(4))
+
+	customBuildahRemotePipeline := os.Getenv(constants.CUSTOM_BUILDAH_REMOTE_PIPELINE_BUILD_BUNDLE_ENV + "_" + platform)
+	Expect(customBuildahRemotePipeline).ShouldNot(BeEmpty())
+	buildPipelineAnnotation := map[string]string{
+		"build.appstudio.openshift.io/pipeline": fmt.Sprintf(`{"name":"java-builder", "bundle": "%s"}`, customBuildahRemotePipeline),
+	}
 
 	// Create a component with Git Source URL being defined
 	componentObj := appservice.ComponentSpec{
@@ -452,7 +443,7 @@ func createApplicationAndComponent(f *framework.Framework, testNamespace string)
 			},
 		},
 	}
-	component, err = f.AsKubeAdmin.HasController.CreateComponent(componentObj, testNamespace, "", "", applicationName, true, constants.DefaultDockerBuildPipelineBundle)
+	component, err = f.AsKubeAdmin.HasController.CreateComponent(componentObj, testNamespace, "", "", applicationName, true, buildPipelineAnnotation)
 	Expect(err).ShouldNot(HaveOccurred())
 	return
 }
@@ -946,33 +937,6 @@ func createSecretsForDynamicInstance(f *framework.Framework) error {
 	_, err = f.AsKubeAdmin.CommonController.CreateSecret(ControllerNamespace, &sshKeys)
 	if err != nil {
 		return fmt.Errorf("error creating secret with ssh private key: %v", err)
-	}
-	return nil
-}
-
-func createBuildPipelineSelector(f *framework.Framework, namespace string, platform string) error {
-	trueBool := true
-	customBuildahRemotePipeline := os.Getenv(constants.CUSTOM_BUILDAH_REMOTE_PIPELINE_BUILD_BUNDLE_ENV + "_" + platform)
-	Expect(customBuildahRemotePipeline).ShouldNot(BeEmpty())
-	if customBuildahRemotePipeline == "" {
-		return fmt.Errorf("remote build pipeline bundle is empty")
-	}
-	ps := &buildservice.BuildPipelineSelector{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "build-pipeline-selector",
-			Namespace: namespace,
-		},
-		Spec: buildservice.BuildPipelineSelectorSpec{Selectors: []buildservice.PipelineSelector{
-			{
-				Name:           "custom remote-buildah selector",
-				PipelineRef:    *tekton.NewBundleResolverPipelineRef("buildah-remote-pipeline", customBuildahRemotePipeline),
-				WhenConditions: buildservice.WhenCondition{DockerfileRequired: &trueBool},
-			},
-		}},
-	}
-	err := f.AsKubeAdmin.CommonController.KubeRest().Create(context.TODO(), ps)
-	if err != nil {
-		return fmt.Errorf("error creating build pipeline selector: %v", err)
 	}
 	return nil
 }


### PR DESCRIPTION
# Description

This PR complete removes any usage of `BuildPipelineSelector` since it's deprecated and will be removed soon.
To configure bundle to use, `build.appstudio.openshift.io/pipeline` annotation used instead.
For example:
```
build.appstudio.openshift.io/pipeline: '{"name": "docker-build", "bundle": "quay.io/my-user/my-pipeline-docker-build:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9"}'
```

## Issue ticket number and link

[STONEBLD-2500](https://issues.redhat.com/browse/STONEBLD-2500)

# How Has This Been Tested?

CI should succeed without BuildPipelineSelector
 
# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
