### PR TITLE
refactor(KONFLUX-3773): Fork repositories sequentially

### DIFF
--- a/tests/load-tests/loadtest.go
+++ b/tests/load-tests/loadtest.go
@@ -95,8 +95,8 @@ func main() {
 	// Tier up measurements logger
 	logging.MeasurementsStart(opts.OutputDir)
 
-	// Start given number of `userJourneyThread()` threads using `journey.Setup()` and wait for them to finish
-	_, err = logging.Measure(journey.Setup, userJourneyThread, &opts)
+	// Start given number of `perUserThread()` threads using `journey.Setup()` and wait for them to finish
+	_, err = logging.Measure(journey.Setup, perUserThread, &opts)
 	if err != nil {
 		logging.Logger.Fatal("Threads setup failed: %v", err)
 	}
@@ -112,7 +112,7 @@ func main() {
 }
 
 // Single user journey
-func userJourneyThread(threadCtx *journey.MainContext) {
+func perUserThread(threadCtx *journey.MainContext) {
 	defer threadCtx.ThreadsWG.Done()
 
 	var err error
@@ -193,13 +193,6 @@ func userJourneyThread(threadCtx *journey.MainContext) {
 	//// Close the watcher when finished
 	//watcher.Stop()
 	//os.Exit(10)
-
-	// Template repo if needed
-	_, err = logging.Measure(journey.HandleRepoForking, threadCtx)
-	if err != nil {
-		logging.Logger.Error("Thread failed: %v", err)
-		return
-	}
 
 	for threadCtx.JourneyRepeatsCounter = 1; threadCtx.JourneyRepeatsCounter <= threadCtx.Opts.JourneyRepeats; threadCtx.JourneyRepeatsCounter++ {
 

--- a/tests/load-tests/pkg/journey/handle_repo_templating.go
+++ b/tests/load-tests/pkg/journey/handle_repo_templating.go
@@ -115,7 +115,7 @@ func HandleRepoForking(ctx *MainContext) error {
 		return nil
 	}
 
-	logging.Logger.Debug("Templating repository %s for user %s", ctx.Opts.ComponentRepoUrl, ctx.Username)
+	logging.Logger.Debug("Forking repository %s for user %s", ctx.Opts.ComponentRepoUrl, ctx.Username)
 
 	forkUrl, err := ForkRepo(
 		ctx.Framework,
@@ -124,14 +124,10 @@ func HandleRepoForking(ctx *MainContext) error {
 		ctx.Username,
 	)
 	if err != nil {
-		ctx.TemplatingDoneWG.Done()
-		return logging.Logger.Fail(80, "Repo templating failed: %v", err)
+		return logging.Logger.Fail(80, "Repo forking failed: %v", err)
 	}
 
 	ctx.ComponentRepoUrl = forkUrl
-
-	ctx.TemplatingDoneWG.Done()
-	ctx.TemplatingDoneWG.Wait()
 
 	return nil
 }


### PR DESCRIPTION
GitHub does not allow forking more than 3 at a time anyway. If 3 are forking already, it returns 403 for more forking requests and as we are retrying after 2 seconds, we soon used whole rate_limit.

With parralel forking it also often happened that process was stuck in loop with 403 and only think that helped was cleaning all 10 temporary repos like "<source_repo>-1".

Anyway, fingers crossed, this will be slower but more stable.