### PR TITLE
fix: adapt e2e tests to backward compatibility reconciler in Image Controller

### DIFF
--- a/pkg/clients/imagecontroller/image_repository.go
+++ b/pkg/clients/imagecontroller/image_repository.go
@@ -5,7 +5,9 @@ import (
 
 	"github.com/konflux-ci/image-controller/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
+	rclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // CreateImageRepositoryCR creates new ImageRepository
@@ -42,4 +44,56 @@ func (i *ImageController) GetImageRepositoryCR(name, namespace string) (*v1alpha
 		return nil, err
 	}
 	return &imageRepository, nil
+}
+
+// ChangeVisibilityToPrivate changes ImageRepository visibility to private
+func (i *ImageController) ChangeVisibilityToPrivate(namespace, applicationName, componentName string) (*v1alpha1.ImageRepository, error) {
+	imageRepositoryList := &v1alpha1.ImageRepositoryList{}
+	imageRepoLabels := map[string]string{"appstudio.redhat.com/component": componentName}
+	err := i.KubeRest().List(context.Background(), imageRepositoryList, &rclient.ListOptions{LabelSelector: labels.SelectorFromSet(imageRepoLabels), Namespace: namespace})
+	if err != nil {
+		return nil, err
+	}
+	imageRepository := &imageRepositoryList.Items[0]
+	// update visibility to private
+	imageRepository.Spec.Image.Visibility = "private"
+
+	err = i.KubeRest().Update(context.Background(), imageRepository)
+	if err != nil {
+		return nil, err
+	}
+	return imageRepository, nil
+}
+
+// GetImageName returns the image repo name for the component
+func (i *ImageController) GetImageName(namespace, componentName string) (string, error) {
+	imageRepositoryList := &v1alpha1.ImageRepositoryList{}
+	imageRepoLabels := map[string]string{"appstudio.redhat.com/component": componentName}
+	err := i.KubeRest().List(context.Background(), imageRepositoryList, &rclient.ListOptions{LabelSelector: labels.SelectorFromSet(imageRepoLabels), Namespace: namespace})
+	if err != nil {
+		return "", err
+	}
+	return imageRepositoryList.Items[0].Spec.Image.Name, err
+}
+
+// GetRobotAccounts returns the pull and push robot accounts for the component
+func (i *ImageController) GetRobotAccounts(namespace, componentName string) (string, string, error) {
+	imageRepositoryList := &v1alpha1.ImageRepositoryList{}
+	imageRepoLabels := map[string]string{"appstudio.redhat.com/component": componentName}
+	err := i.KubeRest().List(context.Background(), imageRepositoryList, &rclient.ListOptions{LabelSelector: labels.SelectorFromSet(imageRepoLabels), Namespace: namespace})
+	if err != nil {
+		return "", "", err
+	}
+	return imageRepositoryList.Items[0].Status.Credentials.PullRobotAccountName, imageRepositoryList.Items[0].Status.Credentials.PushRobotAccountName, nil
+}
+
+// IsVisibilityPublic returns true if imageRepository CR has spec.image.visibility == "public", otherwise false
+func (i *ImageController) IsVisibilityPublic(namespace, componentName string) (bool, error) {
+	imageRepositoryList := &v1alpha1.ImageRepositoryList{}
+	imageRepoLabels := map[string]string{"appstudio.redhat.com/component": componentName}
+	err := i.KubeRest().List(context.Background(), imageRepositoryList, &rclient.ListOptions{LabelSelector: labels.SelectorFromSet(imageRepoLabels), Namespace: namespace})
+	if err != nil {
+		return false, err
+	}
+	return imageRepositoryList.Items[0].Spec.Image.Visibility == "public", nil
 }

--- a/pkg/utils/build/quay.go
+++ b/pkg/utils/build/quay.go
@@ -23,36 +23,6 @@ var (
 	quayClient = quay.NewQuayClient(&http.Client{Transport: &http.Transport{}}, quayToken, quayApiUrl)
 )
 
-func GetQuayImageName(annotations map[string]string) (string, error) {
-	type imageAnnotation struct {
-		Image  string `json:"Image"`
-		Secret string `json:"Secret"`
-	}
-	image_annotation_str := annotations["image.redhat.com/image"]
-	var ia imageAnnotation
-	err := json.Unmarshal([]byte(image_annotation_str), &ia)
-	if err != nil {
-		return "", err
-	}
-	tokens := strings.Split(ia.Image, "/")
-	return strings.Join(tokens[2:], "/"), nil
-}
-
-func IsImageAnnotationPresent(annotations map[string]string) bool {
-	image_annotation_str := annotations["image.redhat.com/image"]
-	return image_annotation_str != ""
-}
-
-func ImageRepoCreationSucceeded(annotations map[string]string) bool {
-	imageAnnotationValue := annotations["image.redhat.com/image"]
-	return !strings.Contains(imageAnnotationValue, "failed to generete image repository")
-}
-
-func GetRobotAccountName(imageName string) string {
-	tokens := strings.Split(imageName, "/")
-	return strings.Join(tokens, "")
-}
-
 func DoesImageRepoExistInQuay(quayImageRepoName string) (bool, error) {
 	exists, err := quayClient.DoesRepositoryExist(quayOrg, quayImageRepoName)
 	if exists {

--- a/tests/build/build.go
+++ b/tests/build/build.go
@@ -218,7 +218,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 				Expect(err).ShouldNot(HaveOccurred(), "failed while checking if image repo exists in quay with error: %+v", err)
 				Expect(imageExist).To(BeTrue(), "quay image does not exists")
 
-				pullRobotAccountName, pushRobotAccountName, err := f.AsKubeAdmin.ImageController.GetRobotAccounts(testNamespace, defaultBranchTestComponentName)
+				pullRobotAccountName, pushRobotAccountName, err = f.AsKubeAdmin.ImageController.GetRobotAccounts(testNamespace, defaultBranchTestComponentName)
 				Expect(err).ShouldNot(HaveOccurred(), "failed to get robot account names")
 				pullRobotAccountExist, err := build.DoesRobotAccountExistInQuay(pullRobotAccountName)
 				Expect(err).ShouldNot(HaveOccurred(), "failed while checking if pull robot account exists in quay with error: %+v", err)
@@ -232,8 +232,8 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 				Expect(err).ShouldNot(HaveOccurred(), fmt.Sprintf("failed while checking if the image repo %s is private", imageRepoName))
 				Expect(isPublic).To(BeFalse(), "Expected image repo to be private, but it is public")
 			})
-			// skipped due to RHTAPBUGS-978
-			It("a related PipelineRun should be deleted after deleting the component", Pending, func() {
+
+			It("a related PipelineRun should be deleted after deleting the component", func() {
 				timeout = time.Second * 60
 				interval = time.Second * 1
 				Expect(f.AsKubeAdmin.HasController.DeleteComponent(defaultBranchTestComponentName, testNamespace, true)).To(Succeed())
@@ -246,8 +246,8 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 					return err
 				}, timeout, constants.PipelineRunPollingInterval).Should(MatchError(ContainSubstring("no pipelinerun found")), fmt.Sprintf("timed out when waiting for the PipelineRun to be removed for Component %s/%s", testNamespace, defaultBranchTestComponentName))
 			})
-			// skipped due to RHTAPBUGS-978
-			It("PR branch should not exist in the repo", Pending, func() {
+
+			It("PR branch should not exist in the repo", func() {
 				timeout = time.Second * 60
 				interval = time.Second * 1
 				branchName := constants.PaCPullRequestBranchPrefix + defaultBranchTestComponentName
@@ -257,16 +257,16 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 					return exists
 				}, timeout, interval).Should(BeFalse(), fmt.Sprintf("timed out when waiting for the branch %s to be deleted from %s repository", branchName, helloWorldComponentGitSourceRepoName))
 			})
-			// skipped due to RHTAPBUGS-978
-			It("related image repo and the robot account should be deleted after deleting the component", Pending, func() {
-				timeout = time.Second * 10
-				interval = time.Second * 1
-				// Check image repo should not be deleted
-				Consistently(func() (bool, error) {
-					return build.DoesImageRepoExistInQuay(imageRepoName)
-				}, timeout, interval).Should(BeFalse(), fmt.Sprintf("image repo %s got deleted while it should not have", imageRepoName))
-				// Check robot account should be deleted
+
+			It("related image repo and the robot account should be deleted after deleting the component", func() {
 				timeout = time.Second * 60
+				interval = time.Second * 1
+				// Check image repo should be deleted
+				Eventually(func() (bool, error) {
+					return build.DoesImageRepoExistInQuay(imageRepoName)
+				}, timeout, interval).Should(BeFalse(), fmt.Sprintf("timed out when waiting for image repo %s to be deleted", imageRepoName))
+
+				// Check robot account should be deleted
 				Eventually(func() (bool, error) {
 					pullRobotAccountExists, err := build.DoesRobotAccountExistInQuay(pullRobotAccountName)
 					if err != nil {
@@ -360,7 +360,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 				Expect(err).ShouldNot(HaveOccurred(), "failed while checking if image repo exists in quay with error: %+v", err)
 				Expect(imageExist).To(BeTrue(), "quay image does not exists")
 
-				pullRobotAccountName, pushRobotAccountName, err := f.AsKubeAdmin.ImageController.GetRobotAccounts(testNamespace, componentName)
+				pullRobotAccountName, pushRobotAccountName, err = f.AsKubeAdmin.ImageController.GetRobotAccounts(testNamespace, componentName)
 				Expect(err).ShouldNot(HaveOccurred(), "failed to get robot account names")
 				pullRobotAccountExist, err := build.DoesRobotAccountExistInQuay(pullRobotAccountName)
 				Expect(err).ShouldNot(HaveOccurred(), "failed while checking if pull robot account exists in quay with error: %+v", err)


### PR DESCRIPTION
# Description

This PR changes the e2e-tests to adapt to backward compatibility reconciler in Image Controller, to check the image repo CR instead of annotations

## Issue ticket number and link
https://issues.redhat.com/browse/STONEBLD-2569

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
