### PR TITLE
fix: fix and improve test selection rules for e2e-tests repo

### DIFF
--- a/magefiles/rulesengine/repos/common.go
+++ b/magefiles/rulesengine/repos/common.go
@@ -7,7 +7,7 @@ import (
 	"k8s.io/klog"
 )
 
-func ExecuteTestAction(rctx *rulesengine.RuleCtx, args ...any) error {
+func ExecuteTestAction(rctx *rulesengine.RuleCtx) error {
 
 	/* This is so that we don't have ginkgo add the prefixes to
 	the command args i.e. '--ginkgo.xx' || '--test.xx' || '--go.xx'

--- a/magefiles/rulesengine/repos/e2e_repo.go
+++ b/magefiles/rulesengine/repos/e2e_repo.go
@@ -44,7 +44,7 @@ var BuildTestFileChangeOnlyRule = rulesengine.Rule{Name: "E2E PR Build Test File
 	}),
 	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
 
-		for _, file := range rctx.DiffFiles.FilterByDirString("tests/build/*.go") {
+		for _, file := range rctx.DiffFiles.FilterByDirGlob("tests/build/*.go") {
 
 			rctx.FocusFiles = dedupeAppendFiles(rctx.FocusFiles, file.Name)
 
@@ -83,11 +83,11 @@ var BuildNonTestFileChangeRule = rulesengine.Rule{Name: "E2E PR Build Test Helpe
 	Description: "Map build tests files when const.go or source_build.go file is changed in the e2e-repo PR",
 	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) bool {
 
-		return len(rctx.DiffFiles.FilterByDirString("tests/build/const.go")) != 0 || len(rctx.DiffFiles.FilterByDirString("tests/build/source_build.go")) != 0
+		return len(rctx.DiffFiles.FilterByDirGlob("tests/build/const.go")) != 0 || len(rctx.DiffFiles.FilterByDirGlob("tests/build/source_build.go")) != 0
 	}),
 	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
 
-		for _, file := range rctx.DiffFiles.FilterByDirString("tests/build/*.go") {
+		for _, file := range rctx.DiffFiles.FilterByDirGlob("tests/build/*.go") {
 
 			if strings.Contains(file.Name, "source_build.go") || strings.Contains(file.Name, "const.go") || strings.Contains(file.Name, "scenarios.go") {
 
@@ -106,11 +106,11 @@ var ReleaseTestTestFilesChangeRule = rulesengine.Rule{Name: "E2E PR Release Test
 	Description: "Map release test files if they are changed in the e2e-repo PR",
 	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) bool {
 
-		return len(rctx.DiffFiles.FilterByDirString("tests/release/*/*.go")) != 0
+		return len(rctx.DiffFiles.FilterByDirGlob("tests/release/*/*.go")) != 0
 	}),
 	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
 
-		for _, file := range rctx.DiffFiles.FilterByDirString("tests/release/*/*.go") {
+		for _, file := range rctx.DiffFiles.FilterByDirGlob("tests/release/*/*.go") {
 
 			rctx.FocusFiles = dedupeAppendFiles(rctx.FocusFiles, file.Name)
 
@@ -124,7 +124,7 @@ var ReleaseTestHelperFilesChangeOnlyRule = rulesengine.Rule{Name: "E2E PR Releas
 	Description: "Map release tests files when only the release helper go files in root of release directory are changed in the e2e-repo PR",
 	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) bool {
 
-		return len(rctx.DiffFiles.FilterByDirString("tests/release/*.go")) != 0 && len(rctx.DiffFiles.FilterByDirString("tests/release/*/*.go")) == 0
+		return len(rctx.DiffFiles.FilterByDirGlob("tests/release/*.go")) != 0 && len(rctx.DiffFiles.FilterByDirGlob("tests/release/*/*.go")) == 0
 	}),
 	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
 
@@ -160,11 +160,11 @@ var KonfluxDemoTestFileChangedRule = rulesengine.Rule{Name: "E2E PR Konflux-Demo
 	Description: "Map demo tests files when konflux-demo test files are changed in the e2e-repo PR",
 	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) bool {
 
-		return len(rctx.DiffFiles.FilterByDirString("tests/*-demo/*.go")) != 0
+		return len(rctx.DiffFiles.FilterByDirGlob("tests/*-demo/*.go")) != 0
 	}),
 	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
 
-		for _, file := range rctx.DiffFiles.FilterByDirString("tests/*-demo/*-demo.go") {
+		for _, file := range rctx.DiffFiles.FilterByDirGlob("tests/*-demo/*-demo.go") {
 
 			rctx.FocusFiles = dedupeAppendFiles(rctx.FocusFiles, file.Name)
 
@@ -177,7 +177,7 @@ var KonfluxDemoConfigsFileOnlyChangeRule = rulesengine.Rule{Name: "E2E PR Konflu
 	Description: "Map demo tests files when konflux-demo config.go|type.go test files are changed in the e2e-repo PR",
 	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) bool {
 
-		return len(rctx.DiffFiles.FilterByDirString("tests/*-demo/*.go")) == 0 && len(rctx.DiffFiles.FilterByDirString("tests/*-demo/*/*")) != 0
+		return len(rctx.DiffFiles.FilterByDirGlob("tests/*-demo/*.go")) == 0 && len(rctx.DiffFiles.FilterByDirGlob("tests/*-demo/*/*")) != 0
 	}),
 	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
 
@@ -199,11 +199,11 @@ var IntegrationTestsFileChangeRule = rulesengine.Rule{Name: "E2E PR Integration 
 	Description: "Map integration tests files when integration test files are changed in the e2e-repo PR",
 	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) bool {
 
-		return len(rctx.DiffFiles.FilterByDirString("tests/integration-*/*.go")) != 0
+		return len(rctx.DiffFiles.FilterByDirGlob("tests/integration-*/*.go")) != 0
 	}),
 	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
 
-		for _, file := range rctx.DiffFiles.FilterByDirString("tests/integration-*/*.go") {
+		for _, file := range rctx.DiffFiles.FilterByDirGlob("tests/integration-*/*.go") {
 
 			if strings.Contains(file.Name, "const.go") {
 
@@ -223,7 +223,7 @@ var IntegrationTestsConstFileChangeRule = rulesengine.Rule{Name: "E2E PR Integra
 	Description: "Map integration tests files when integration const files are changed in the e2e-repo PR",
 	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) bool {
 
-		return len(rctx.DiffFiles.FilterByDirString("tests/integration-*/const.go")) != 0 && len(rctx.DiffFiles.FilterByDirString("tests/integration-*/*.go")) == 0
+		return len(rctx.DiffFiles.FilterByDirGlob("tests/integration-*/const.go")) != 0 && len(rctx.DiffFiles.FilterByDirGlob("tests/integration-*/*.go")) == 0
 	}),
 	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
 
@@ -252,11 +252,11 @@ var EcTestFileChangeRule = rulesengine.Rule{Name: "E2E PR EC Test File Change Ru
 	Description: "Map EC tests files when EC test files are changed in the e2e-repo PR",
 	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) bool {
 
-		return len(rctx.DiffFiles.FilterByDirString("tests/enterprise-*/*.go")) != 0
+		return len(rctx.DiffFiles.FilterByDirGlob("tests/enterprise-*/*.go")) != 0
 	}),
 	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
 
-		for _, file := range rctx.DiffFiles.FilterByDirString("tests/enterprise-*/*.go") {
+		for _, file := range rctx.DiffFiles.FilterByDirGlob("tests/enterprise-*/*.go") {
 
 			rctx.FocusFiles = dedupeAppendFiles(rctx.FocusFiles, file.Name)
 
@@ -275,19 +275,19 @@ func CheckNoFilesChanged(rctx *rulesengine.RuleCtx) bool {
 
 func CheckPkgFilesChanged(rctx *rulesengine.RuleCtx) bool {
 
-	return len(rctx.DiffFiles.FilterByDirString("pkg/*")) != 0
+	return len(rctx.DiffFiles.FilterByDirString("pkg/")) != 0
 
 }
 
 func CheckMageFilesChanged(rctx *rulesengine.RuleCtx) bool {
 
-	return len(rctx.DiffFiles.FilterByDirString("magefiles/*")) != 0
+	return len(rctx.DiffFiles.FilterByDirString("magefiles/")) != 0
 
 }
 
 func CheckCmdFilesChanged(rctx *rulesengine.RuleCtx) bool {
 
-	return len(rctx.DiffFiles.FilterByDirString("cmd/*")) != 0
+	return len(rctx.DiffFiles.FilterByDirString("cmd/")) != 0
 
 }
 

--- a/magefiles/rulesengine/repos/e2e_repo.go
+++ b/magefiles/rulesengine/repos/e2e_repo.go
@@ -1,6 +1,7 @@
 package repos
 
 import (
+	"path/filepath"
 	"strings"
 
 	"github.com/konflux-ci/e2e-tests/magefiles/rulesengine"
@@ -16,81 +17,295 @@ var NonTestFilesRule = rulesengine.Rule{Name: "E2E Default PR Test Exectuion",
 
 var TestFilesOnlyRule = rulesengine.Rule{Name: "E2E PR Test File Diff Execution",
 	Description: "Runs specific tests when test files are the only changes in the e2e-repo PR",
-	Condition: rulesengine.None{rulesengine.ConditionFunc(CheckPkgFilesChanged),
+	Condition: rulesengine.All{rulesengine.None{rulesengine.ConditionFunc(CheckPkgFilesChanged),
 		rulesengine.ConditionFunc(CheckMageFilesChanged),
 		rulesengine.ConditionFunc(CheckCmdFilesChanged),
-		rulesengine.ConditionFunc(CheckNoFilesChanged)},
-	Actions: []rulesengine.Action{rulesengine.ActionFunc(ExecuteFocusedFileAction)}}
+		rulesengine.ConditionFunc(CheckNoFilesChanged)}, rulesengine.Any{
+		&BuildTestFileChangeOnlyRule,
+		&BuildTemplateScenarioFileChangeRule,
+		&BuildNonTestFileChangeRule,
+		&KonfluxDemoConfigsFileOnlyChangeRule,
+		&KonfluxDemoTestFileChangedRule,
+		&ReleaseTestHelperFilesChangeOnlyRule,
+		&ReleaseTestTestFilesChangeRule,
+		&ReleaseConstFileChangeBuildTestRule,
+		&IntegrationTestsConstFileChangeRule,
+		&IntegrationTestsFileChangeRule,
+		&EcTestFileChangeRule}},
+	Actions: []rulesengine.Action{rulesengine.ActionFunc(ExecuteTestAction)}}
+
+var BuildTestFileChangeOnlyRule = rulesengine.Rule{Name: "E2E PR Build Test File Change Only Rule",
+	Description: "Map build tests files when build test file are only changed in the e2e-repo PR",
+	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) bool {
+
+		return len(rctx.DiffFiles.FilterByDirString("tests/build/build_templates_scenario.go")) == 0 &&
+			len(rctx.DiffFiles.FilterByDirString("tests/build/const.go")) == 0 &&
+			len(rctx.DiffFiles.FilterByDirString("tests/build/source_build.go")) == 0
+	}),
+	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
+
+		for _, file := range rctx.DiffFiles.FilterByDirString("tests/build/*.go") {
+
+			rctx.FocusFiles = dedupeAppendFiles(rctx.FocusFiles, file.Name)
+
+		}
+		return nil
+
+	})}}
+
+var BuildTemplateScenarioFileChangeRule = rulesengine.Rule{Name: "E2E PR Build Template Scenario File Changed Rule",
+	Description: "Map build tests files when build template scenario file is changed in the e2e-repo PR",
+	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) bool {
+
+		return len(rctx.DiffFiles.FilterByDirString("tests/build/build_templates_scenario.go")) != 0
+	}),
+	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
+
+		foundInDiff := false
+		for _, file := range rctx.DiffFiles.FilterByDirString("tests/build/build_templates.go") {
+
+			rctx.FocusFiles = dedupeAppendFiles(rctx.FocusFiles, file.Name)
+			foundInDiff = true
+
+		}
+
+		if !foundInDiff {
+
+			rctx.FocusFiles = dedupeAppendFiles(rctx.FocusFiles, "tests/build/build_templates.go")
+
+		}
+
+		return nil
+
+	})}}
+
+var BuildNonTestFileChangeRule = rulesengine.Rule{Name: "E2E PR Build Test Helper Files Change Rule",
+	Description: "Map build tests files when const.go or source_build.go file is changed in the e2e-repo PR",
+	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) bool {
+
+		return len(rctx.DiffFiles.FilterByDirString("tests/build/const.go")) != 0 || len(rctx.DiffFiles.FilterByDirString("tests/build/source_build.go")) != 0
+	}),
+	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
+
+		for _, file := range rctx.DiffFiles.FilterByDirString("tests/build/*.go") {
+
+			if strings.Contains(file.Name, "source_build.go") || strings.Contains(file.Name, "const.go") || strings.Contains(file.Name, "scenarios.go") {
+
+				continue
+
+			}
+			rctx.FocusFiles = dedupeAppendFiles(rctx.FocusFiles, file.Name)
+
+		}
+
+		return nil
+
+	})}}
+
+var ReleaseTestTestFilesChangeRule = rulesengine.Rule{Name: "E2E PR Release Test File Change Rule",
+	Description: "Map release test files if they are changed in the e2e-repo PR",
+	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) bool {
+
+		return len(rctx.DiffFiles.FilterByDirString("tests/release/*/*.go")) != 0
+	}),
+	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
+
+		for _, file := range rctx.DiffFiles.FilterByDirString("tests/release/*/*.go") {
+
+			rctx.FocusFiles = dedupeAppendFiles(rctx.FocusFiles, file.Name)
+
+		}
+
+		return nil
+
+	})}}
+
+var ReleaseTestHelperFilesChangeOnlyRule = rulesengine.Rule{Name: "E2E PR Release Test Helper File CHange Rule",
+	Description: "Map release tests files when only the release helper go files in root of release directory are changed in the e2e-repo PR",
+	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) bool {
+
+		return len(rctx.DiffFiles.FilterByDirString("tests/release/*.go")) != 0 && len(rctx.DiffFiles.FilterByDirString("tests/release/*/*.go")) == 0
+	}),
+	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
+
+		matched, err := filepath.Glob("tests/release/*/*.go")
+		if err != nil {
+
+			return err
+		}
+		for _, matched := range matched {
+
+			rctx.FocusFiles = dedupeAppendFiles(rctx.FocusFiles, matched)
+		}
+
+		return nil
+
+	})}}
+
+var ReleaseConstFileChangeBuildTestRule = rulesengine.Rule{Name: "E2E PR Release Test Const File Dependency Change Rule",
+	Description: "Map build tests files when release const.go file is changed in the e2e-repo PR",
+	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) bool {
+
+		return len(rctx.DiffFiles.FilterByDirString("tests/release/const.go")) != 0
+	}),
+	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
+
+		rctx.FocusFiles = dedupeAppendFiles(rctx.FocusFiles, "tests/build/build.go")
+
+		return nil
+
+	})}}
+
+var KonfluxDemoTestFileChangedRule = rulesengine.Rule{Name: "E2E PR Konflux-Demo Test File Diff Map",
+	Description: "Map demo tests files when konflux-demo test files are changed in the e2e-repo PR",
+	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) bool {
+
+		return len(rctx.DiffFiles.FilterByDirString("tests/*-demo/*.go")) != 0
+	}),
+	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
+
+		for _, file := range rctx.DiffFiles.FilterByDirString("tests/*-demo/*-demo.go") {
+
+			rctx.FocusFiles = dedupeAppendFiles(rctx.FocusFiles, file.Name)
+
+		}
+		return nil
+
+	})}}
+
+var KonfluxDemoConfigsFileOnlyChangeRule = rulesengine.Rule{Name: "E2E PR Konflux-Demo Config File Change Only Rule",
+	Description: "Map demo tests files when konflux-demo config.go|type.go test files are changed in the e2e-repo PR",
+	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) bool {
+
+		return len(rctx.DiffFiles.FilterByDirString("tests/*-demo/*.go")) == 0 && len(rctx.DiffFiles.FilterByDirString("tests/*-demo/*/*")) != 0
+	}),
+	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
+
+		matched, err := filepath.Glob("tests/*-demo/*-demo.go")
+		if err != nil {
+
+			return err
+
+		}
+		for _, matched := range matched {
+
+			rctx.FocusFiles = dedupeAppendFiles(rctx.FocusFiles, matched)
+		}
+		return nil
+
+	})}}
+
+var IntegrationTestsFileChangeRule = rulesengine.Rule{Name: "E2E PR Integration TestFile Change Rule",
+	Description: "Map integration tests files when integration test files are changed in the e2e-repo PR",
+	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) bool {
+
+		return len(rctx.DiffFiles.FilterByDirString("tests/integration-*/*.go")) != 0
+	}),
+	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
+
+		for _, file := range rctx.DiffFiles.FilterByDirString("tests/integration-*/*.go") {
+
+			if strings.Contains(file.Name, "const.go") {
+
+				continue
+
+			}
+
+			rctx.FocusFiles = dedupeAppendFiles(rctx.FocusFiles, file.Name)
+
+		}
+
+		return nil
+
+	})}}
+
+var IntegrationTestsConstFileChangeRule = rulesengine.Rule{Name: "E2E PR Integration TestFile Change Rule",
+	Description: "Map integration tests files when integration const files are changed in the e2e-repo PR",
+	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) bool {
+
+		return len(rctx.DiffFiles.FilterByDirString("tests/integration-*/const.go")) != 0 && len(rctx.DiffFiles.FilterByDirString("tests/integration-*/*.go")) == 0
+	}),
+	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
+
+		matched, err := filepath.Glob("tests/integration-*/*.go")
+		if err != nil {
+
+			return err
+
+		}
+		for _, matched := range matched {
+
+			if strings.Contains(matched, "const.go") {
+
+				continue
+
+			}
+
+			rctx.FocusFiles = dedupeAppendFiles(rctx.FocusFiles, matched)
+		}
+
+		return nil
+
+	})}}
+
+var EcTestFileChangeRule = rulesengine.Rule{Name: "E2E PR EC Test File Change Rule",
+	Description: "Map EC tests files when EC test files are changed in the e2e-repo PR",
+	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) bool {
+
+		return len(rctx.DiffFiles.FilterByDirString("tests/enterprise-*/*.go")) != 0
+	}),
+	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
+
+		for _, file := range rctx.DiffFiles.FilterByDirString("tests/enterprise-*/*.go") {
+
+			rctx.FocusFiles = dedupeAppendFiles(rctx.FocusFiles, file.Name)
+
+		}
+
+		return nil
+
+	})}}
 
 var E2ETestRulesCatalog = rulesengine.RuleCatalog{NonTestFilesRule, TestFilesOnlyRule}
 
 func CheckNoFilesChanged(rctx *rulesengine.RuleCtx) bool {
 
-	return len(rctx.DiffFiles) == 0 || len(rctx.DiffFiles.FilterByStatus("D")) == 0
+	return len(rctx.DiffFiles) == 0
 }
 
 func CheckPkgFilesChanged(rctx *rulesengine.RuleCtx) bool {
 
-	for _, file := range rctx.DiffFiles {
-
-		switch {
-		case strings.Contains(file.Name, "pkg/"):
-			return true
-		}
-
-	}
-
-	return false
+	return len(rctx.DiffFiles.FilterByDirString("pkg/*")) != 0
 
 }
 
 func CheckMageFilesChanged(rctx *rulesengine.RuleCtx) bool {
 
-	for _, file := range rctx.DiffFiles {
-
-		switch {
-		case strings.Contains(file.Name, "magefile/"):
-			return true
-		}
-
-	}
-
-	return false
+	return len(rctx.DiffFiles.FilterByDirString("magefiles/*")) != 0
 
 }
 
 func CheckCmdFilesChanged(rctx *rulesengine.RuleCtx) bool {
 
-	for _, file := range rctx.DiffFiles {
-
-		switch {
-
-		case strings.Contains(file.Name, "cmd/"):
-			return true
-		}
-
-	}
-
-	return false
+	return len(rctx.DiffFiles.FilterByDirString("cmd/*")) != 0
 
 }
 
 func ExecuteDefaultTestAction(rctx *rulesengine.RuleCtx) error {
 
 	rctx.LabelFilter = "!upgrade-create && !upgrade-verify && !upgrade-cleanup && !release-pipelines"
-
 	return ExecuteTestAction(rctx)
 
 }
 
-func ExecuteFocusedFileAction(rctx *rulesengine.RuleCtx) error {
+func dedupeAppendFiles(files []string, file string) []string {
 
-	for _, file := range rctx.DiffFiles.FilterByStatus("D") {
+	for _, f := range files {
 
-		rctx.FocusFiles = append(rctx.FocusFiles, file.Name)
-
+		if f == file {
+			return files
+		}
 	}
 
-	return ExecuteTestAction(rctx)
-
+	return append(files, file)
 }

--- a/magefiles/rulesengine/types.go
+++ b/magefiles/rulesengine/types.go
@@ -217,14 +217,19 @@ type Any []Conditional
 
 func (a Any) Check(rctx *RuleCtx) bool {
 
+	// Initial logic was to pass on the first
+	// evail to true but that might not be the
+	// case. So not eval all and as long as any
+	// eval true then filter is satisfied
+	isAny := false
 	for _, c := range a {
 
 		if c.Check(rctx) {
-			return true
+			isAny = true
 		}
 	}
 
-	return false
+	return isAny
 }
 
 type All []Conditional
@@ -304,7 +309,7 @@ func (cf ConditionFunc) Check(rctx *RuleCtx) bool {
 type Rule struct {
 	Name        string
 	Description string
-	Condition    Conditional
+	Condition   Conditional
 	Actions     []Action
 }
 
@@ -379,15 +384,12 @@ func (cfs *Files) FilterByDirString(filter string) Files {
 
 	for _, file := range *cfs {
 
-		if !strings.Contains(file.Name, filter) {
+		if matched, _ := filepath.Match(filter, file.Name); !matched {
+
 			continue
 		}
 
 		subfiles = append(subfiles, file)
-
-	}
-
-	return subfiles
 
 }
 

--- a/magefiles/rulesengine/types.go
+++ b/magefiles/rulesengine/types.go
@@ -385,6 +385,23 @@ func (cfs *Files) FilterByDirString(filter string) Files {
 
 	for _, file := range *cfs {
 
+		if !strings.Contains(file.Name, filter) {
+			continue
+		}
+
+		subfiles = append(subfiles, file)
+	}
+
+	return subfiles
+
+}
+
+func (cfs *Files) FilterByDirGlob(filter string) Files {
+
+	var subfiles Files
+
+	for _, file := range *cfs {
+
 		if matched, _ := filepath.Match(filter, file.Name); !matched {
 
 			continue

--- a/magefiles/rulesengine/types.go
+++ b/magefiles/rulesengine/types.go
@@ -2,6 +2,7 @@ package rulesengine
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -390,6 +391,9 @@ func (cfs *Files) FilterByDirString(filter string) Files {
 		}
 
 		subfiles = append(subfiles, file)
+	}
+
+	return subfiles
 
 }
 


### PR DESCRIPTION
 * Remove the checks for filtering on "D" status which was causing a bug
 * Changed FilterByDirString implementation to use filepath.match to support glob expression
 * Changed conditional Any implementation to eval all conditionals
 * Added more smaller nuanced rules for specific test directories

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue ticket number and link

## Type of change

- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ X] I have performed a self-review of my code
- [ X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
