### PR TITLE
fix: no extra setup for load tests

### DIFF
--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -332,7 +332,10 @@ func PreflightChecks() error {
 }
 
 func setRequiredEnvVars() error {
-
+	// Load test jobs require no additional setup
+	if strings.Contains(jobName, "-load-test") {
+		return nil
+	}
 	// Konflux Nightly E2E job
 	if strings.Contains(jobName, "-periodic") {
 		requiresMultiPlatformTests = true


### PR DESCRIPTION
# Description
[slack conversation](https://redhat-internal.slack.com/archives/C02FANRBZQD/p1719427922490049)

load tests are failing on sprayproxy setup (that should not be triggered for load test jobs) due to this recent change: https://github.com/konflux-ci/e2e-tests/pull/1223

since load tests do not use sprayproxy, this PR introduces the change that will cause sprayproxy setup being skipped for load-tests jobs

## Issue ticket number and link
N/A

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

in CI 🤷 

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
