### PR TITLE
feat: Add validation for floating tags functionality

### DIFF
--- a/tests/build/build_templates_scenarios.go
+++ b/tests/build/build_templates_scenarios.go
@@ -5,12 +5,13 @@ import (
 )
 
 type ComponentScenarioSpec struct {
-	GitURL             string
-	ContextDir         string
-	DockerFilePath     string
-	PipelineBundleName string
-	EnableHermetic     bool
-	PrefetchInput      string
+	GitURL              string
+	ContextDir          string
+	DockerFilePath      string
+	PipelineBundleName  string
+	EnableHermetic      bool
+	PrefetchInput       string
+	CheckAdditionalTags bool
 }
 
 var componentScenarios = []ComponentScenarioSpec{
@@ -31,12 +32,13 @@ var componentScenarios = []ComponentScenarioSpec{
 		PrefetchInput:      "gomod",
 	},
 	{
-		GitURL:             "https://github.com/cachito-testing/pip-e2e-test",
-		ContextDir:         ".",
-		DockerFilePath:     "Dockerfile",
-		PipelineBundleName: "docker-build",
-		EnableHermetic:     true,
-		PrefetchInput:      "pip",
+		GitURL:              "https://github.com/cachito-testing/pip-e2e-test",
+		ContextDir:          ".",
+		DockerFilePath:      "Dockerfile",
+		PipelineBundleName:  "docker-build",
+		EnableHermetic:      true,
+		PrefetchInput:       "pip",
+		CheckAdditionalTags: true,
 	},
 	{
 		GitURL:             "https://github.com/redhat-appstudio-qe/fbc-sample-repo",
@@ -80,11 +82,11 @@ var componentScenarios = []ComponentScenarioSpec{
 	},
 }
 
-func GetComponentScenarioDetailsFromGitUrl(gitUrl string) (string, string, string, bool, string) {
+func GetComponentScenarioDetailsFromGitUrl(gitUrl string) (string, string, string, bool, string, bool) {
 	for _, componentScenario := range componentScenarios {
 		if componentScenario.GitURL == gitUrl {
-			return componentScenario.ContextDir, componentScenario.DockerFilePath, componentScenario.PipelineBundleName, componentScenario.EnableHermetic, componentScenario.PrefetchInput
+			return componentScenario.ContextDir, componentScenario.DockerFilePath, componentScenario.PipelineBundleName, componentScenario.EnableHermetic, componentScenario.PrefetchInput, componentScenario.CheckAdditionalTags
 		}
 	}
-	return "", "", "", false, ""
+	return "", "", "", false, "", false
 }

--- a/tests/build/const.go
+++ b/tests/build/const.go
@@ -21,7 +21,7 @@ const (
 
 	helloWorldComponentGitSourceRepoName = "devfile-sample-hello-world"
 	helloWorldComponentDefaultBranch     = "default"
-	helloWorldComponentRevision          = "b915157dc9efac492ebc285d4a44ce67e6ab2075"
+	helloWorldComponentRevision          = "d2d03e69de912e3827c29b4c5b71ffe8bcb5dad8"
 
 	multiComponentGitSourceRepoName = "sample-multi-component"
 	multiComponentDefaultBranch     = "main"
@@ -56,6 +56,7 @@ const (
 )
 
 var (
+	additionalTags                  = []string{"test-tag1", "test-tag2"}
 	componentUrls                   = strings.Split(utils.GetEnv(COMPONENT_REPO_URLS_ENV, pythonComponentGitSourceURL), ",") //multiple urls
 	componentNames                  []string
 	gihubOrg                        = utils.GetEnv(constants.GITHUB_E2E_ORGANIZATION_ENV, "redhat-appstudio-qe")


### PR DESCRIPTION
# Description

This PR adds the validation for the floating tag functionality, when additional tags are added in the dockerfile, build pipeline should create the additional tags for them in the quay image repo   

## Issue ticket number and link
https://issues.redhat.com/browse/STONEBLD-2425

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested locally and also in the build-defintions CI through [PR](https://github.com/konflux-ci/build-definitions/pull/1106)

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
