### PR TITLE
fix(KONFLUX-1054): Setup defaults for ARTIFACT_DIR in max-concurrency load tests

### DIFF
--- a/tests/load-tests/.gitignore
+++ b/tests/load-tests/.gitignore
@@ -4,4 +4,7 @@
 *.csv
 load-tests.json
 load-tests.*.json
+load-test.max-concurrency.json
 output.json
+started
+ended

--- a/tests/load-tests/ci-scripts/max-concurrency/collect-results.sh
+++ b/tests/load-tests/ci-scripts/max-concurrency/collect-results.sh
@@ -9,6 +9,10 @@ source "/usr/local/ci-secrets/redhat-appstudio-load-test/load-test-scenario.${1:
 
 pushd "${2:-.}"
 
+# Setup directories
+ARTIFACT_DIR=${ARTIFACT_DIR:-artifacts}
+mkdir -p ${ARTIFACT_DIR}
+
 output_dir="${OUTPUT_DIR:-./tests/load-tests}"
 
 csv_delim=";"


### PR DESCRIPTION
# Changes

- Setup and create **ARTIFACT_DIR** in **max-concurrency** load test scenario as part result collector script.
- Update *.gitignore* entries for skipping test related artifacts.

## Issue ticket number and link

Found the issue while testing: https://issues.redhat.com/browse/KONFLUX-1054

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested the fix locally on running the max-concurrency tests on Hive OpenShift cluster. 