### PR TITLE
fix: stop checking BASE_IMAGES_DIGESTS

### DIFF
--- a/pkg/utils/build/source_image.go
+++ b/pkg/utils/build/source_image.go
@@ -431,8 +431,8 @@ func (d *Dockerfile) IsBuildFromScratch() bool {
 	return parentImages[len(parentImages)-1] == "scratch"
 }
 
-// convertImageToBuildahOutputForm converts an image pullspec to the corresponding form within
-// BASE_IMAGES_DIGESTS output by buildah task.
+// convertImageToBuildahOutputForm converts an image pullspec to a
+// format corresponding to `buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}'`
 func convertImageToBuildahOutputForm(imagePullspec string) (string, error) {
 	ref, err := reference.Parse(imagePullspec)
 	if err != nil {
@@ -460,10 +460,10 @@ func convertImageToBuildahOutputForm(imagePullspec string) (string, error) {
 	return fmt.Sprintf("%s/%s:%s@sha256:%s", converted, ref.Name, tag, digest), nil
 }
 
-// ConvertParentImagesToBaseImagesDigestsForm is a helper function for testing the order is matched
-// between BASE_IMAGES_DIGESTS and parent images within Dockerfile.
-// ConvertParentImagesToBaseImagesDigestsForm de-duplicates the images what buildah task does for BASE_IMAGES_DIGESTS.
-func (d *Dockerfile) ConvertParentImagesToBaseImagesDigestsForm() ([]string, error) {
+// ConvertParentImagesToBuildahOutputForm converts the image pullspecs found in the Dockerfile
+// to a format corresponding to `buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}'`.
+// ConvertParentImagesToBuildahOutputForm de-duplicates the images.
+func (d *Dockerfile) ConvertParentImagesToBuildahOutputForm() ([]string, error) {
 	convertedImagePullspecs := make([]string, 0, 5)
 	seen := make(map[string]int)
 	parentImages := d.ParentImages()

--- a/tests/build/source_build.go
+++ b/tests/build/source_build.go
@@ -40,7 +40,7 @@ func CheckParentSources(c client.Client, tektonController *tekton.TektonControll
 			Expect(buildResult.BaseImageSourceIncluded).Should(BeFalse())
 			return
 		}
-		baseImagesDigests, err = parsedDockerfile.ConvertParentImagesToBaseImagesDigestsForm()
+		baseImagesDigests, err = parsedDockerfile.ConvertParentImagesToBuildahOutputForm()
 		Expect(err).ShouldNot(HaveOccurred())
 	} else {
 		Fail("CheckParentSources only works for docker-build pipelines")

--- a/tests/build/source_build.go
+++ b/tests/build/source_build.go
@@ -14,25 +14,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func ensureBaseImagesDigestsOrder(
-	c client.Client, tektonController *tekton.TektonController, pr *pipeline.PipelineRun, baseImagesDigests []string,
+func parseDockerfileUsedForBuild(
+	c client.Client, tektonController *tekton.TektonController, pr *pipeline.PipelineRun,
 ) *build.Dockerfile {
 	dockerfileContent, err := build.ReadDockerfileUsedForBuild(c, tektonController, pr)
 	Expect(err).ShouldNot(HaveOccurred())
 
 	parsedDockerfile, err := build.ParseDockerfile(dockerfileContent)
 	Expect(err).ShouldNot(HaveOccurred())
-
-	// Check the order of BASE_IMAGES_DIGESTS in order to get the correct parent image used in the last build stage.
-	convertedBaseImages, err := parsedDockerfile.ConvertParentImagesToBaseImagesDigestsForm()
-	Expect(err).ShouldNot(HaveOccurred())
-	GinkgoWriter.Println("converted base images:", convertedBaseImages)
-	GinkgoWriter.Println("base_images_digests:", baseImagesDigests)
-	n := len(convertedBaseImages)
-	Expect(n).Should(Equal(len(baseImagesDigests)))
-	for i := 0; i < n; i++ {
-		Expect(convertedBaseImages[i]).Should(Equal(baseImagesDigests[i]))
-	}
 
 	return parsedDockerfile
 }
@@ -41,22 +30,20 @@ func ensureBaseImagesDigestsOrder(
 // This check is applied to every build for which source build is enabled, then the several prerequisites
 // for including parent sources are handled as well.
 func CheckParentSources(c client.Client, tektonController *tekton.TektonController, pr *pipeline.PipelineRun) {
-	value, err := tektonController.GetTaskRunResult(c, pr, "build-container", "BASE_IMAGES_DIGESTS")
-	Expect(err).ShouldNot(HaveOccurred())
-	baseImagesDigests := strings.Split(strings.TrimSpace(value), "\n")
-	Expect(baseImagesDigests).ShouldNot(BeEmpty(),
-		"checkParentSources: no parent image presents in result BASE_IMAGES_DIGESTS")
-	GinkgoWriter.Println("BASE_IMAGES_DIGESTS used to build:", baseImagesDigests)
-
 	buildResult, err := build.ReadSourceBuildResult(c, tektonController, pr)
 	Expect(err).ShouldNot(HaveOccurred())
 
+	var baseImagesDigests []string
 	if build.IsDockerBuild(pr) {
-		parsedDockerfile := ensureBaseImagesDigestsOrder(c, tektonController, pr, baseImagesDigests)
+		parsedDockerfile := parseDockerfileUsedForBuild(c, tektonController, pr)
 		if parsedDockerfile.IsBuildFromScratch() {
 			Expect(buildResult.BaseImageSourceIncluded).Should(BeFalse())
 			return
 		}
+		baseImagesDigests, err = parsedDockerfile.ConvertParentImagesToBaseImagesDigestsForm()
+		Expect(err).ShouldNot(HaveOccurred())
+	} else {
+		Fail("CheckParentSources only works for docker-build pipelines")
 	}
 
 	lastBaseImage := baseImagesDigests[len(baseImagesDigests)-1]


### PR DESCRIPTION
# Description

Stop checking BASE_IMAGES_DIGESTS. Most build tasks are about to stop returning this result.

As a consequence, it is currently not possible to check the parent image
sources for non-docker build pipelines. The support could be added (read
the base image from the SBOM), but it seems unnecessary at the moment.

## Issue ticket number and link

[STONEBLD-2326](https://issues.redhat.com//browse/STONEBLD-2326)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

About to be tested ~via branch pairing (hopefully)~ by using the e2e-tests image built for this PR in https://github.com/konflux-ci/build-definitions/pull/1160

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
