### PR TITLE
fix: unregister PaC from sprayproxy separately

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,9 @@ ci/test/upgrade:
 ci/prepare/e2e-branch:
 	./mage -v ci:prepareE2Ebranch
 
+ci/sprayproxy/unregister:
+	./mage -v ci:unregisterSprayproxy
+
 local/cluster/prepare:
 	./mage -v local:prepareCluster
 

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -253,7 +253,6 @@ func (ci CI) PerformOpenShiftUpgrade() error {
 }
 
 func (ci CI) TestE2E() error {
-	var testFailure bool
 
 	if err := ci.init(); err != nil {
 		return fmt.Errorf("error when running ci init: %v", err)
@@ -279,34 +278,20 @@ func (ci CI) TestE2E() error {
 		}
 	}
 
-	if requiresSprayProxyRegistering {
-		err := registerPacServer()
-		if err != nil {
-			os.Setenv(constants.SKIP_PAC_TESTS_ENV, "true")
-			if alertErr := HandleErrorWithAlert(fmt.Errorf("failed to register SprayProxy: %+v", err), slack.ErrorSeverityLevelError); alertErr != nil {
-				return alertErr
-			}
-		}
-	}
-
 	if err := RunE2ETests(); err != nil {
-		testFailure = true
-	}
-
-	if requiresSprayProxyRegistering && sprayProxyConfig != nil {
-		err := unregisterPacServer()
-		if err != nil {
-			if alertErr := HandleErrorWithAlert(fmt.Errorf("failed to unregister SprayProxy: %+v", err), slack.ErrorSeverityLevelInfo); alertErr != nil {
-				klog.Warning(alertErr)
-			}
-		}
-	}
-
-	if testFailure {
-		return fmt.Errorf("error when running e2e tests - see the log above for more details")
+		return fmt.Errorf("error when running e2e tests: %+v", err)
 	}
 
 	return nil
+}
+
+func (ci CI) UnregisterSprayproxy() {
+	err := unregisterPacServer()
+	if err != nil {
+		if alertErr := HandleErrorWithAlert(fmt.Errorf("failed to unregister SprayProxy: %+v", err), slack.ErrorSeverityLevelInfo); alertErr != nil {
+			klog.Warning(alertErr)
+		}
+	}
 }
 
 func RunE2ETests() error {
@@ -757,7 +742,20 @@ func BootstrapCluster() error {
 		return fmt.Errorf("failed to initialize installation controller: %+v", err)
 	}
 
-	return ic.InstallAppStudioPreviewMode()
+	if err := ic.InstallAppStudioPreviewMode(); err != nil {
+		return err
+	}
+
+	if os.Getenv("CI") == "true" && requiresSprayProxyRegistering {
+		err := registerPacServer()
+		if err != nil {
+			os.Setenv(constants.SKIP_PAC_TESTS_ENV, "true")
+			if alertErr := HandleErrorWithAlert(fmt.Errorf("failed to register SprayProxy: %+v", err), slack.ErrorSeverityLevelError); alertErr != nil {
+				return alertErr
+			}
+		}
+	}
+	return nil
 }
 
 func isPRPairingRequired(repoForPairing string) bool {
@@ -1032,17 +1030,20 @@ func registerPacServer() error {
 }
 
 func unregisterPacServer() error {
-	if sprayProxyConfig == nil {
-		return fmt.Errorf("SprayProxy config is empty")
+	var err error
+	var pacHost string
+	sprayProxyConfig, err = newSprayProxy()
+	if err != nil {
+		return fmt.Errorf("failed to set up SprayProxy credentials: %+v", err)
 	}
 	// for debugging purposes
 	klog.Infof("Before unregistering pac server...")
-	err := printRegisteredPacServers()
+	err = printRegisteredPacServers()
 	if err != nil {
 		klog.Error(err)
 	}
 
-	pacHost, err := sprayproxy.GetPaCHost()
+	pacHost, err = sprayproxy.GetPaCHost()
 	if err != nil {
 		return fmt.Errorf("failed to get PaC host: %+v", err)
 	}


### PR DESCRIPTION
# Description

* register sprayproxy function call moved to a bootstrap function
* sprayproxy unregistering moved to a separate mage target
* failing konflux-ci check is fixed in [another PR](https://github.com/konflux-ci/e2e-tests/pull/1224)

## Issue ticket number and link
[KFLUXBUGS-1358](https://issues.redhat.com//browse/KFLUXBUGS-1358)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

via this PR: https://github.com/openshift/release/pull/53285

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
