### PR TITLE
fix: changes to build-defintions CI e2e-tests after build-pipeline-selector removal

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -94,6 +94,12 @@ const (
 	// Bundle ref for custom source-build, format example: quay.io/redhat-appstudio-qe/test-images:pipeline-bundle-1715584704-fftb
 	CUSTOM_SOURCE_BUILD_PIPELINE_BUNDLE_ENV string = "CUSTOM_SOURCE_BUILD_PIPELINE_BUNDLE"
 
+	// Bundle ref for custom docker-build, format example: quay.io/redhat-appstudio-qe/test-images:pipeline-bundle-1715584704-fftb
+	CUSTOM_DOCKER_BUILD_PIPELINE_BUNDLE_ENV string = "CUSTOM_DOCKER_BUILD_PIPELINE_BUNDLE"
+
+	// Bundle ref for custom fbc-builder, format example: quay.io/redhat-appstudio-qe/test-images:pipeline-bundle-1715584704-fftb
+	CUSTOM_FBC_BUILDER_PIPELINE_BUNDLE_ENV string = "CUSTOM_FBC_BUILDER_PIPELINE_BUNDLE"
+
 	// QE slack bot token used for delivering messages about critical failures during CI runs
 	SLACK_BOT_TOKEN_ENV = "SLACK_BOT_TOKEN"
 

--- a/tests/build/build_templates.go
+++ b/tests/build/build_templates.go
@@ -27,7 +27,12 @@ import (
 
 	tektonpipeline "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	remoteimg "github.com/google/go-containerregistry/pkg/v1/remote"
+
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/yaml"
 )
 
@@ -39,6 +44,33 @@ const pipelineCompletionRetries = 2
 
 // CreateComponent creates a component from a test repository URL and returns the component's name
 func CreateComponent(ctrl *has.HasController, gitUrl, revision, applicationName, componentName, namespace string) string {
+	var err error
+	var buildPipelineAnnotation map[string]string
+	contextDir, dockerfilePath, pipelineBundleName, enableHermetic, prefetchInput := GetComponentScenarioDetailsFromGitUrl(gitUrl)
+	Expect(pipelineBundleName).ShouldNot(BeEmpty())
+	if pipelineBundleName == "docker-build" {
+		customDockerBuildBundle := os.Getenv(constants.CUSTOM_DOCKER_BUILD_PIPELINE_BUNDLE_ENV)
+		if enableHermetic {
+			//Update the docker-build pipeline bundle with param hermetic=true
+			customDockerBuildBundle, err = enableHermeticBuildInPipelineBundle(customDockerBuildBundle, prefetchInput)
+			if err != nil {
+				GinkgoWriter.Printf("failed to enable hermetic build in the pipeline bundle with: %v\n", err)
+				return ""
+			}
+		}
+		if customDockerBuildBundle == "" {
+			customDockerBuildBundle = "latest"
+		}
+		buildPipelineAnnotation = map[string]string{
+			"build.appstudio.openshift.io/pipeline": fmt.Sprintf(`{"name":"docker-build", "bundle": "%s"}`, customDockerBuildBundle),
+		}
+	} else if pipelineBundleName == "fbc-builder" {
+		customFbcBuilderBundle := os.Getenv(constants.CUSTOM_FBC_BUILDER_PIPELINE_BUNDLE_ENV)
+		buildPipelineAnnotation = map[string]string{
+			"build.appstudio.openshift.io/pipeline": fmt.Sprintf(`{"name":"fbc-builder", "bundle": "%s"}`, customFbcBuilderBundle),
+		}
+	}
+
 	componentObj := appservice.ComponentSpec{
 		ComponentName: componentName,
 		Source: appservice.ComponentSource{
@@ -46,23 +78,20 @@ func CreateComponent(ctrl *has.HasController, gitUrl, revision, applicationName,
 				GitSource: &appservice.GitSource{
 					URL:           gitUrl,
 					Revision:      revision,
-					DockerfileURL: constants.DockerFilePath,
+					Context:       contextDir,
+					DockerfileURL: dockerfilePath,
 				},
 			},
 		},
 	}
 
-	var buildPipelineAnnotation map[string]string
 	if os.Getenv(constants.CUSTOM_SOURCE_BUILD_PIPELINE_BUNDLE_ENV) != "" {
 		customSourceBuildBundle := os.Getenv(constants.CUSTOM_SOURCE_BUILD_PIPELINE_BUNDLE_ENV)
 		Expect(customSourceBuildBundle).ShouldNot(BeEmpty())
 		buildPipelineAnnotation = map[string]string{
 			"build.appstudio.openshift.io/pipeline": fmt.Sprintf(`{"name":"docker-build", "bundle": "%s"}`, customSourceBuildBundle),
 		}
-	} else {
-		buildPipelineAnnotation = constants.DefaultDockerBuildPipelineBundle
 	}
-
 	c, err := ctrl.CreateComponent(componentObj, namespace, "", "", applicationName, false, buildPipelineAnnotation)
 	Expect(err).ShouldNot(HaveOccurred())
 	return c.Name
@@ -613,4 +642,37 @@ func getImageWithDigest(c *framework.ControllerHub, componentName, applicationNa
 		return "", fmt.Errorf("IMAGE_DIGEST for component %q could not be found", componentName)
 	}
 	return fmt.Sprintf("%s@%s", url, digest), nil
+}
+
+func enableHermeticBuildInPipelineBundle(customDockerBuildBundle, prefetchInput string) (string, error) {
+	var tektonObj runtime.Object
+	var err error
+	var newPipelineYaml []byte
+	if tektonObj, err = tekton.ExtractTektonObjectFromBundle(customDockerBuildBundle, "pipeline", "docker-build"); err != nil {
+		return "", fmt.Errorf("failed to extract the Tekton Pipeline from bundle: %+v", err)
+	}
+	dockerPipelineObject := tektonObj.(*tektonpipeline.Pipeline)
+	// Update hermetic params value to true
+	for i := range dockerPipelineObject.PipelineSpec().Params {
+		if dockerPipelineObject.PipelineSpec().Params[i].Name == "hermetic" {
+			dockerPipelineObject.PipelineSpec().Params[i].Default.StringVal = "true"
+		}
+		if dockerPipelineObject.PipelineSpec().Params[i].Name == "prefetch-input" {
+			dockerPipelineObject.PipelineSpec().Params[i].Default.StringVal = prefetchInput
+		}
+	}
+	if newPipelineYaml, err = yaml.Marshal(dockerPipelineObject); err != nil {
+		return "", fmt.Errorf("error when marshalling a new pipeline to YAML: %v", err)
+	}
+	keychain := authn.NewMultiKeychain(authn.DefaultKeychain)
+	authOption := remoteimg.WithAuthFromKeychain(keychain)
+	tag := fmt.Sprintf("%d-%s", time.Now().Unix(), util.GenerateRandomString(4))
+	quayOrg := utils.GetEnv(constants.QUAY_E2E_ORGANIZATION_ENV, constants.DefaultQuayOrg)
+	newDockerBuildPipelineImg := strings.ReplaceAll(constants.DefaultImagePushRepo, constants.DefaultQuayOrg, quayOrg)
+	var newDockerBuildPipeline, _ = name.ParseReference(fmt.Sprintf("%s:pipeline-bundle-%s", newDockerBuildPipelineImg, tag))
+
+	if err = tekton.BuildAndPushTektonBundle(newPipelineYaml, newDockerBuildPipeline, authOption); err != nil {
+		return "", fmt.Errorf("error when building/pushing a tekton pipeline bundle: %v", err)
+	}
+	return newDockerBuildPipeline.String(), nil
 }

--- a/tests/build/build_templates_scenarios.go
+++ b/tests/build/build_templates_scenarios.go
@@ -1,0 +1,90 @@
+package build
+
+import (
+	"github.com/konflux-ci/e2e-tests/pkg/constants"
+)
+
+type ComponentScenarioSpec struct {
+	GitURL             string
+	ContextDir         string
+	DockerFilePath     string
+	PipelineBundleName string
+	EnableHermetic     bool
+	PrefetchInput      string
+}
+
+var componentScenarios = []ComponentScenarioSpec{
+	{
+		GitURL:             "https://github.com/redhat-appstudio-qe/devfile-sample-python-basic",
+		ContextDir:         ".",
+		DockerFilePath:     constants.DockerFilePath,
+		PipelineBundleName: "docker-build",
+		EnableHermetic:     false,
+		PrefetchInput:      "",
+	},
+	{
+		GitURL:             "https://github.com/redhat-appstudio-qe/retrodep",
+		ContextDir:         ".",
+		DockerFilePath:     "Dockerfile",
+		PipelineBundleName: "docker-build",
+		EnableHermetic:     true,
+		PrefetchInput:      "gomod",
+	},
+	{
+		GitURL:             "https://github.com/cachito-testing/pip-e2e-test",
+		ContextDir:         ".",
+		DockerFilePath:     "Dockerfile",
+		PipelineBundleName: "docker-build",
+		EnableHermetic:     true,
+		PrefetchInput:      "pip",
+	},
+	{
+		GitURL:             "https://github.com/redhat-appstudio-qe/fbc-sample-repo",
+		ContextDir:         "4.13",
+		DockerFilePath:     "catalog.Dockerfile",
+		PipelineBundleName: "fbc-builder",
+		EnableHermetic:     false,
+		PrefetchInput:      "",
+	},
+	{
+		GitURL:             "https://github.com/redhat-appstudio-qe/source-build-parent-image-with-digest-only",
+		ContextDir:         ".",
+		DockerFilePath:     "Dockerfile",
+		PipelineBundleName: "docker-build",
+		EnableHermetic:     false,
+		PrefetchInput:      "",
+	},
+	{
+		GitURL:             "https://github.com/redhat-appstudio-qe/source-build-use-latest-parent-image",
+		ContextDir:         ".",
+		DockerFilePath:     "Dockerfile",
+		PipelineBundleName: "docker-build",
+		EnableHermetic:     false,
+		PrefetchInput:      "",
+	},
+	{
+		GitURL:             "https://github.com/redhat-appstudio-qe/source-build-parent-image-from-registry-rh-io",
+		ContextDir:         ".",
+		DockerFilePath:     "Dockerfile",
+		PipelineBundleName: "docker-build",
+		EnableHermetic:     false,
+		PrefetchInput:      "",
+	},
+	{
+		GitURL:             "https://github.com/redhat-appstudio-qe/source-build-base-on-konflux-image",
+		ContextDir:         ".",
+		DockerFilePath:     "Dockerfile",
+		PipelineBundleName: "docker-build",
+		EnableHermetic:     false,
+		PrefetchInput:      "",
+	},
+}
+
+func GetComponentScenarioDetailsFromGitUrl(gitUrl string) (string, string, string, bool, string) {
+	for _, componentScenario := range componentScenarios {
+		if componentScenario.GitURL == gitUrl {
+			return componentScenario.ContextDir, componentScenario.DockerFilePath, componentScenario.PipelineBundleName, componentScenario.EnableHermetic, componentScenario.PrefetchInput
+		}
+	}
+	return "", "", "", false, ""
+}

--- a/tests/build/const.go
+++ b/tests/build/const.go
@@ -12,7 +12,7 @@ const (
 	COMPONENT_REPO_URLS_ENV string = "COMPONENT_REPO_URLS"
 
 	containerImageSource             = "quay.io/redhat-appstudio-qe/busybox-loop@sha256:f698f1f2cf641fe9176d2a277c9052d872f6b1c39e56248a1dd259b96281dda9"
-	pythonComponentGitSourceURL      = "https://github.com/redhat-appstudio-qe/devfile-sample-python-basic.git"
+	pythonComponentGitSourceURL      = "https://github.com/redhat-appstudio-qe/devfile-sample-python-basic"
 	gitRepoContainsSymlinkBranchName = "symlink"
 	dummyPipelineBundleRef           = "quay.io/redhat-appstudio-qe/dummy-pipeline-bundle@sha256:9805fc3f309af8f838622e49d3e7705d8364eb5c8287043d5725f3ef12232f24"
 	buildTemplatesTestLabel          = "build-templates-e2e"


### PR DESCRIPTION
# Description

These changes are needed after build-pipeline-selector got removed and are part of the build-definitions CI e2e-tests 

## Issue ticket number and link
https://issues.redhat.com/browse/STONEBLD-2284

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Change has been tested with [this PR](https://github.com/konflux-ci/build-definitions/pull/1066)

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
