### PR TITLE
chore: Ussually a task have by default 1h timeout. Increase timeout to 2h

### DIFF
--- a/integration-tests/pipelines/konflux-e2e-tests-pipeline.yaml
+++ b/integration-tests/pipelines/konflux-e2e-tests-pipeline.yaml
@@ -100,6 +100,7 @@
           - name: hcp-config-secret
             value: "$(params.hcp-config-secret)"
       - name: konflux-e2e-tests
+        timeout: 2h
         when:
           - input: "$(tasks.test-metadata.results.test-event-type)"
             operator: in


### PR DESCRIPTION
# Description

Tasks which takes more than 1h fail with timeout and will not be visible in Konflux UI. The message is: Logs are no longer accessible for konflux-e2e-wdvd5-lplsl-konflux-e2e-tests task

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
