### PR TITLE
chore: validate offboarding is done successfully with github token

### DIFF
--- a/tests/build/build.go
+++ b/tests/build/build.go
@@ -1018,6 +1018,16 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 					return true, nil
 				}, time.Minute*2, constants.PipelineRunPollingInterval).Should(BeTrue(), "timeout while checking if any more pipelinerun is triggered")
 			})
+			It("when second component is deleted, pac pr branch should not exist in the repo", Pending, func() {
+				timeout = time.Second * 60
+				interval = time.Second * 1
+				Expect(f.AsKubeAdmin.HasController.DeleteComponent(secondComponentName, testNamespace, true)).To(Succeed())
+				Eventually(func() bool {
+					exists, err := f.AsKubeAdmin.CommonController.Github.ExistsRef(secretLookupGitSourceRepoTwoName, secondPacBranchName)
+					Expect(err).ShouldNot(HaveOccurred())
+					return exists
+				}, timeout, interval).Should(BeFalse(), fmt.Sprintf("timed out when waiting for the branch %s to be deleted from %s repository", secondPacBranchName, secretLookupGitSourceRepoTwoName))
+			})
 		})
 	})
 	Describe("test build annotations", Label("annotations"), Ordered, func() {


### PR DESCRIPTION
# Description

This small change will complete work needed for the story to add scenario for `Component onboarding to PaC using github token instead of the PaC github App`, since [this scenario](https://github.com/konflux-ci/e2e-tests/blob/2e39ddce4b49e89bf191614dec64e0f8c439680e/tests/build/build.go#L859) already covers the onboarding part, this PR add the vaidation for offboarding as well. 

## Issue ticket number and link

https://issues.redhat.com/browse/STONEBLD-2486

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Locally 

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
