### PR TITLE
feat(KONFLUX-3857): Stop Mintmaker creating 'chore: ...' update PRs that provoke 'on-pull-request' builds that might interfere with testing

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -229,4 +229,5 @@ var (
 	IntegrationTestScenarioDefaultLabels        = map[string]string{"test.appstudio.openshift.io/optional": "false"}
 	DefaultDockerBuildPipelineBundle            = map[string]string{"build.appstudio.openshift.io/pipeline": `{"name": "docker-build", "bundle": "latest"}`}
 	DefaultFbcBuilderPipelineBundle             = map[string]string{"build.appstudio.openshift.io/pipeline": `{"name": "fbc-builder", "bundle": "latest"}`}
+	ComponentMintmakerDisabledAnnotation        = map[string]string{"mintmaker.appstudio.redhat.com/disabled": "true"}
 )

--- a/tests/load-tests/loadtest.go
+++ b/tests/load-tests/loadtest.go
@@ -52,6 +52,7 @@ func init() {
 	rootCmd.Flags().StringVar(&opts.JourneyDuration, "journey-duration", "1h", "repeat user journey until this timeout (either this or --journey-repeats)")
 	rootCmd.Flags().BoolVar(&opts.PipelineSkipInitialChecks, "pipeline-skip-initial-checks", true, "if build pipeline runs' initial checks are to be skipped")
 	rootCmd.Flags().BoolVar(&opts.PipelineRequestConfigurePac, "pipeline-request-configure-pac", false, "if build pipeline should be taken from component repository .tekton directory")
+	rootCmd.Flags().BoolVar(&opts.PipelineMintmakerDisabled, "pipeline-mintmaker-disabled", true, "if you want to stop Mintmaker to be creating update PRs for your component (default in loadtest different from Konflux default)")
 	rootCmd.Flags().BoolVar(&opts.MultiarchWorkflow, "multiarch-workflow", false, "if we should template repo so it is suitable for multi arch test, merge PR and ignore custom pipeline run from PR")
 	rootCmd.Flags().StringVarP(&opts.OutputDir, "output-dir", "o", ".", "directory where output files such as load-tests.log or load-tests.json are stored")
 	rootCmd.Flags().StringVar(&opts.BuildPipelineSelectorBundle, "build-pipeline-selector-bundle", "", "BuildPipelineSelector bundle to use when testing with build-definition PR")

--- a/tests/load-tests/pkg/journey/handle_component.go
+++ b/tests/load-tests/pkg/journey/handle_component.go
@@ -76,7 +76,7 @@ func getPaCPull(annotations map[string]string) (string, error) {
 	}
 }
 
-func createComponent(f *framework.Framework, namespace, name, repoUrl, repoRevision, containerContext, containerFile, buildPipelineSelector, appName string, skipInitialChecks, requestConfigurePac bool) error {
+func createComponent(f *framework.Framework, namespace, name, repoUrl, repoRevision, containerContext, containerFile, buildPipelineSelector, appName string, skipInitialChecks, requestConfigurePac, mintmakerDisabled bool) error {
 	// Prepare annotations to add to component
 	annotationsMap := constants.DefaultDockerBuildPipelineBundle
 	if buildPipelineSelector != "" {
@@ -86,6 +86,12 @@ func createComponent(f *framework.Framework, namespace, name, repoUrl, repoRevis
 	if requestConfigurePac {
 		// This is PaC build
 		for key, value := range constants.ComponentPaCRequestAnnotation {
+			annotationsMap[key] = value
+		}
+	}
+	if mintmakerDisabled {
+		// Stop Mintmaker creating update PRs for your component
+		for key, value := range constants.ComponentMintmakerDisabledAnnotation {
 			annotationsMap[key] = value
 		}
 	}
@@ -267,6 +273,7 @@ func HandleComponent(ctx *PerComponentContext) error {
 		ctx.ParentContext.ApplicationName,
 		ctx.ParentContext.ParentContext.Opts.PipelineSkipInitialChecks,
 		ctx.ParentContext.ParentContext.Opts.PipelineRequestConfigurePac,
+		ctx.ParentContext.ParentContext.Opts.PipelineMintmakerDisabled,
 	)
 	if err != nil {
 		return logging.Logger.Fail(60, "Component failed creation: %v", err)

--- a/tests/load-tests/pkg/options/options.go
+++ b/tests/load-tests/pkg/options/options.go
@@ -26,6 +26,7 @@ type Opts struct {
 	OutputDir                     string
 	PipelineRequestConfigurePac   bool
 	PipelineSkipInitialChecks     bool
+	PipelineMintmakerDisabled     bool
 	Purge                         bool
 	PurgeOnly                     bool
 	QuayRepo                      string


### PR DESCRIPTION
# Description
Adding a possibility for Loadtest to add `mintmaker.appstudio.redhat.com/disabled=true` annotation to components.

It is important when testing PaC build (multi-arch), because 'on-pull-request' builds that these Mintmaker PRs causes might interfere with testing.

## Issue ticket number and link
https://issues.redhat.com/browse/KONFLUX-3857