### PR TITLE
fix: nil pointer reference to PipelineRun object

### DIFF
--- a/pkg/clients/has/components.go
+++ b/pkg/clients/has/components.go
@@ -180,6 +180,9 @@ func (h *HasController) WaitForComponentPipelineToBeFinished(component *appservi
 		})
 
 		if err != nil {
+			if pr == nil {
+				return fmt.Errorf("PipelineRun cannot be created for the Component %s/%s", component.GetNamespace(), component.GetName())
+			}
 			GinkgoWriter.Printf("attempt %d/%d: PipelineRun %q failed: %+v", attempts, r.Retries+1, pr.GetName(), err)
 			// CouldntGetTask: Retry the PipelineRun only in case we hit the known issue https://issues.redhat.com/browse/SRVKP-2749
 			// TaskRunImagePullFailed: Retry in case of https://issues.redhat.com/browse/RHTAPBUGS-985 and https://github.com/tektoncd/pipeline/issues/7184


### PR DESCRIPTION
# Description

In function WaitForComponentPipelineToBeFinished, if the PipelineRun creation times out, variable pr will be nil. Then, function call pr.GetName() will panic.

## Issue ticket number and link

No issue ticket. Found this issue from a CI run, https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/redhat-appstudio_infra-deployments/3863/pull-ci-redhat-appstudio-infra-deployments-main-appstudio-e2e-tests/1804001654681374720

Excerpt:

```
  PipelineRun has not been created yet for the Component rhtap-demo-titr-tenant/quarkus-devfile
  PipelineRun has not been created yet for the Component rhtap-demo-titr-tenant/quarkus-devfile
  PipelineRun has not been created yet for the Component rhtap-demo-titr-tenant/quarkus-devfile
  PipelineRun has not been created yet for the Component rhtap-demo-titr-tenant/quarkus-devfile
  PipelineRun has not been created yet for the Component rhtap-demo-titr-tenant/quarkus-devfile
  PipelineRun has not been created yet for the Component rhtap-demo-titr-tenant/quarkus-devfile
  [PANICKED] in [It] - /usr/lib/golang/src/runtime/panic.go:261 @ 06/21/24 04:55:19.406
  test: rhtap-demo, namespace: rhtap-demo-titr-tenant, resourceQuota: appstudio-crds-spi, resource: count/spiaccesschecks.appstudio.redhat.com, available: 512, used: 0
  test: rhtap-demo, namespace: rhtap-demo-titr-tenant, resourceQuota: appstudio-crds-spi, resource: count/spiaccesstokenbindings.appstudio.redhat.com, available: 512, used: 1
  test: rhtap-demo, namespace: rhtap-demo-titr-tenant, resourceQuota: appstudio-crds-spi, resource: count/spiaccesstokendataupdates.appstudio.redhat.com, available: 512, used: 0
  test: rhtap-demo, namespace: rhtap-demo-titr-tenant, resourceQuota: appstudio-crds-spi, resource: count/spiaccesstokens.appstudio.redhat.com, available: 512, used: 1
  test: rhtap-demo, namespace: rhtap-demo-titr-tenant, resourceQuota: appstudio-crds-spi, resource: count/spifilecontentrequests.appstudio.redhat.com, available: 512, used: 0
  << Timeline
  [PANICKED] Test Panicked
  In [It] at: /usr/lib/golang/src/runtime/panic.go:261 @ 06/21/24 04:55:19.406
  runtime error: invalid memory address or nil pointer dereference
  Full Stack Trace
    github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.(*PipelineRun).GetName(...)
    	/go/pkg/mod/github.com/tektoncd/pipeline@v0.58.0/pkg/apis/pipeline/v1/pipelinerun_types.go:63
    github.com/konflux-ci/e2e-tests/pkg/clients/has.(*HasController).WaitForComponentPipelineToBeFinished(0xc000a1e3c0, 0xc000a9ab00, {0x0, 0x0}, 0xc0011af250, 0xc001499f10, 0x0)
    	/tmp/tmp.mqsa2kHEmD/pkg/clients/has/components.go:183 +0x1a1
    github.com/konflux-ci/e2e-tests/tests/rhtap-demo.glob..func1.1.7()
    	/tmp/tmp.mqsa2kHEmD/tests/rhtap-demo/rhtap-demo.go:235 +0x291 
```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This issue happened during the CI execution.

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
