### PR TITLE
fix: update PLR SHA if PLR was retriggered

### DIFF
--- a/tests/build/build.go
+++ b/tests/build/build.go
@@ -43,6 +43,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 	Describe("test PaC component build", Ordered, Label("github-webhook", "pac-build", "pipeline", "image-controller"), func() {
 		var applicationName, componentName, componentBaseBranchName, pacBranchName, testNamespace, defaultBranchTestComponentName, imageRepoName, robotAccountName string
 		var component *appservice.Component
+		var plr *pipeline.PipelineRun
 
 		var timeout, interval time.Duration
 
@@ -167,13 +168,13 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 			It("triggers a PipelineRun", func() {
 				timeout = time.Minute * 5
 				Eventually(func() error {
-					pr, err := f.AsKubeAdmin.HasController.GetComponentPipelineRun(defaultBranchTestComponentName, applicationName, testNamespace, "")
+					plr, err = f.AsKubeAdmin.HasController.GetComponentPipelineRun(defaultBranchTestComponentName, applicationName, testNamespace, "")
 					if err != nil {
 						GinkgoWriter.Printf("PipelineRun has not been created yet for the component %s/%s\n", testNamespace, defaultBranchTestComponentName)
 						return err
 					}
-					if !pr.HasStarted() {
-						return fmt.Errorf("pipelinerun %s/%s hasn't started yet", pr.GetNamespace(), pr.GetName())
+					if !plr.HasStarted() {
+						return fmt.Errorf("pipelinerun %s/%s hasn't started yet", plr.GetNamespace(), plr.GetName())
 					}
 					return nil
 				}, timeout, constants.PipelineRunPollingInterval).Should(Succeed(), fmt.Sprintf("timed out when waiting for the PipelineRun to start for the component %s/%s", defaultBranchTestComponentName, testNamespace))
@@ -236,11 +237,10 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 				interval = time.Second * 1
 				Expect(f.AsKubeAdmin.HasController.DeleteComponent(defaultBranchTestComponentName, testNamespace, true)).To(Succeed())
 				// Test removal of PipelineRun
-				var pr *pipeline.PipelineRun
 				Eventually(func() error {
-					pr, err = f.AsKubeAdmin.HasController.GetComponentPipelineRun(defaultBranchTestComponentName, applicationName, testNamespace, "")
+					plr, err = f.AsKubeAdmin.HasController.GetComponentPipelineRun(defaultBranchTestComponentName, applicationName, testNamespace, "")
 					if err == nil {
-						return fmt.Errorf("pipelinerun %s/%s is not removed yet", pr.GetNamespace(), pr.GetName())
+						return fmt.Errorf("pipelinerun %s/%s is not removed yet", plr.GetNamespace(), plr.GetName())
 					}
 					return err
 				}, timeout, constants.PipelineRunPollingInterval).Should(MatchError(ContainSubstring("no pipelinerun found")), fmt.Sprintf("timed out when waiting for the PipelineRun to be removed for Component %s/%s", testNamespace, defaultBranchTestComponentName))
@@ -307,13 +307,13 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 				timeout = time.Second * 600
 				interval = time.Second * 1
 				Eventually(func() error {
-					pr, err := f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, "")
+					plr, err = f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, "")
 					if err != nil {
 						GinkgoWriter.Printf("PipelineRun has not been created yet for the component %s/%s\n", testNamespace, componentName)
 						return err
 					}
-					if !pr.HasStarted() {
-						return fmt.Errorf("pipelinerun %s/%s hasn't started yet", pr.GetNamespace(), pr.GetName())
+					if !plr.HasStarted() {
+						return fmt.Errorf("pipelinerun %s/%s hasn't started yet", plr.GetNamespace(), plr.GetName())
 					}
 					return nil
 				}, timeout, constants.PipelineRunPollingInterval).Should(Succeed(), fmt.Sprintf("timed out when waiting for the PipelineRun to start for the component %s/%s", testNamespace, componentName))
@@ -338,7 +338,9 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 			})
 			It("the PipelineRun should eventually finish successfully", func() {
 				Expect(f.AsKubeAdmin.HasController.WaitForComponentPipelineToBeFinished(component, "",
-					f.AsKubeAdmin.TektonController, &has.RetryOptions{Retries: 2, Always: true}, nil)).To(Succeed())
+					f.AsKubeAdmin.TektonController, &has.RetryOptions{Retries: 2, Always: true}, plr)).To(Succeed())
+				// in case the first pipelineRun attempt has failed and was retried, we need to update the git branch head ref
+				prHeadSha = plr.Labels["pipelinesascode.tekton.dev/sha"]
 			})
 			It("image repo and robot account created successfully", func() {
 
@@ -366,10 +368,10 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 			})
 			It("image tag is updated successfully", func() {
 				// check if the image tag exists in quay
-				pipelineRun, err := f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, "")
+				plr, err = f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, "")
 				Expect(err).ShouldNot(HaveOccurred())
 
-				for _, p := range pipelineRun.Spec.Params {
+				for _, p := range plr.Spec.Params {
 					if p.Name == "output-image" {
 						outputImage = p.Value.StringVal
 					}
@@ -381,10 +383,10 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 			})
 
 			It("should ensure pruning labels are set", func() {
-				pipelineRun, err := f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, "")
+				plr, err = f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, "")
 				Expect(err).ShouldNot(HaveOccurred())
 
-				image, err := build.ImageFromPipelineRun(pipelineRun)
+				image, err := build.ImageFromPipelineRun(plr)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				labels := image.Config.Config.Labels
@@ -416,13 +418,13 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 				timeout = time.Minute * 5
 
 				Eventually(func() error {
-					pr, err := f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, createdFileSHA)
+					plr, err = f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, createdFileSHA)
 					if err != nil {
 						GinkgoWriter.Printf("PipelineRun has not been created yet for the component %s/%s\n", testNamespace, componentName)
 						return err
 					}
-					if !pr.HasStarted() {
-						return fmt.Errorf("pipelinerun %s/%s hasn't started yet", pr.GetNamespace(), pr.GetName())
+					if !plr.HasStarted() {
+						return fmt.Errorf("pipelinerun %s/%s hasn't started yet", plr.GetNamespace(), plr.GetName())
 					}
 					return nil
 				}, timeout, constants.PipelineRunPollingInterval).Should(Succeed(), fmt.Sprintf("timed out when waiting for the PipelineRun to start for the component %s/%s", testNamespace, componentName))
@@ -447,21 +449,20 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 				}, timeout, interval).Should(BeTrue(), fmt.Sprintf("timed out when waiting for init PaC PR (branch name '%s') to be created in %s repository", pacBranchName, helloWorldComponentGitSourceRepoName))
 			})
 			It("PipelineRun should eventually finish", func() {
-				pr := &pipeline.PipelineRun{}
 				Expect(f.AsKubeAdmin.HasController.WaitForComponentPipelineToBeFinished(component, createdFileSHA,
-					f.AsKubeAdmin.TektonController, &has.RetryOptions{Retries: 2, Always: true}, pr)).To(Succeed())
-				createdFileSHA = pr.Labels["pipelinesascode.tekton.dev/sha"]
+					f.AsKubeAdmin.TektonController, &has.RetryOptions{Retries: 2, Always: true}, plr)).To(Succeed())
+				// in case the first pipelineRun attempt has failed and was retried, we need to update the git branch head ref
+				createdFileSHA = plr.Labels["pipelinesascode.tekton.dev/sha"]
 			})
 			It("eventually leads to another update of a PR about the PipelineRun status report at Checks tab", func() {
 				expectedCheckRunName := fmt.Sprintf("%s-%s", componentName, "on-pull-request")
-				Expect(f.AsKubeAdmin.CommonController.Github.GetCheckRunConclusion(expectedCheckRunName, helloWorldComponentGitSourceRepoName, prHeadSha, prNumber)).To(Equal(constants.CheckrunConclusionSuccess))
+				Expect(f.AsKubeAdmin.CommonController.Github.GetCheckRunConclusion(expectedCheckRunName, helloWorldComponentGitSourceRepoName, createdFileSHA, prNumber)).To(Equal(constants.CheckrunConclusionSuccess))
 			})
 		})
 
 		When("the PaC init branch is merged", Label("build-custom-branch"), func() {
 			var mergeResult *github.PullRequestMergeResult
 			var mergeResultSha string
-			var pipelineRun *pipeline.PipelineRun
 
 			BeforeAll(func() {
 				Eventually(func() error {
@@ -477,13 +478,13 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 				timeout = time.Minute * 10
 
 				Eventually(func() error {
-					pipelineRun, err = f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, mergeResultSha)
+					plr, err = f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, mergeResultSha)
 					if err != nil {
 						GinkgoWriter.Printf("PipelineRun has not been created yet for the component %s/%s\n", testNamespace, componentName)
 						return err
 					}
-					if !pipelineRun.HasStarted() {
-						return fmt.Errorf("pipelinerun %s/%s hasn't started yet", pipelineRun.GetNamespace(), pipelineRun.GetName())
+					if !plr.HasStarted() {
+						return fmt.Errorf("pipelinerun %s/%s hasn't started yet", plr.GetNamespace(), plr.GetName())
 					}
 					return nil
 				}, timeout, constants.PipelineRunPollingInterval).Should(Succeed(), fmt.Sprintf("timed out when waiting for the PipelineRun to start for the component %s/%s", testNamespace, componentName))
@@ -491,12 +492,12 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 
 			It("pipelineRun should eventually finish", func() {
 				Expect(f.AsKubeAdmin.HasController.WaitForComponentPipelineToBeFinished(component,
-					mergeResultSha, f.AsKubeAdmin.TektonController, &has.RetryOptions{Retries: 2, Always: true}, pipelineRun)).To(Succeed())
-				mergeResultSha = pipelineRun.Labels["pipelinesascode.tekton.dev/sha"]
+					mergeResultSha, f.AsKubeAdmin.TektonController, &has.RetryOptions{Retries: 2, Always: true}, plr)).To(Succeed())
+				mergeResultSha = plr.Labels["pipelinesascode.tekton.dev/sha"]
 			})
 
 			It("does not have expiration set", func() {
-				image, err := build.ImageFromPipelineRun(pipelineRun)
+				image, err := build.ImageFromPipelineRun(plr)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				labels := image.Config.Config.Labels


### PR DESCRIPTION
# Description
A follow-up on https://github.com/konflux-ci/e2e-tests/pull/1139, which should have fixed the issue caused by re-triggering PaC build PLR (in case the initial PLR failed)

This PR:
* fixes an issue mentioned above by [updating the `prHeadSha` variable](https://github.com/konflux-ci/e2e-tests/pull/1214/files#diff-938ddf0d569d68c3df496d8b4065614ff56cc303c33555755621cffcec97ef74R343) after PLR is finished, which then ensures that the PR head SHA is the most recent one and is used in verifications later in the test
* unifies the assignments of PLR variable in `pac-build` test scenario

## Issue ticket number and link
https://issues.redhat.com/browse/KFLUXBUGS-20

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

in CI 🤷 

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
