### PR TITLE
fix: Fix task exit_code, improve memory and fix deprecated-img

### DIFF
--- a/.tekton/konflux-e2e-tests-pull-request.yaml
+++ b/.tekton/konflux-e2e-tests-pull-request.yaml
@@ -254,8 +254,6 @@ spec:
       params:
       - name: BINARY_IMAGE
         value: $(params.output-image)
-      - name: BASE_IMAGES
-        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
       runAfter:
       - build-container
       taskRef:
@@ -281,8 +279,6 @@ spec:
         workspace: workspace
     - name: deprecated-base-image-check
       params:
-      - name: BASE_IMAGES_DIGESTS
-        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
       - name: IMAGE_URL
         value: $(tasks.build-container.results.IMAGE_URL)
       - name: IMAGE_DIGEST

--- a/.tekton/konflux-e2e-tests-push.yaml
+++ b/.tekton/konflux-e2e-tests-push.yaml
@@ -261,8 +261,6 @@ spec:
       params:
       - name: BINARY_IMAGE
         value: $(params.output-image)
-      - name: BASE_IMAGES
-        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
       runAfter:
       - build-container
       taskRef:
@@ -288,8 +286,6 @@ spec:
         workspace: workspace
     - name: deprecated-base-image-check
       params:
-      - name: BASE_IMAGES_DIGESTS
-        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
       - name: IMAGE_URL
         value: $(tasks.build-container.results.IMAGE_URL)
       - name: IMAGE_DIGEST

--- a/integration-tests/tasks/konflux-e2e-tests-task.yaml
+++ b/integration-tests/tasks/konflux-e2e-tests-task.yaml
@@ -47,11 +47,11 @@ spec:
     - name: e2e-test
       computeResources:
         requests:
-          cpu: "1"
-          memory: "2Gi"
+          cpu: "500m"
+          memory: "1Gi"
         limits:
-          cpu: "1"
-          memory: "4Gi"
+          cpu: "2"
+          memory: "6Gi"
       image: $(params.container-image)
       volumeMounts:
         - name: konflux-secret-volume
@@ -75,6 +75,8 @@ spec:
       script: |
         #!/bin/sh
         function saveArtifacts() {
+          EXIT_CODE=$?
+
           cd /workspace
 
           oras login -u "$ORAS_USERNAME" -p "$ORAS_PASSWORD" quay.io


### PR DESCRIPTION
# Description

1. Fix the exit code in the trap oras.
2. Fix buildah task. See more at: https://github.com/konflux-ci/build-definitions/blob/main/task/buildah/0.2/MIGRATION.md
3. Seems like only 7 processes are running in the e2e tests. Increasing memory..

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
