### PR TITLE
fix: stop creating build-secret when github app installed

### DIFF
--- a/tests/build/build.go
+++ b/tests/build/build.go
@@ -287,13 +287,13 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 			BeforeAll(func() {
 
 				// create the build secret in the user namespace
-				secretName := "build-secret"
-				token := os.Getenv("GITHUB_TOKEN")
-				secretAnnotations := map[string]string{
-					"appstudio.redhat.com/scm.repository": os.Getenv("MY_GITHUB_ORG") + "/*",
-				}
-				err = createBuildSecret(f, secretName, secretAnnotations, token)
-				Expect(err).ShouldNot(HaveOccurred())
+				// secretName := "build-secret"
+				// token := os.Getenv("GITHUB_TOKEN")
+				// secretAnnotations := map[string]string{
+				// 	"appstudio.redhat.com/scm.repository": os.Getenv("MY_GITHUB_ORG") + "/*",
+				// }
+				// err = createBuildSecret(f, secretName, secretAnnotations, token)
+				// Expect(err).ShouldNot(HaveOccurred())
 
 				componentObj := appservice.ComponentSpec{
 					ComponentName: componentName,


### PR DESCRIPTION
# Description

Two pipelineruns getting created when build-secret is created and onboarding component repo has github app installed, which might be the root cause for the issue

## Issue ticket number and link
https://issues.redhat.com/browse/KFLUXBUGS-1462

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
