### PR TITLE
fix(KFLUXBUGS-1297): failure for an already successful snapshot

### DIFF
--- a/tests/konflux-demo/konflux-demo.go
+++ b/tests/konflux-demo/konflux-demo.go
@@ -321,9 +321,9 @@ var _ = framework.KonfluxDemoSuiteDescribe(Label(devEnvTestLabel), func() {
 
 			When("Integration Test PipelineRun completes successfully", func() {
 				It("should lead to Snapshot CR being marked as passed", func() {
-					snapshot, err = fw.AsKubeAdmin.IntegrationController.GetSnapshot("", pipelineRun.Name, "", fw.UserNamespace)
-					Expect(err).ShouldNot(HaveOccurred())
 					Eventually(func() bool {
+						snapshot, err = fw.AsKubeAdmin.IntegrationController.GetSnapshot("", pipelineRun.Name, "", fw.UserNamespace)
+						Expect(err).ShouldNot(HaveOccurred())
 						return fw.AsKubeAdmin.CommonController.HaveTestsSucceeded(snapshot)
 					}, time.Minute*5, defaultPollingInterval).Should(BeTrue(), fmt.Sprintf("tests have not succeeded for snapshot %s/%s", snapshot.GetNamespace(), snapshot.GetName()))
 				})


### PR DESCRIPTION
The rhtap-demo test suite will sometimes fail due to the integration service lagging when marking a snapshot as succeeded. A test expecting the snapshot in a passing state can fail as a result.

[KFLUXBUGS-1297](https://issues.redhat.com/browse/KFLUXBUGS-1297)
