### PR TITLE
fix(KFLUXBUGS-1310): use GitLab API when retriggering GitLab-based Build PLRs

### DIFF
--- a/pkg/clients/gitlab/git.go
+++ b/pkg/clients/gitlab/git.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/konflux-ci/e2e-tests/pkg/constants"
+	"github.com/konflux-ci/e2e-tests/pkg/utils"
 	. "github.com/onsi/gomega"
 	gitlab "github.com/xanzy/go-gitlab"
 )
@@ -148,4 +150,19 @@ func (gc *GitlabClient) DeleteWebhooks(projectID, clusterAppDomain string) error
 	}
 
 	return nil
+}
+
+func (gc *GitlabClient) CreateFile(pathToFile, fileContent, branchName string) (*gitlab.FileInfo, error) {
+	opts := &gitlab.CreateFileOptions{
+		Branch:   gitlab.Ptr(branchName),
+		Content:  &fileContent,
+		CommitMessage: gitlab.Ptr("e2e test commit message"),
+	}
+
+	file, resp, err := gc.client.RepositoryFiles.CreateFile(utils.GetEnv(constants.GITLAB_PROJECT_ID, ""), pathToFile, opts)
+	if resp.StatusCode != 201 || err != nil {
+		return nil, fmt.Errorf("error when creating file contents: response (%v) and error: %v", resp, err)
+	}
+
+	return file, nil
 }

--- a/pkg/clients/has/controller.go
+++ b/pkg/clients/has/controller.go
@@ -5,13 +5,17 @@ import (
 	"github.com/konflux-ci/e2e-tests/pkg/utils"
 
 	"github.com/konflux-ci/e2e-tests/pkg/clients/github"
+	"github.com/konflux-ci/e2e-tests/pkg/clients/gitlab"
 	kubeCl "github.com/konflux-ci/e2e-tests/pkg/clients/kubernetes"
 )
 
-// Factory to initialize the comunication against different API like github or kubernetes.
+// Factory to initialize the comunication against different API like github, gitlab or kubernetes.
 type HasController struct {
 	// A Client manages communication with the GitHub API in a specific Organization.
 	Github *github.Github
+
+	// A Client manages communication with the GitLab API in a specific Organization.
+	GitLab *gitlab.GitlabClient
 
 	// Generates a kubernetes client to interact with clusters.
 	*kubeCl.CustomClient
@@ -25,8 +29,15 @@ func NewSuiteController(kube *kubeCl.CustomClient) (*HasController, error) {
 		return nil, err
 	}
 
+	gl, err := gitlab.NewGitlabClient(utils.GetEnv(constants.GITLAB_TOKEN_ENV, ""),
+		utils.GetEnv(constants.GITLAB_URL_ENV, "https://gitlab.com/api/v4"))
+	if err != nil {
+		return nil, err
+	}
+
 	return &HasController{
 		gh,
+		gl,
 		kube,
 	}, nil
 }


### PR DESCRIPTION
# Description

use GitLab API when retriggering GitLab-based Build PLRs

## Issue ticket number and link
[KFLUXBUGS-1310](https://issues.redhat.com//browse/KFLUXBUGS-1310)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

```
# run GitLab test case, e.g:
./bin/e2e-appstudio --ginkgo.focus="Gitlab Status Reporting of Integration tests"
# Wait until PaC PLR is running and cancel it
# Wait until a new PaC PLR is created and the test eventually completes with no errors
```

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
