### PR TITLE
refactor: remove PAC_GITLAB_* env vars

### DIFF
--- a/integration-tests/scripts/konflux-e2e-runner.sh
+++ b/integration-tests/scripts/konflux-e2e-runner.sh
@@ -59,12 +59,10 @@ export MULTI_PLATFORM_AWS_ACCESS_KEY=$(cat /usr/local/konflux-ci-secrets/multi-p
 export MULTI_PLATFORM_AWS_SECRET_ACCESS_KEY=$(cat /usr/local/konflux-ci-secrets/multi-platform-aws-secret-access-key)
 export MULTI_PLATFORM_AWS_SSH_KEY=$(cat /usr/local/konflux-ci-secrets/multi-platform-aws-ssh-key)
 export MULTI_PLATFORM_IBM_API_KEY=$(cat /usr/local/konflux-ci-secrets/multi-platform-ibm-api-key)
-export PAC_GITLAB_TOKEN=$(cat /usr/local/konflux-ci-secrets/pac-gitlab-token)
-export PAC_GITLAB_URL=$(cat /usr/local/konflux-ci-secrets/pac-gitlab-url)
-export PAC_PROJECT_ID=$(cat /usr/local/konflux-ci-secrets/pac-project-id)
 export ORAS_USERNAME=$(cat /usr/local/konflux-ci-secrets/oras-username)
 export ORAS_PASSWORD=$(cat /usr/local/konflux-ci-secrets/oras-password)
 export DOCKER_IO_AUTH=$(cat /usr/local/konflux-ci-secrets/docker_io)
+export GITLAB_BOT_TOKEN=$(cat /usr/local/konflux-ci-secrets/gitlab-bot-token)
 
 export ENABLE_SCHEDULING_ON_MASTER_NODES=false
 

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -924,15 +924,15 @@ func CleanGitHubWebHooks() error {
 
 // Remove all webhooks older than 1 day from GitLab repo.
 func CleanGitLabWebHooks() error {
-	gcToken := utils.GetEnv(constants.GITLAB_TOKEN_ENV, "")
+	gcToken := utils.GetEnv(constants.GITLAB_BOT_TOKEN_ENV, "")
 	if gcToken == "" {
 		return fmt.Errorf("empty PAC_GITLAB_TOKEN env")
 	}
-	projectID := utils.GetEnv(constants.GITLAB_PROJECT_ID, "")
+	projectID := utils.GetEnv(constants.GITLAB_PROJECT_ID_ENV, "")
 	if projectID == "" {
 		return fmt.Errorf("empty PAC_PROJECT_ID env. Please provide a valid GitLab Project ID")
 	}
-	gitlabURL := utils.GetEnv(constants.GITLAB_URL_ENV, "https://gitlab.com/api/v4")
+	gitlabURL := utils.GetEnv(constants.GITLAB_API_URL_ENV, constants.DefaultGitLabAPIURL)
 	gc, err := gitlab.NewGitlabClient(gcToken, gitlabURL)
 	if err != nil {
 		return err

--- a/pkg/clients/common/controller.go
+++ b/pkg/clients/common/controller.go
@@ -30,7 +30,7 @@ func NewSuiteController(kubeC *kubeCl.CustomClient) (*SuiteController, error) {
 		return nil, err
 	}
 
-	gl, err := gitlab.NewGitlabClient(utils.GetEnv(constants.GITLAB_TOKEN_ENV, ""), utils.GetEnv(constants.GITLAB_URL_ENV, ""))
+	gl, err := gitlab.NewGitlabClient(utils.GetEnv(constants.GITLAB_BOT_TOKEN_ENV, ""), utils.GetEnv(constants.GITLAB_API_URL_ENV, constants.DefaultGitLabAPIURL))
 	if err != nil {
 		return nil, fmt.Errorf("failed to authenticate with GitLab: %w", err)
 	}

--- a/pkg/clients/gitlab/git.go
+++ b/pkg/clients/gitlab/git.go
@@ -6,10 +6,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/konflux-ci/e2e-tests/pkg/constants"
-	"github.com/konflux-ci/e2e-tests/pkg/utils"
 	. "github.com/onsi/gomega"
-	gitlab "github.com/xanzy/go-gitlab"
+	"github.com/xanzy/go-gitlab"
 )
 
 // CreateBranch creates a new branch in a GitLab project with the given projectID and newBranchName
@@ -152,14 +150,14 @@ func (gc *GitlabClient) DeleteWebhooks(projectID, clusterAppDomain string) error
 	return nil
 }
 
-func (gc *GitlabClient) CreateFile(pathToFile, fileContent, branchName string) (*gitlab.FileInfo, error) {
+func (gc *GitlabClient) CreateFile(projectId, pathToFile, fileContent, branchName string) (*gitlab.FileInfo, error) {
 	opts := &gitlab.CreateFileOptions{
-		Branch:   gitlab.Ptr(branchName),
-		Content:  &fileContent,
+		Branch:        gitlab.Ptr(branchName),
+		Content:       &fileContent,
 		CommitMessage: gitlab.Ptr("e2e test commit message"),
 	}
 
-	file, resp, err := gc.client.RepositoryFiles.CreateFile(utils.GetEnv(constants.GITLAB_PROJECT_ID, ""), pathToFile, opts)
+	file, resp, err := gc.client.RepositoryFiles.CreateFile(projectId, pathToFile, opts)
 	if resp.StatusCode != 201 || err != nil {
 		return nil, fmt.Errorf("error when creating file contents: response (%v) and error: %v", resp, err)
 	}

--- a/pkg/clients/has/components.go
+++ b/pkg/clients/has/components.go
@@ -408,7 +408,8 @@ func (h *HasController) RetriggerComponentPipelineRun(component *appservice.Comp
 		}
 
 		if gitProvider == "gitlab" {
-			_, err := h.GitLab.CreateFile(util.GenerateRandomString(5), "test", branchName)
+			projectID := utils.GetEnv(constants.GITLAB_PROJECT_ID_ENV, "")
+			_, err := h.GitLab.CreateFile(projectID, util.GenerateRandomString(5), "test", branchName)
 			if err != nil {
 				return "", fmt.Errorf("failed to retrigger PipelineRun %s in %s namespace: %+v", pr.GetName(), pr.GetNamespace(), err)
 			}

--- a/pkg/clients/has/controller.go
+++ b/pkg/clients/has/controller.go
@@ -29,8 +29,8 @@ func NewSuiteController(kube *kubeCl.CustomClient) (*HasController, error) {
 		return nil, err
 	}
 
-	gl, err := gitlab.NewGitlabClient(utils.GetEnv(constants.GITLAB_TOKEN_ENV, ""),
-		utils.GetEnv(constants.GITLAB_URL_ENV, "https://gitlab.com/api/v4"))
+	gl, err := gitlab.NewGitlabClient(utils.GetEnv(constants.GITLAB_BOT_TOKEN_ENV, ""),
+		utils.GetEnv(constants.GITLAB_API_URL_ENV, constants.DefaultGitLabAPIURL))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -109,14 +109,17 @@ const (
 	// If set to "true", e2e-tests installer will configure master/control plane nodes as schedulable
 	ENABLE_SCHEDULING_ON_MASTER_NODES_ENV = "ENABLE_SCHEDULING_ON_MASTER_NODES"
 
-	// A gitlab token is required to run tests against gitlab.com. The token need to have permissions to the given github organization.
-	GITLAB_TOKEN_ENV string = "PAC_GITLAB_TOKEN" // #nosec
+	// A gitlab bot token is required to run tests against gitlab.com. The token need to have permissions to the given github organization.
+	GITLAB_BOT_TOKEN_ENV string = "GITLAB_BOT_TOKEN" // #nosec
 
-	// The gitlab URL used to run integration reporting e2e tests against
-	GITLAB_URL_ENV string = "PAC_GITLAB_URL" // #nosec
+	// The GitLab org which owns the test repositories
+	GITLAB_QE_ORG_ENV string = "GITLAB_QE_ORG"
 
-	// For PaC Gitlab tests required project ID
-	GITLAB_PROJECT_ID string = "PAC_PROJECT_ID"
+	// The gitlab API URL used to run e2e tests against
+	GITLAB_API_URL_ENV string = "GITLAB_API_URL" // #nosec
+
+	// GitLab Project ID used for helper functions in magefiles
+	GITLAB_PROJECT_ID_ENV string = "GITLAB_PROJECT_ID"
 
 	// Test namespace's required labels
 	ArgoCDLabelKey   string = "argocd.argoproj.io/managed-by"
@@ -138,8 +141,11 @@ const (
 
 	DefaultQuayOrg = "redhat-appstudio-qe"
 
+	DefaultGitLabAPIURL = "https://gitlab.com/api/v4"
+	DefaultGitLabQEOrg  = "konflux-qe"
+
 	RegistryAuthSecretName = "redhat-appstudio-registry-pull-secret"
-	ComponentSecretName = "comp-secret"
+	ComponentSecretName    = "comp-secret"
 
 	QuayRepositorySecretName      = "quay-repository"
 	QuayRepositorySecretNamespace = "e2e-secrets"

--- a/tests/build/const.go
+++ b/tests/build/const.go
@@ -48,6 +48,7 @@ const (
 	componentDependenciesChildGitRevision    = "56c13d17b1a8f801f2c41091e6f4e62cf16ee5f2"
 
 	githubUrlFormat = "https://github.com/%s/%s"
+	gitlabUrlFormat = "https://gitlab.com/%s"
 
 	//Logging related
 	buildStatusAnnotationValueLoggingFormat = "build status annotation value: %s\n"
@@ -58,15 +59,15 @@ const (
 
 var (
 	additionalTags                       = []string{"test-tag1", "test-tag2"}
-	pythonComponentGitSourceURL          = fmt.Sprintf(githubUrlFormat, gihubOrg, pythonComponentRepoName)
 	componentUrls                        = strings.Split(utils.GetEnv(COMPONENT_REPO_URLS_ENV, pythonComponentGitSourceURL), ",") //multiple urls
 	componentNames                       []string
 	gihubOrg                             = utils.GetEnv(constants.GITHUB_E2E_ORGANIZATION_ENV, "redhat-appstudio-qe")
 	helloWorldComponentGitSourceURL      = fmt.Sprintf(githubUrlFormat, gihubOrg, helloWorldComponentGitSourceRepoName)
-	helloWorldComponentGitSourceCloneURL = fmt.Sprintf(githubUrlFormat, gihubOrg, helloWorldComponentGitSourceCloneRepoName)
 	annotationsTestGitSourceURL          = fmt.Sprintf(githubUrlFormat, gihubOrg, annotationsTestGitSourceRepoName)
 	multiComponentGitSourceURL           = fmt.Sprintf(githubUrlFormat, gihubOrg, multiComponentGitSourceRepoName)
 	multiComponentContextDirs            = []string{"go-component", "python-component"}
+	pythonComponentGitSourceURL          = fmt.Sprintf(githubUrlFormat, gihubOrg, pythonComponentRepoName)
+	helloWorldComponentGitSourceCloneURL = fmt.Sprintf(githubUrlFormat, gihubOrg, helloWorldComponentGitSourceCloneRepoName)
 
 	secretLookupComponentOneGitSourceURL = fmt.Sprintf(githubUrlFormat, noAppOrgName, secretLookupGitSourceRepoOneName)
 	secretLookupComponentTwoGitSourceURL = fmt.Sprintf(githubUrlFormat, noAppOrgName, secretLookupGitSourceRepoTwoName)

--- a/tests/integration-service/const.go
+++ b/tests/integration-service/const.go
@@ -40,5 +40,7 @@ const (
 
 var (
 	componentGitSourceURLForStatusReporting       = fmt.Sprintf("https://github.com/%s/%s", utils.GetEnv(constants.GITHUB_E2E_ORGANIZATION_ENV, "redhat-appstudio-qe"), componentRepoNameForStatusReporting)
-	gitlabComponentGitSourceURLForStatusReporting = fmt.Sprintf("https://gitlab.com/konflux-qe/%s", componentRepoNameForStatusReporting)
+	gitlabOrg                                     = utils.GetEnv(constants.GITLAB_QE_ORG_ENV, constants.DefaultGitLabQEOrg)
+	gitlabProjectIDForStatusReporting             = fmt.Sprintf("%s/%s", gitlabOrg, componentRepoNameForStatusReporting)
+	gitlabComponentGitSourceURLForStatusReporting = fmt.Sprintf("https://gitlab.com/%s/%s", gitlabOrg, componentRepoNameForStatusReporting)
 )

--- a/tests/integration-service/gitlab-integration-reporting.go
+++ b/tests/integration-service/gitlab-integration-reporting.go
@@ -67,11 +67,10 @@ var _ = framework.IntegrationServiceSuiteDescribe("Gitlab Status Reporting of In
 			pacBranchName = constants.PaCPullRequestBranchPrefix + componentName
 			componentBaseBranchName = fmt.Sprintf("base-gitlab-%s", util.GenerateRandomString(6))
 
-			projectID = utils.GetEnv(constants.GITLAB_PROJECT_ID, "")
-			Expect(projectID).ShouldNot(BeEmpty())
+			projectID = gitlabProjectIDForStatusReporting
 
-			gitlabToken = utils.GetEnv(constants.GITLAB_TOKEN_ENV, "")
-			Expect(gitlabToken).ShouldNot(BeEmpty())
+			gitlabToken = utils.GetEnv(constants.GITLAB_BOT_TOKEN_ENV, "")
+			Expect(gitlabToken).ShouldNot(BeEmpty(), fmt.Sprintf("'%s' env var is not set", constants.GITLAB_BOT_TOKEN_ENV))
 
 			err = f.AsKubeAdmin.CommonController.Gitlab.CreateGitlabNewBranch(projectID, componentBaseBranchName, componentRevision, componentDefaultBranch)
 			Expect(err).ShouldNot(HaveOccurred())


### PR DESCRIPTION
~~Depending on https://github.com/openshift/release/pull/55025 getting merged first~~ merged

# Description
`PAC_GITLAB_URL` and `PAC_GITLAB_ID` will be getting removed from Hashicorp Vault
- Introduce new env var `GITLAB_BOT_TOKEN` (already in Hashicorp Vault)
- Change logic of getting GitLab project id since more than one repo will now be used
- Default values for API URL and QE org
- Rename PAC_GITLAB_* env vars

## Issue ticket number and link
[STONEBLD-2388](https://issues.redhat.com/browse/STONEBLD-2388)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
