### PR TITLE
feat(KONFLUX-3187): adding test selection logic for repo infra-deploy…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -126,7 +126,7 @@ require (
 	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/blendle/zapdriver v1.3.1 // indirect
-	github.com/bmatcuk/doublestar/v4 v4.6.0 // indirect
+	github.com/bmatcuk/doublestar/v4 v4.6.1 // indirect
 	github.com/bombsimon/logrusr/v2 v2.0.1 // indirect
 	github.com/bradleyfalzon/ghinstallation/v2 v2.10.0 // indirect
 	github.com/census-instrumentation/opencensus-proto v0.4.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -884,8 +884,8 @@ github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/blendle/zapdriver v1.3.1 h1:C3dydBOWYRiOk+B8X9IVZ5IOe+7cl+tGOexN4QqHfpE=
 github.com/blendle/zapdriver v1.3.1/go.mod h1:mdXfREi6u5MArG4j9fewC+FGnXaBR+T4Ox4J2u4eHCc=
-github.com/bmatcuk/doublestar/v4 v4.6.0 h1:HTuxyug8GyFbRkrffIpzNCSK4luc0TY3wzXvzIZhEXc=
-github.com/bmatcuk/doublestar/v4 v4.6.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
+github.com/bmatcuk/doublestar/v4 v4.6.1 h1:FH9SifrbvJhnlQpztAx++wlkk70QBf0iBWDwNy7PA4I=
+github.com/bmatcuk/doublestar/v4 v4.6.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/bombsimon/logrusr/v2 v2.0.1 h1:1VgxVNQMCvjirZIYaT9JYn6sAVGVEcNtRE0y4mvaOAM=
 github.com/bombsimon/logrusr/v2 v2.0.1/go.mod h1:ByVAX+vHdLGAfdroiMg6q0zgq2FODY2lc5YJvzmOJio=
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=

--- a/magefiles/rulesengine/engine/engine.go
+++ b/magefiles/rulesengine/engine/engine.go
@@ -8,7 +8,7 @@ import (
 var MageEngine = rulesengine.RuleEngine{
 	"tests": {
 		"e2e-repo":          repos.E2ETestRulesCatalog,
-		"infra-deployments": repos.InfraDeploymentsTestRulesCatalog,
+		"infra-deployments": repos.InfraDeploymentsRulesCatalog,
 		"release-catalog":   repos.ReleaseServiceCatalogTestRulesCatalog,
 	},
 	"demo": {

--- a/magefiles/rulesengine/repos/infra_deployments.go
+++ b/magefiles/rulesengine/repos/infra_deployments.go
@@ -1,17 +1,166 @@
 package repos
 
-import "github.com/konflux-ci/e2e-tests/magefiles/rulesengine"
+import (
+	"fmt"
+	"strings"
 
-// Example rule for infra-deployments using anonymous functions embedded in the rule
-var InfraDeploymentsTestRulesCatalog = rulesengine.RuleCatalog{
-	rulesengine.Rule{Name: "Infra Deployments Default Test Execution",
-		Description: "Run the default test suites which include the demo and components suites.",
-		Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) bool {
+	"github.com/konflux-ci/e2e-tests/magefiles/rulesengine"
+)
 
-			return rctx.RepoName == "infra-deployments"
-		}),
-		Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
-			rctx.LabelFilter = "e2e-demo,konflux-demo,spi-suite,remote-secret,integration-service,ec,build-templates,multi-platform"
-			return ExecuteTestAction(rctx)
-		})}},
+// Default Rule of repo infra-deployments running konflux-demo suite.
+var InfraDeploymentsDefaultRule = rulesengine.Rule{Name: "Infra Deployments Default Test Execution",
+	Description: "Run the Konflux-demo suite tests when an Infra-deployments PR includes changes to files outside of the specified components.",
+	Condition: rulesengine.None{
+		&InfraDeploymentsIntegrationComponentChangeRule,
+		&InfraDeploymentsImageControllerComponentChangeRule,
+		&InfraDeploymentsMultiPlatformComponentChangeRule,
+		&InfraDeploymentsBuildTemplatesComponentChangeRule,
+		&InfraDeploymentsBuildServiceComponentChangeRule,
+		&InfraDeploymentsReleaseServiceComponentChangeRule,
+		&InfraDeploymentsEnterpriseControllerComponentChangeRule,
+		&InfraDeploymentsJVMComponentChangeRule,
+		rulesengine.ConditionFunc(CheckNoFilesChanged)},
+
+	Actions: []rulesengine.Action{rulesengine.ActionFunc(ExecuteInfraDeploymentsDefaultTestAction)}}
+
+// ExecuteInfraDeploymentsDefaultTestAction excutes all the e2e-tests and component suites
+func ExecuteInfraDeploymentsDefaultTestAction(rctx *rulesengine.RuleCtx) error {
+	rctx.LabelFilter = "konflux"
+	return ExecuteTestAction(rctx)
+}
+
+// InfraDeploymentsComponentsRule defines rules of test suites running of each changed component
+var InfraDeploymentsComponentsRule = rulesengine.Rule{Name: "Infra-deployments PR Components File Diff Execution",
+	Description: "Runs specific tests of changed component by infra-deployments PR.",
+	Condition: rulesengine.Any{
+		&InfraDeploymentsIntegrationComponentChangeRule,
+		&InfraDeploymentsImageControllerComponentChangeRule,
+		&InfraDeploymentsMultiPlatformComponentChangeRule,
+		&InfraDeploymentsBuildTemplatesComponentChangeRule,
+		&InfraDeploymentsBuildServiceComponentChangeRule,
+		&InfraDeploymentsReleaseServiceComponentChangeRule,
+		&InfraDeploymentsEnterpriseControllerComponentChangeRule,
+		&InfraDeploymentsBuildServiceTemplatesComponentChangeRule,
+		&InfraDeploymentsJVMComponentChangeRule},
+	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
+		// Adding "konflux" to the label filter when component is updated
+		AddLabelToLabelFilter(rctx, "konflux")
+		return nil
+
+	}),
+		rulesengine.ActionFunc(ExecuteTestAction)}}
+
+var InfraDeploymentsIntegrationComponentChangeRule = rulesengine.Rule{Name: "Infra-deployments PR Integration component File Change Rule",
+	Description: "Map Integration tests files when Integration component files are changed in the infra-deployments PR",
+	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) bool {
+
+		return len(rctx.DiffFiles.FilterByDirGlob("components/integration/**/*")) != 0
+
+	}),
+	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
+		AddLabelToLabelFilter(rctx, "integration-service")
+		return nil
+	})}}
+
+var InfraDeploymentsEnterpriseControllerComponentChangeRule = rulesengine.Rule{Name: "Infra-deployments PR Enterprise Controller component File Change Rule",
+	Description: "Map Enterprise Controller tests files when EC component files are changed in the infra-deployments PR",
+	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) bool {
+
+		return len(rctx.DiffFiles.FilterByDirGlob("components/enterprise-contract/**/*")) != 0
+	}),
+	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
+		AddLabelToLabelFilter(rctx, "ec")
+		return nil
+	})}}
+
+var InfraDeploymentsJVMComponentChangeRule = rulesengine.Rule{Name: "Infra-deployments PR Jvm-build-service component File Change Rule",
+	Description: "Map jvm-build-service tests files when Jvm-build-service component files are changed in the infra-deployments PR",
+	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) bool {
+
+		return len(rctx.DiffFiles.FilterByDirGlob("components/jvm-build-service/**/*")) != 0
+	}),
+	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
+		AddLabelToLabelFilter(rctx, "jvm-build-service")
+		return nil
+	})}}
+
+var InfraDeploymentsImageControllerComponentChangeRule = rulesengine.Rule{Name: "Infra-deployments PR Image Controller component File Change Rule",
+	Description: "Map image-controller tests files when Image Controller component files are changed in the infra-deployments PR",
+	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) bool {
+
+		return len(rctx.DiffFiles.FilterByDirGlob("components/image-controller/**/*")) != 0
+	}),
+	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
+		AddLabelToLabelFilter(rctx, "image-controller")
+		return nil
+	})}}
+
+var InfraDeploymentsMultiPlatformComponentChangeRule = rulesengine.Rule{Name: "Infra-deployments PR Multi Controller component File Change Rule",
+	Description: "Map multi platform tests files when Multi Controller component files are changed in the infra-deployments PR",
+	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) bool {
+
+		return len(rctx.DiffFiles.FilterByDirGlob("components/multi-platform-controller/**/*")) != 0
+	}),
+	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
+		AddLabelToLabelFilter(rctx, "multi-platform")
+		return nil
+	})}}
+
+var InfraDeploymentsBuildTemplatesComponentChangeRule = rulesengine.Rule{Name: "Infra-deployments PR Build-templates component File Change Rule",
+	Description: "Map build-templates tests files when Build-templates component files are changed in the infra-deployments PR",
+	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) bool {
+
+		return len(rctx.DiffFiles.FilterByDirGlob("components/build-service/base/build-pipeline-config/*")) != 0
+	}),
+	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
+		AddLabelToLabelFilter(rctx, "build-templates")
+		return nil
+	})}}
+
+var InfraDeploymentsBuildServiceComponentChangeRule = rulesengine.Rule{Name: "Infra-deployments PR Build service component File Change Rule",
+	Description: "Map build service tests files when Build service component files are changed in the infra-deployments PR",
+	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) bool {
+
+		return len(rctx.DiffFiles.FilterByDirGlob("components/build-service/**/*")) != 0 &&
+			len(rctx.DiffFiles.FilterByDirGlob("components/build-service/base/build-pipeline-config/*")) == 0
+	}),
+	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
+		AddLabelToLabelFilter(rctx, "build-service")
+		return nil
+	})}}
+
+var InfraDeploymentsBuildServiceTemplatesComponentChangeRule = rulesengine.Rule{Name: "Infra-deployments PR Build service component and templates File Change Rule",
+	Description: "Map build service tests files when Build service component and templates files are changed in the infra-deployments PR",
+	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) bool {
+
+		return len(rctx.DiffFiles.FilterByDirGlob("components/build-service/**/*")) != 0 &&
+			len(rctx.DiffFiles.FilterByDirGlob("components/build-service/base/build-pipeline-config/*")) != 0
+	}),
+	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
+		AddLabelToLabelFilter(rctx, "build-service")
+		return nil
+	})}}
+
+var InfraDeploymentsReleaseServiceComponentChangeRule = rulesengine.Rule{Name: "Infra-deployments PR Release service component File Change Rule",
+	Description: "Map release service tests files when Release service component files are changed in the infra-deployments PR",
+	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) bool {
+
+		return len(rctx.DiffFiles.FilterByDirGlob("components/release/**/*")) != 0
+	}),
+	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
+		AddLabelToLabelFilter(rctx, "release-service")
+		return nil
+	})}}
+
+var InfraDeploymentsRulesCatalog = rulesengine.RuleCatalog{InfraDeploymentsDefaultRule, InfraDeploymentsComponentsRule}
+
+// AddLabelToLabelFilter ensures the given label is added to the LabelFilter of rctx
+func AddLabelToLabelFilter(rctx *rulesengine.RuleCtx, label string) {
+	if !strings.Contains(rctx.LabelFilter, label) {
+		if rctx.LabelFilter == "" {
+			rctx.LabelFilter = label
+		} else {
+			rctx.LabelFilter = fmt.Sprintf("%s,%s", rctx.LabelFilter, label)
+		}
+	}
 }

--- a/magefiles/rulesengine/types.go
+++ b/magefiles/rulesengine/types.go
@@ -2,10 +2,10 @@ package rulesengine
 
 import (
 	"fmt"
-	"path/filepath"
 	"strings"
 	"time"
 
+	"github.com/bmatcuk/doublestar/v4"
 	"github.com/onsi/ginkgo/v2/types"
 	"k8s.io/klog"
 )
@@ -402,7 +402,7 @@ func (cfs *Files) FilterByDirGlob(filter string) Files {
 
 	for _, file := range *cfs {
 
-		if matched, _ := filepath.Match(filter, file.Name); !matched {
+		if matched, _ := doublestar.PathMatch(filter, file.Name); !matched {
 
 			continue
 		}

--- a/magefiles/utils.go
+++ b/magefiles/utils.go
@@ -441,9 +441,15 @@ func HandleErrorWithAlert(err error, errLevel slack.ErrorSeverityLevel) error {
 	return nil
 }
 
-func getChangedFiles() (rulesengine.Files, error) {
+func getChangedFiles(repo string) (rulesengine.Files, error) {
 	var gitDiff = sh.OutCmd("git", "diff")
-	output, err := gitDiff("--name-status", "main..HEAD")
+	// If the repo is infra-deployments then we check changed files in path tmp/infra-deployments
+	// else it will run locally which is from e2e-tests directory
+	if repo == "infra-deployments" {
+		wd, _ := os.Getwd()
+		gitDiff = sh.OutCmd("git", "-C", fmt.Sprintf("%s/tmp/%s", wd, repo), "diff")
+	}
+	output, err := gitDiff("--name-status", "upstream/main")
 
 	if err != nil {
 		klog.Error("Failed to run git status locally")


### PR DESCRIPTION
- Add Rules for the infra-deployments so changes in a specific component in infra-deployments runs it's suite
- If changes are out of components it runs the default konflux-demo suite 
- Fixed the getChangedFiles to look into infra-deployments adding to the e2e-tests

1- Examples from local Run : 
in the tmp/infra-deployments created a new branch , edited README of components/integration  , added committed 
ran the DryRun , so we expect that the **LabelFilter** have both "integration-service" and "konflux-demo": 

```
exec: git "-C" "/home/kasemalem/integration-project/e2e-tests/tmp/infra-deployments" "diff" "--name-status" "main..HEAD"
I0815 15:47:48.094713  520112 utils.go:474] The following files, components/integration/README.md, were changed!
I0815 15:47:48.094747  520112 types.go:72] Loading the catalog for, infra-deployments, from category, tests
I0815 15:47:48.094759  520112 types.go:144] The following rules have matched Infra-deployments PR Components File Diff Execution.

exec: ginkgo "--seed=1723726067" "--timeout=1h30m0s" "--grace-period=30s" "--output-interceptor-mode=none" "--label-filter=,integration-service,konflux-demo" "--junit-report=e2e-report.xml" "--p" "--output-dir=." "./cmd" "--"

```
 




2- Example of local Run :

Changing only the README.md file in Infra-deployments folder so we expect that only the **konflux-demo**  run 

```
exec: git "-C" "/home/kasemalem/integration-project/e2e-tests/tmp/infra-deployments" "diff" "--name-status" "main..HEAD"
I0815 16:01:32.736127  526636 utils.go:474] The following files, README.md, were changed!
I0815 16:01:32.736182  526636 types.go:72] Loading the catalog for, infra-deployments, from category, tests
I0815 16:01:32.736198  526636 types.go:144] The following rules have matched Infra Deployments Default Test Execution.
I0815 16:01:32.736203  526636 types.go:169] Will apply rules
exec: ginkgo "--seed=1723726891" "--timeout=1h30m0s" "--grace-period=30s" "--output-interceptor-mode=none" "--label-filter=konflux-demo" "--junit-report=e2e-report.xml" "--p" "--output-dir=." "./cmd" "--"
```


3- Example when no file was changed: 
```
exec: git "-C" "/home/kasemalem/integration-project/e2e-tests/tmp/infra-deployments" "diff" "--name-status" "main..HEAD"
I0815 16:16:29.763682  534150 utils.go:461] Found no changed files.
I0815 16:16:29.763749  534150 types.go:72] Loading the catalog for, infra-deployments, from category, tests
I0815 16:16:29.763766  534150 types.go:144] The following rules have matched .
I0815 16:16:29.763772  534150 types.go:169] Will apply rules
```



# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## [KONFLUX-3187](https://issues.redhat.com/browse/KONFLUX-3187)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
