### PR TITLE
feat(STONEINTG-937): add nightly Gitlab webhooks cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,9 @@ clean-gitops-repositories:
 clean-github-webhooks:
 	./mage -v cleanWebHooks
 
+clean-gitlab-webhooks:
+	./mage -v gitlabcleanWebHooks
+
 clean-quay-repos-and-robots:
 	./mage -v local:cleanupQuayReposAndRobots
 

--- a/Makefile
+++ b/Makefile
@@ -58,10 +58,10 @@ clean-gitops-repositories:
 	DRY_RUN=false ./mage -v local:cleanupGithubOrg
 
 clean-github-webhooks:
-	./mage -v cleanWebHooks
+	./mage -v cleanGitHubWebHooks
 
 clean-gitlab-webhooks:
-	./mage -v gitlabcleanWebHooks
+	./mage -v cleanGitLabWebHooks
 
 clean-quay-repos-and-robots:
 	./mage -v local:cleanupQuayReposAndRobots

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -824,8 +824,9 @@ func GenerateTestSuiteFile(packageName string) error {
 	return nil
 }
 
-// Remove all webhooks which with 1 day lifetime. By default will delete webooks from redhat-appstudio-qe
-func CleanWebHooks() error {
+// Remove all webhooks older than 1 day from GitHub repo.
+// By default will delete webhooks from redhat-appstudio-qe
+func CleanGitHubWebHooks() error {
 	token := utils.GetEnv(constants.GITHUB_TOKEN_ENV, "")
 	if token == "" {
 		return fmt.Errorf("empty GITHUB_TOKEN env. Please provide a valid github token")
@@ -854,8 +855,8 @@ func CleanWebHooks() error {
 	return nil
 }
 
-// Remove all webhooks which with 1 day lifetime from Gitlab rpo.
-func GitlabCleanWebHooks() error {
+// Remove all webhooks older than 1 day from GitLab repo.
+func CleanGitLabWebHooks() error {
 	gcToken := utils.GetEnv(constants.GITLAB_TOKEN_ENV, "")
 	if gcToken == "" {
 		return fmt.Errorf("empty PAC_GITLAB_TOKEN env")
@@ -873,7 +874,7 @@ func GitlabCleanWebHooks() error {
 	if err != nil {
 		return fmt.Errorf("failed to list project hooks: %v", err)
 	}
-	// Delete webhooks were created older than 1 day
+	// Delete webhooks that are older than 1 day
 	for _, webhook := range webhooks {
 		dayDuration, _ := time.ParseDuration("24h")
 		if time.Since(*webhook.CreatedAt) > dayDuration {

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -36,6 +36,7 @@ import (
 	"github.com/konflux-ci/image-controller/pkg/quay"
 	"github.com/magefile/mage/sh"
 	tektonapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	gl "github.com/xanzy/go-gitlab"
 )
 
 const (
@@ -870,7 +871,7 @@ func CleanGitLabWebHooks() error {
 	if err != nil {
 		return err
 	}
-	webhooks, _, err := gc.GetClient().Projects.ListProjectHooks(projectID, nil)
+	webhooks, _, err := gc.GetClient().Projects.ListProjectHooks(projectID, &gl.ListProjectHooksOptions{PerPage: 100})
 	if err != nil {
 		return fmt.Errorf("failed to list project hooks: %v", err)
 	}


### PR DESCRIPTION
# Description

we create a nightly webhooks cleanup form the Gitlab e2e-tests, 

## [STONEINTG-937](https://issues.redhat.com/browse/STONEINTG-937)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
