### PR TITLE
fix: update quay cleanup regexp

### DIFF
--- a/magefiles/utils.go
+++ b/magefiles/utils.go
@@ -27,7 +27,7 @@ import (
 	"github.com/magefile/mage/sh"
 )
 
-const quayPrefixesToDeleteRegexp = "e2e-demos|has-e2e|multi-comp|build-e2e"
+const quayPrefixesToDeleteRegexp = "rhtap[-_]demo|happy-path|multi-platform|ex-registry|gitlab|build-e2e|build-templates|byoc|user1|spi|release-|integration|jvm|stat-rep|nbe|stack|rs[-_]demos|push-pyxis"
 
 func getRemoteAndBranchNameFromPRLink(url string) (remote, branchName string, err error) {
 	ghRes := &GithubPRInfo{}

--- a/magefiles/utils_test.go
+++ b/magefiles/utils_test.go
@@ -106,22 +106,22 @@ func TestCleanupQuayReposAndRobots(t *testing.T) {
 	timeFormat := "Mon, 02 Jan 2006 15:04:05 -0700"
 
 	deletedRepos := []quay.Repository{
-		{Name: "e2e-demos/test-old"},
-		{Name: "has-e2e/test-old"},
+		{Name: "rhtap-demo/test-old"},
+		{Name: "multi-platform/test-old"},
 	}
 	preservedRepos := []quay.Repository{
-		{Name: "e2e-demos/test-new"},
-		{Name: "has-e2e/test-new"},
+		{Name: "rhtap-demo/test-new"},
+		{Name: "multi-platform/test-new"},
 		{Name: "other/test-new"},
 		{Name: "other/test-old"},
 	}
 	deletedRobots := []quay.RobotAccount{
-		{Name: "test-org+e2e-demostest-old", Created: time.Now().Add(-25 * time.Hour).Format(timeFormat)},
-		{Name: "test-org+has-e2etest-old", Created: time.Now().Add(-25 * time.Hour).Format(timeFormat)},
+		{Name: "test-org+rhtap-demotest-old", Created: time.Now().Add(-25 * time.Hour).Format(timeFormat)},
+		{Name: "test-org+multi-platformtest-old", Created: time.Now().Add(-25 * time.Hour).Format(timeFormat)},
 	}
 	preservedRobots := []quay.RobotAccount{
-		{Name: "test-org+e2e-demostest-new", Created: time.Now().Format(timeFormat)},
-		{Name: "test-org+has-e2etest-new", Created: time.Now().Format(timeFormat)},
+		{Name: "test-org+rhtap-demotest-new", Created: time.Now().Format(timeFormat)},
+		{Name: "test-org+multi-platformtest-new", Created: time.Now().Format(timeFormat)},
 		{Name: "test-org+othertest-old", Created: time.Now().Add(-25 * time.Hour).Format(timeFormat)},
 		{Name: "test-org+othertest-new", Created: time.Now().Format(timeFormat)},
 	}


### PR DESCRIPTION
# Description

we had around 17k+ leftover robot accounts in [QE quay org](https://quay.io/organization/redhat-appstudio-qe/?tab=robots) which were not cleaned up due to cleanup regex not being updated

## Issue ticket number and link
N/A

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

```
DEFAULT_QUAY_ORG_TOKEN=<redacted> DEFAULT_QUAY_ORG=redhat-appstudio-qe  make clean-quay-repos-and-robots
```

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
