### PR TITLE
chore(STONEINTG-1028): revert deletion of Integration service e2e-tests

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -96,7 +96,9 @@ In that case, before you run the test, make sure you have created
   * https://github.com/redhat-appstudio-qe/devfile-sample-hello-world (for running build-service tests)
   * https://github.com/redhat-appstudio-qe/hacbs-test-project (for konflux-demo test)
   * https://github.com/redhat-appstudio-qe/strategy-configs (for konflux-demo test)
-  * https://github.com/redhat-appstudio-qe/hacbs-test-project-integration (for status-reporting-to-pullrequest test)
+  * https://github.com/redhat-appstudio-qe/hacbs-test-project-integration (for integration test)
+  * https://github.com/redhat-appstudio-qe/test-integration-status-report (for status-reporting-to-pullrequest test)
+  * https://github.com/redhat-appstudio-qe/test-integration-with-env (for integration-with-env test)
 
 Note: All Environments used in all e2e-tests are in [default.env](../default.env) file. In case you need to run a specific tests, not all environments are necessary to be defined.
 

--- a/tests/integration-service/const.go
+++ b/tests/integration-service/const.go
@@ -17,7 +17,9 @@ const (
 	autoReleasePlan                = "auto-releaseplan"
 	targetReleaseNamespace         = "default"
 
-	componentRepoNameForStatusReporting       = "hacbs-test-project-integration"
+	componentRepoNameForGeneralIntegration    = "hacbs-test-project-integration"
+	componentRepoNameForIntegrationWithEnv    = "test-integration-with-env"
+	componentRepoNameForStatusReporting       = "test-integration-status-report"
 	componentDefaultBranch                    = "main"
 	componentRevision                         = "34da5a8f51fba6a8b7ec75a727d3c72ebb5e1274"
 	referenceDoesntExist                      = "Reference does not exist"
@@ -39,6 +41,8 @@ const (
 )
 
 var (
+	componentGitSourceURLForGeneralIntegration    = fmt.Sprintf("https://github.com/%s/%s", utils.GetEnv(constants.GITHUB_E2E_ORGANIZATION_ENV, "redhat-appstudio-qe"), componentRepoNameForGeneralIntegration)
+	componentGitSourceURLForIntegrationWithEnv    = fmt.Sprintf("https://github.com/%s/%s", utils.GetEnv(constants.GITHUB_E2E_ORGANIZATION_ENV, "redhat-appstudio-qe"), componentRepoNameForIntegrationWithEnv)
 	componentGitSourceURLForStatusReporting       = fmt.Sprintf("https://github.com/%s/%s", utils.GetEnv(constants.GITHUB_E2E_ORGANIZATION_ENV, "redhat-appstudio-qe"), componentRepoNameForStatusReporting)
 	gitlabComponentGitSourceURLForStatusReporting = fmt.Sprintf("https://gitlab.com/konflux-qe/%s", componentRepoNameForStatusReporting)
 )

--- a/tests/integration-service/integration-with-env.go
+++ b/tests/integration-service/integration-with-env.go
@@ -1,0 +1,179 @@
+package integration
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/codeready-toolchain/api/api/v1alpha1"
+	"github.com/konflux-ci/e2e-tests/pkg/clients/has"
+	"github.com/konflux-ci/e2e-tests/pkg/framework"
+	"github.com/konflux-ci/e2e-tests/pkg/utils"
+	pipeline "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	appstudioApi "github.com/konflux-ci/application-api/api/v1alpha1"
+	integrationv1beta2 "github.com/konflux-ci/integration-service/api/v1beta2"
+	intgteststat "github.com/konflux-ci/integration-service/pkg/integrationteststatus"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests", Label("integration-service", "integration-env"), func() {
+	defer GinkgoRecover()
+
+	var f *framework.Framework
+	var err error
+
+	var applicationName, componentName, testNamespace string
+	var integrationTestScenario *integrationv1beta2.IntegrationTestScenario
+	var timeout, interval time.Duration
+	var originalComponent *appstudioApi.Component
+	var pipelineRun, integrationPipelineRun *pipeline.PipelineRun
+	var snapshot *appstudioApi.Snapshot
+	var spaceRequest *v1alpha1.SpaceRequest
+
+	AfterEach(framework.ReportFailure(&f))
+
+	Describe("with happy path for general flow of Integration service with ephemeral environment", Ordered, func() {
+		BeforeAll(func() {
+			// Initialize the tests controllers
+			f, err = framework.NewFramework(utils.GetGeneratedNamespace("integration-env"))
+			Expect(err).NotTo(HaveOccurred())
+			testNamespace = f.UserNamespace
+
+			applicationName = createApp(*f, testNamespace)
+			componentName, originalComponent = createComponent(*f, testNamespace, applicationName, componentGitSourceURLForIntegrationWithEnv)
+			integrationTestScenario, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenario("", applicationName, testNamespace, gitURL, revision, pathIntegrationPipelineWithEnv)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		AfterAll(func() {
+			if !CurrentSpecReport().Failed() {
+				Expect(f.SandboxController.DeleteUserSignup(f.UserName)).To(BeTrue())
+			}
+		})
+
+		When("a new Component is created", func() {
+			It("triggers a build PipelineRun", Label("integration-service"), func() {
+				pipelineRun, err = f.AsKubeDeveloper.IntegrationController.GetBuildPipelineRun(componentName, applicationName, testNamespace, false, "")
+				Expect(err).ShouldNot(HaveOccurred())
+			})
+
+			It("verifies if the build PipelineRun contains the finalizer", Label("integration-service"), func() {
+				Eventually(func() error {
+					pipelineRun, err = f.AsKubeDeveloper.IntegrationController.GetBuildPipelineRun(componentName, applicationName, testNamespace, false, "")
+					Expect(err).ShouldNot(HaveOccurred())
+					if !controllerutil.ContainsFinalizer(pipelineRun, pipelinerunFinalizerByIntegrationService) {
+						return fmt.Errorf("build pipelineRun %s/%s doesn't contain the finalizer: %s yet", pipelineRun.GetNamespace(), pipelineRun.GetName(), pipelinerunFinalizerByIntegrationService)
+					}
+					return nil
+				}, 1*time.Minute, 1*time.Second).Should(Succeed(), "timeout when waiting for finalizer to be added")
+			})
+
+			It("waits for build PipelineRun to succeed", Label("integration-service"), func() {
+				Expect(pipelineRun.Annotations[snapshotAnnotation]).To(Equal(""))
+				Expect(f.AsKubeDeveloper.HasController.WaitForComponentPipelineToBeFinished(originalComponent, "",
+					f.AsKubeAdmin.TektonController, &has.RetryOptions{Retries: 2, Always: true}, pipelineRun)).To(Succeed())
+			})
+		})
+
+		When("the build pipelineRun run succeeded", func() {
+			It("checks if the BuildPipelineRun have the annotation of chains signed", func() {
+				Expect(f.AsKubeDeveloper.IntegrationController.WaitForBuildPipelineRunToGetAnnotated(testNamespace, applicationName, componentName, chainsSignedAnnotation)).To(Succeed())
+			})
+
+			It("checks if the Snapshot is created", func() {
+				snapshot, err = f.AsKubeDeveloper.IntegrationController.WaitForSnapshotToGetCreated("", "", componentName, testNamespace)
+
+			})
+
+			It("checks if the Build PipelineRun got annotated with Snapshot name", func() {
+				Expect(f.AsKubeDeveloper.IntegrationController.WaitForBuildPipelineRunToGetAnnotated(testNamespace, applicationName, componentName, snapshotAnnotation)).To(Succeed())
+			})
+
+			It("verifies that the finalizer has been removed from the build pipelinerun", func() {
+				timeout := "60s"
+				interval := "1s"
+				Eventually(func() error {
+					pipelineRun, err := f.AsKubeDeveloper.IntegrationController.GetBuildPipelineRun(componentName, applicationName, testNamespace, false, "")
+					if err != nil {
+						if k8sErrors.IsNotFound(err) {
+							return nil
+						}
+						return fmt.Errorf("error getting PipelineRun: %v", err)
+					}
+					if pipelineRun == nil || pipelineRun.Name == "" {
+						return nil
+					}
+					if controllerutil.ContainsFinalizer(pipelineRun, pipelinerunFinalizerByIntegrationService) {
+						return fmt.Errorf("build PipelineRun %s/%s still contains the finalizer: %s", pipelineRun.GetNamespace(), pipelineRun.GetName(), pipelinerunFinalizerByIntegrationService)
+					}
+					return nil
+				}, timeout, interval).Should(Succeed(), "timeout when waiting for finalizer to be removed")
+			})
+
+			It(fmt.Sprintf("checks if CronJob %s exists", spaceRequestCronJobName), func() {
+				spaceRequestCleanerCronJob, err := f.AsKubeAdmin.CommonController.GetCronJob(spaceRequestCronJobNamespace, spaceRequestCronJobName)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(strings.Contains(spaceRequestCleanerCronJob.Name, spaceRequestCronJobName)).Should(BeTrue())
+			})
+
+			It("checks if all of the integrationPipelineRuns passed", Label("slow"), func() {
+				Expect(f.AsKubeDeveloper.IntegrationController.WaitForAllIntegrationPipelinesToBeFinished(testNamespace, applicationName, snapshot)).To(Succeed())
+			})
+
+			It("checks if space request is created in namespace", func() {
+				spaceRequestsList, err := f.AsKubeAdmin.GitOpsController.GetSpaceRequests(testNamespace)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				Expect(spaceRequestsList.Items).To(HaveLen(1), "Expected spaceRequestsList.Items to have at least one item")
+				spaceRequest = &spaceRequestsList.Items[0]
+				Expect(strings.Contains(spaceRequest.Name, spaceRequestNamePrefix)).Should(BeTrue())
+			})
+
+			It("checks if the passed status of integration test is reported in the Snapshot", func() {
+				timeout = time.Second * 240
+				interval = time.Second * 5
+				Eventually(func() error {
+					snapshot, err = f.AsKubeAdmin.IntegrationController.GetSnapshot(snapshot.Name, "", "", testNamespace)
+					Expect(err).ShouldNot(HaveOccurred())
+
+					statusDetail, err := f.AsKubeDeveloper.IntegrationController.GetIntegrationTestStatusDetailFromSnapshot(snapshot, integrationTestScenario.Name)
+					Expect(err).ToNot(HaveOccurred())
+
+					if statusDetail.Status != intgteststat.IntegrationTestStatusTestPassed {
+						return fmt.Errorf("test status for scenario: %s, doesn't have expected value %s, within the snapshot: %s", integrationTestScenario.Name, intgteststat.IntegrationTestStatusTestPassed, snapshot.Name)
+					}
+					return nil
+				}, timeout, interval).Should(Succeed())
+			})
+
+			It("checks if the finalizer was removed from all of the related Integration pipelineRuns", func() {
+				Expect(f.AsKubeDeveloper.IntegrationController.WaitForFinalizerToGetRemovedFromAllIntegrationPipelineRuns(testNamespace, applicationName, snapshot)).To(Succeed())
+			})
+
+			It("checks that when deleting integration test scenario pipelineRun, spaceRequest is deleted too", func() {
+				integrationPipelineRun, err = f.AsKubeAdmin.IntegrationController.GetIntegrationPipelineRun(integrationTestScenario.Name, snapshot.Name, testNamespace)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(f.AsKubeDeveloper.TektonController.DeletePipelineRun(integrationPipelineRun.Name, integrationPipelineRun.Namespace)).To(Succeed())
+
+				timeout = time.Second * 200
+				interval = time.Second * 5
+				Eventually(func() error {
+					currentSpaceRequest, err := f.AsKubeAdmin.GitOpsController.GetSpaceRequest(testNamespace, spaceRequest.Name)
+					if err != nil {
+						if k8sErrors.IsNotFound(err) {
+							return nil
+						}
+						return fmt.Errorf("failed to get %s/%s spaceRequest: %+v", currentSpaceRequest.Namespace, currentSpaceRequest.Name, err)
+					}
+					return fmt.Errorf("spaceRequest %s/%s still exists", currentSpaceRequest.Namespace, currentSpaceRequest.Name)
+				}, timeout, interval).Should(Succeed())
+
+			})
+		})
+	})
+})

--- a/tests/integration-service/integration-with-env.go
+++ b/tests/integration-service/integration-with-env.go
@@ -27,13 +27,14 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 	var f *framework.Framework
 	var err error
 
-	var applicationName, componentName, testNamespace string
+	var prHeadSha string
 	var integrationTestScenario *integrationv1beta2.IntegrationTestScenario
 	var timeout, interval time.Duration
 	var originalComponent *appstudioApi.Component
 	var pipelineRun, integrationPipelineRun *pipeline.PipelineRun
 	var snapshot *appstudioApi.Snapshot
 	var spaceRequest *v1alpha1.SpaceRequest
+	var applicationName, componentName, componentBaseBranchName, pacBranchName, testNamespace string
 
 	AfterEach(framework.ReportFailure(&f))
 
@@ -45,7 +46,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 			testNamespace = f.UserNamespace
 
 			applicationName = createApp(*f, testNamespace)
-			componentName, originalComponent = createComponent(*f, testNamespace, applicationName, componentGitSourceURLForIntegrationWithEnv)
+			originalComponent, componentName, pacBranchName, componentBaseBranchName = createComponent(*f, testNamespace, applicationName, componentRepoNameForIntegrationWithEnv, componentGitSourceURLForIntegrationWithEnv)
 			integrationTestScenario, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenario("", applicationName, testNamespace, gitURL, revision, pathIntegrationPipelineWithEnv)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
@@ -53,6 +54,16 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 		AfterAll(func() {
 			if !CurrentSpecReport().Failed() {
 				Expect(f.SandboxController.DeleteUserSignup(f.UserName)).To(BeTrue())
+			}
+
+			// Delete new branches created by PaC and a testing branch used as a component's base branch
+			err = f.AsKubeAdmin.CommonController.Github.DeleteRef(componentRepoNameForIntegrationWithEnv, pacBranchName)
+			if err != nil {
+				Expect(err.Error()).To(ContainSubstring(referenceDoesntExist))
+			}
+			err = f.AsKubeAdmin.CommonController.Github.DeleteRef(componentRepoNameForIntegrationWithEnv, componentBaseBranchName)
+			if err != nil {
+				Expect(err.Error()).To(ContainSubstring(referenceDoesntExist))
 			}
 		})
 
@@ -78,6 +89,28 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 				Expect(f.AsKubeDeveloper.HasController.WaitForComponentPipelineToBeFinished(originalComponent, "",
 					f.AsKubeAdmin.TektonController, &has.RetryOptions{Retries: 2, Always: true}, pipelineRun)).To(Succeed())
 			})
+
+			It("should have a related PaC init PR created", func() {
+				timeout = time.Second * 300
+				interval = time.Second * 1
+
+				Eventually(func() bool {
+					prs, err := f.AsKubeAdmin.CommonController.Github.ListPullRequests(componentRepoNameForIntegrationWithEnv)
+					Expect(err).ShouldNot(HaveOccurred())
+
+					for _, pr := range prs {
+						if pr.Head.GetRef() == pacBranchName {
+							prHeadSha = pr.Head.GetSHA()
+							return true
+						}
+					}
+					return false
+				}, timeout, interval).Should(BeTrue(), fmt.Sprintf("timed out when waiting for init PaC PR (branch name '%s') to be created in %s repository", pacBranchName, componentRepoNameForStatusReporting))
+
+				// in case the first pipelineRun attempt has failed and was retried, we need to update the value of pipelineRun variable
+				pipelineRun, err = f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, prHeadSha)
+				Expect(err).ShouldNot(HaveOccurred())
+			})
 		})
 
 		When("the build pipelineRun run succeeded", func() {
@@ -87,7 +120,6 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 
 			It("checks if the Snapshot is created", func() {
 				snapshot, err = f.AsKubeDeveloper.IntegrationController.WaitForSnapshotToGetCreated("", "", componentName, testNamespace)
-
 			})
 
 			It("checks if the Build PipelineRun got annotated with Snapshot name", func() {
@@ -172,7 +204,6 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 					}
 					return fmt.Errorf("spaceRequest %s/%s still exists", currentSpaceRequest.Namespace, currentSpaceRequest.Name)
 				}, timeout, interval).Should(Succeed())
-
 			})
 		})
 	})

--- a/tests/integration-service/integration.go
+++ b/tests/integration-service/integration.go
@@ -1,0 +1,380 @@
+package integration
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/konflux-ci/operator-toolkit/metadata"
+
+	"github.com/devfile/library/v2/pkg/util"
+	"github.com/konflux-ci/e2e-tests/pkg/clients/has"
+	"github.com/konflux-ci/e2e-tests/pkg/constants"
+	"github.com/konflux-ci/e2e-tests/pkg/framework"
+	"github.com/konflux-ci/e2e-tests/pkg/utils"
+	pipeline "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	integrationv1beta2 "github.com/konflux-ci/integration-service/api/v1beta2"
+	intgteststat "github.com/konflux-ci/integration-service/pkg/integrationteststatus"
+
+	appstudioApi "github.com/konflux-ci/application-api/api/v1alpha1"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests", Label("integration-service"), func() {
+	defer GinkgoRecover()
+
+	var f *framework.Framework
+	var err error
+
+	var applicationName, componentName, testNamespace string
+	var integrationTestScenario *integrationv1beta2.IntegrationTestScenario
+	var newIntegrationTestScenario *integrationv1beta2.IntegrationTestScenario
+	var timeout, interval time.Duration
+	var originalComponent *appstudioApi.Component
+	var pipelineRun *pipeline.PipelineRun
+	var snapshot *appstudioApi.Snapshot
+	var snapshotPush *appstudioApi.Snapshot
+	AfterEach(framework.ReportFailure(&f))
+
+	Describe("with happy path for general flow of Integration service", Ordered, func() {
+		BeforeAll(func() {
+			// Initialize the tests controllers
+			f, err = framework.NewFramework(utils.GetGeneratedNamespace("integration1"))
+			Expect(err).NotTo(HaveOccurred())
+			testNamespace = f.UserNamespace
+
+			applicationName = createApp(*f, testNamespace)
+			componentName, originalComponent = createComponent(*f, testNamespace, applicationName, componentGitSourceURLForGeneralIntegration)
+			integrationTestScenario, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenario("", applicationName, testNamespace, gitURL, revision, pathInRepoPass)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		AfterAll(func() {
+			if !CurrentSpecReport().Failed() {
+				cleanup(*f, testNamespace, applicationName, componentName)
+
+				Expect(f.AsKubeAdmin.IntegrationController.DeleteSnapshot(snapshotPush, testNamespace)).To(Succeed())
+			}
+		})
+
+		When("a new Component is created", func() {
+			It("triggers a build PipelineRun", Label("integration-service"), func() {
+				pipelineRun, err = f.AsKubeDeveloper.IntegrationController.GetBuildPipelineRun(componentName, applicationName, testNamespace, false, "")
+				Expect(err).ShouldNot(HaveOccurred())
+			})
+
+			It("verifies if the build PipelineRun contains the finalizer", Label("integration-service"), func() {
+				Eventually(func() error {
+					pipelineRun, err = f.AsKubeDeveloper.IntegrationController.GetBuildPipelineRun(componentName, applicationName, testNamespace, false, "")
+					Expect(err).ShouldNot(HaveOccurred())
+					if !controllerutil.ContainsFinalizer(pipelineRun, pipelinerunFinalizerByIntegrationService) {
+						return fmt.Errorf("build pipelineRun %s/%s doesn't contain the finalizer: %s yet", pipelineRun.GetNamespace(), pipelineRun.GetName(), pipelinerunFinalizerByIntegrationService)
+					}
+					return nil
+				}, 1*time.Minute, 1*time.Second).Should(Succeed(), "timeout when waiting for finalizer to be added")
+			})
+
+			It("waits for build PipelineRun to succeed", Label("integration-service"), func() {
+				Expect(pipelineRun.Annotations[snapshotAnnotation]).To(Equal(""))
+				Expect(f.AsKubeDeveloper.HasController.WaitForComponentPipelineToBeFinished(originalComponent, "",
+					f.AsKubeAdmin.TektonController, &has.RetryOptions{Retries: 2, Always: true}, pipelineRun)).To(Succeed())
+			})
+		})
+
+		When("the build pipelineRun run succeeded", func() {
+			It("checks if the BuildPipelineRun have the annotation of chains signed", func() {
+				Expect(f.AsKubeDeveloper.IntegrationController.WaitForBuildPipelineRunToGetAnnotated(testNamespace, applicationName, componentName, chainsSignedAnnotation)).To(Succeed())
+			})
+
+			It("checks if the Snapshot is created", func() {
+				snapshot, err = f.AsKubeDeveloper.IntegrationController.WaitForSnapshotToGetCreated("", "", componentName, testNamespace)
+				Expect(err).ShouldNot(HaveOccurred())
+			})
+
+			It("checks if the Build PipelineRun got annotated with Snapshot name", func() {
+				Expect(f.AsKubeDeveloper.IntegrationController.WaitForBuildPipelineRunToGetAnnotated(testNamespace, applicationName, componentName, snapshotAnnotation)).To(Succeed())
+			})
+
+			It("verifies that the finalizer has been removed from the build pipelinerun", func() {
+				timeout := "60s"
+				interval := "1s"
+				Eventually(func() error {
+					pipelineRun, err = f.AsKubeDeveloper.IntegrationController.GetBuildPipelineRun(componentName, applicationName, testNamespace, false, "")
+					Expect(err).ShouldNot(HaveOccurred())
+					if controllerutil.ContainsFinalizer(pipelineRun, pipelinerunFinalizerByIntegrationService) {
+						return fmt.Errorf("build pipelineRun %s/%s still contains the finalizer: %s", pipelineRun.GetNamespace(), pipelineRun.GetName(), pipelinerunFinalizerByIntegrationService)
+					}
+					return nil
+				}, timeout, interval).Should(Succeed(), "timeout when waiting for finalizer to be removed")
+			})
+
+			It("checks if all of the integrationPipelineRuns passed", Label("slow"), func() {
+				Expect(f.AsKubeDeveloper.IntegrationController.WaitForAllIntegrationPipelinesToBeFinished(testNamespace, applicationName, snapshot)).To(Succeed())
+			})
+
+			It("checks if the passed status of integration test is reported in the Snapshot", func() {
+				timeout = time.Second * 240
+				interval = time.Second * 5
+				Eventually(func() error {
+					snapshot, err = f.AsKubeAdmin.IntegrationController.GetSnapshot(snapshot.Name, "", "", testNamespace)
+					Expect(err).ShouldNot(HaveOccurred())
+
+					statusDetail, err := f.AsKubeDeveloper.IntegrationController.GetIntegrationTestStatusDetailFromSnapshot(snapshot, integrationTestScenario.Name)
+					Expect(err).ToNot(HaveOccurred())
+
+					if statusDetail.Status != intgteststat.IntegrationTestStatusTestPassed {
+						return fmt.Errorf("test status for scenario: %s, doesn't have expected value %s, within the snapshot: %s", integrationTestScenario.Name, intgteststat.IntegrationTestStatusTestPassed, snapshot.Name)
+					}
+					return nil
+				}, timeout, interval).Should(Succeed())
+			})
+
+			It("checks if the finalizer was removed from all of the related Integration pipelineRuns", func() {
+				Expect(f.AsKubeDeveloper.IntegrationController.WaitForFinalizerToGetRemovedFromAllIntegrationPipelineRuns(testNamespace, applicationName, snapshot)).To(Succeed())
+			})
+		})
+
+		It("creates a ReleasePlan", func() {
+			_, err = f.AsKubeAdmin.ReleaseController.CreateReleasePlan(autoReleasePlan, testNamespace, applicationName, targetReleaseNamespace, "", nil, nil)
+			Expect(err).ShouldNot(HaveOccurred())
+			testScenarios, err := f.AsKubeAdmin.IntegrationController.GetIntegrationTestScenarios(applicationName, testNamespace)
+			Expect(err).ShouldNot(HaveOccurred())
+			for _, testScenario := range *testScenarios {
+				GinkgoWriter.Printf("IntegrationTestScenario %s is found\n", testScenario.Name)
+			}
+		})
+
+		It("creates an snapshot of push event", func() {
+			sampleImage := "quay.io/redhat-appstudio/sample-image@sha256:841328df1b9f8c4087adbdcfec6cc99ac8308805dea83f6d415d6fb8d40227c1"
+			snapshotPush, err = f.AsKubeAdmin.IntegrationController.CreateSnapshotWithImage(componentName, applicationName, testNamespace, sampleImage)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		When("An snapshot of push event is created", func() {
+			It("checks if the global candidate is updated after push event", func() {
+				timeout = time.Second * 600
+				interval = time.Second * 10
+				Eventually(func() error {
+					snapshotPush, err = f.AsKubeAdmin.IntegrationController.GetSnapshot(snapshotPush.Name, "", "", testNamespace)
+					Expect(err).ShouldNot(HaveOccurred())
+
+					component, err := f.AsKubeAdmin.HasController.GetComponentByApplicationName(applicationName, testNamespace)
+					Expect(err).ShouldNot(HaveOccurred())
+					Expect(component.Spec.ContainerImage).ToNot(Equal(originalComponent.Spec.ContainerImage))
+					return nil
+
+				}, timeout, interval).Should(Succeed(), fmt.Sprintf("time out when waiting for updating the global candidate in %s namespace", testNamespace))
+			})
+
+			It("checks if all of the integrationPipelineRuns created by push event passed", Label("slow"), func() {
+				Expect(f.AsKubeAdmin.IntegrationController.WaitForAllIntegrationPipelinesToBeFinished(testNamespace, applicationName, snapshotPush)).To(Succeed(), "Error when waiting for one of the integration pipelines to finish in %s namespace", testNamespace)
+			})
+
+			It("checks if a Release is created successfully", func() {
+				timeout = time.Second * 60
+				interval = time.Second * 5
+				Eventually(func() error {
+					_, err := f.AsKubeAdmin.ReleaseController.GetReleases(testNamespace)
+					return err
+				}, timeout, interval).Should(Succeed(), fmt.Sprintf("time out when waiting for release created for snapshot %s/%s", snapshotPush.GetNamespace(), snapshotPush.GetName()))
+			})
+		})
+	})
+
+	Describe("with an integration test fail", Ordered, func() {
+		BeforeAll(func() {
+			// Initialize the tests controllers
+			f, err = framework.NewFramework(utils.GetGeneratedNamespace("integration2"))
+			Expect(err).NotTo(HaveOccurred())
+			testNamespace = f.UserNamespace
+
+			applicationName = createApp(*f, testNamespace)
+			componentName, originalComponent = createComponent(*f, testNamespace, applicationName, componentGitSourceURLForGeneralIntegration)
+
+			integrationTestScenario, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenario("", applicationName, testNamespace, gitURL, revision, pathInRepoFail)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		AfterAll(func() {
+			if !CurrentSpecReport().Failed() {
+				cleanup(*f, testNamespace, applicationName, componentName)
+
+			}
+		})
+
+		It("triggers a build PipelineRun", Label("integration-service"), func() {
+			pipelineRun, err = f.AsKubeDeveloper.IntegrationController.GetBuildPipelineRun(componentName, applicationName, testNamespace, false, "")
+			Expect(pipelineRun.Annotations[snapshotAnnotation]).To(Equal(""))
+			Expect(f.AsKubeDeveloper.HasController.WaitForComponentPipelineToBeFinished(originalComponent, "", f.AsKubeAdmin.TektonController,
+				&has.RetryOptions{Retries: 2, Always: true}, pipelineRun)).To(Succeed())
+
+		})
+
+		It("checks if the BuildPipelineRun have the annotation of chains signed", func() {
+			Expect(f.AsKubeDeveloper.IntegrationController.WaitForBuildPipelineRunToGetAnnotated(testNamespace, applicationName, componentName, chainsSignedAnnotation)).To(Succeed())
+		})
+
+		It("checks if the Snapshot is created", func() {
+			snapshot, err = f.AsKubeDeveloper.IntegrationController.WaitForSnapshotToGetCreated("", pipelineRun.Name, componentName, testNamespace)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		It("checks if the Build PipelineRun got annotated with Snapshot name", func() {
+			Expect(f.AsKubeDeveloper.IntegrationController.WaitForBuildPipelineRunToGetAnnotated(testNamespace, applicationName, componentName, snapshotAnnotation)).To(Succeed())
+		})
+
+		It("checks if all of the integrationPipelineRuns finished", Label("slow"), func() {
+			Expect(f.AsKubeDeveloper.IntegrationController.WaitForAllIntegrationPipelinesToBeFinished(testNamespace, applicationName, snapshot)).To(Succeed())
+		})
+
+		It("checks if the failed status of integration test is reported in the Snapshot", func() {
+			Eventually(func() error {
+				snapshot, err = f.AsKubeAdmin.IntegrationController.GetSnapshot(snapshot.Name, "", "", testNamespace)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				statusDetail, err := f.AsKubeDeveloper.IntegrationController.GetIntegrationTestStatusDetailFromSnapshot(snapshot, integrationTestScenario.Name)
+				Expect(err).ToNot(HaveOccurred())
+
+				if statusDetail.Status != intgteststat.IntegrationTestStatusTestFail {
+					return fmt.Errorf("test status doesn't have expected value %s", intgteststat.IntegrationTestStatusTestFail)
+				}
+				return nil
+			}, timeout, interval).Should(Succeed())
+		})
+
+		It("checks if snapshot is marked as failed", FlakeAttempts(3), func() {
+			snapshot, err = f.AsKubeAdmin.IntegrationController.GetSnapshot(snapshot.Name, "", "", testNamespace)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(f.AsKubeAdmin.CommonController.HaveTestsSucceeded(snapshot)).To(BeFalse(), "expected tests to fail for snapshot %s/%s", snapshot.GetNamespace(), snapshot.GetName())
+		})
+
+		It("checks if the finalizer was removed from all of the related Integration pipelineRuns", func() {
+			Expect(f.AsKubeDeveloper.IntegrationController.WaitForFinalizerToGetRemovedFromAllIntegrationPipelineRuns(testNamespace, applicationName, snapshot)).To(Succeed())
+		})
+
+		It("creates a new IntegrationTestScenario", func() {
+			newIntegrationTestScenario, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenario("", applicationName, testNamespace, gitURL, revision, pathInRepoPass)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		It("updates the Snapshot with the re-run label for the new scenario", FlakeAttempts(3), func() {
+			updatedSnapshot := snapshot.DeepCopy()
+			err := metadata.AddLabels(updatedSnapshot, map[string]string{snapshotRerunLabel: newIntegrationTestScenario.Name})
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(f.AsKubeAdmin.IntegrationController.PatchSnapshot(snapshot, updatedSnapshot)).Should(Succeed())
+			Expect(metadata.GetLabelsWithPrefix(updatedSnapshot, snapshotRerunLabel)).NotTo(BeEmpty())
+		})
+
+		When("An snapshot is updated with a re-run label for a given scenario", func() {
+			It("checks if the new integration pipelineRun started", Label("slow"), func() {
+				reRunPipelineRun, err := f.AsKubeDeveloper.IntegrationController.WaitForIntegrationPipelineToGetStarted(newIntegrationTestScenario.Name, snapshot.Name, testNamespace)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(reRunPipelineRun).ShouldNot(BeNil())
+			})
+
+			It("checks if the re-run label was removed from the Snapshot", func() {
+				Eventually(func() error {
+					snapshot, err = f.AsKubeAdmin.IntegrationController.GetSnapshot(snapshot.Name, "", "", testNamespace)
+					if err != nil {
+						return fmt.Errorf("encountered error while getting Snapshot %s/%s: %w", snapshot.Name, snapshot.Namespace, err)
+					}
+
+					if metadata.HasLabel(snapshot, snapshotRerunLabel) {
+						return fmt.Errorf("the Snapshot %s/%s shouldn't contain the %s label", snapshot.Name, snapshot.Namespace, snapshotRerunLabel)
+					}
+					return nil
+				}, timeout, interval).Should(Succeed())
+			})
+
+			It("checks if all integration pipelineRuns finished successfully", Label("slow"), func() {
+				Expect(f.AsKubeDeveloper.IntegrationController.WaitForAllIntegrationPipelinesToBeFinished(testNamespace, applicationName, snapshot)).To(Succeed())
+			})
+
+			It("checks if the name of the re-triggered pipelinerun is reported in the Snapshot", FlakeAttempts(3), func() {
+				Eventually(func(g Gomega) {
+					snapshot, err = f.AsKubeAdmin.IntegrationController.GetSnapshot(snapshot.Name, "", "", testNamespace)
+					g.Expect(err).ShouldNot(HaveOccurred())
+
+					statusDetail, err := f.AsKubeDeveloper.IntegrationController.GetIntegrationTestStatusDetailFromSnapshot(snapshot, newIntegrationTestScenario.Name)
+					g.Expect(err).ToNot(HaveOccurred())
+					g.Expect(statusDetail).NotTo(BeNil())
+
+					integrationPipelineRun, err := f.AsKubeDeveloper.IntegrationController.GetIntegrationPipelineRun(newIntegrationTestScenario.Name, snapshot.Name, testNamespace)
+					g.Expect(err).ToNot(HaveOccurred())
+					g.Expect(integrationPipelineRun).NotTo(BeNil())
+
+					g.Expect(statusDetail.TestPipelineRunName).To(Equal(integrationPipelineRun.Name))
+				}, timeout, interval).Should(Succeed())
+			})
+
+			It("checks if snapshot is still marked as failed", func() {
+				snapshot, err = f.AsKubeAdmin.IntegrationController.GetSnapshot(snapshot.Name, "", "", testNamespace)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(f.AsKubeAdmin.CommonController.HaveTestsSucceeded(snapshot)).To(BeFalse(), "expected tests to fail for snapshot %s/%s", snapshot.GetNamespace(), snapshot.GetName())
+			})
+
+		})
+
+		It("creates an snapshot of push event", func() {
+			sampleImage := "quay.io/redhat-appstudio/sample-image@sha256:841328df1b9f8c4087adbdcfec6cc99ac8308805dea83f6d415d6fb8d40227c1"
+			snapshotPush, err = f.AsKubeAdmin.IntegrationController.CreateSnapshotWithImage(componentName, applicationName, testNamespace, sampleImage)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		When("An snapshot of push event is created", func() {
+			It("checks no Release CRs are created", func() {
+				releases, err := f.AsKubeAdmin.ReleaseController.GetReleases(testNamespace)
+				Expect(err).NotTo(HaveOccurred(), "Error when fetching the Releases")
+				Expect(releases.Items).To(BeEmpty(), "Expected no Release CRs to be present, but found some")
+			})
+		})
+	})
+})
+
+func createApp(f framework.Framework, testNamespace string) string {
+	applicationName := fmt.Sprintf("integ-app-%s", util.GenerateRandomString(4))
+
+	_, err := f.AsKubeAdmin.HasController.CreateApplication(applicationName, testNamespace)
+	Expect(err).NotTo(HaveOccurred())
+
+	return applicationName
+}
+
+func createComponent(f framework.Framework, testNamespace, applicationName, componentRepoURL string) (string, *appstudioApi.Component) {
+
+	componentName := fmt.Sprintf("integration-suite-test-component-git-source-%s", util.GenerateRandomString(6))
+
+	componentObj := appstudioApi.ComponentSpec{
+		ComponentName: componentName,
+		Application:   applicationName,
+		Source: appstudioApi.ComponentSource{
+			ComponentSourceUnion: appstudioApi.ComponentSourceUnion{
+				GitSource: &appstudioApi.GitSource{
+					URL: componentRepoURL,
+				},
+			},
+		},
+	}
+
+	originalComponent, err := f.AsKubeAdmin.HasController.CreateComponent(componentObj, testNamespace, "", "", applicationName, true, constants.DefaultDockerBuildPipelineBundle)
+	Expect(err).NotTo(HaveOccurred())
+
+	return componentName, originalComponent
+}
+
+func cleanup(f framework.Framework, testNamespace, applicationName, componentName string) {
+	if !CurrentSpecReport().Failed() {
+		Expect(f.AsKubeAdmin.HasController.DeleteApplication(applicationName, testNamespace, false)).To(Succeed())
+		Expect(f.AsKubeAdmin.HasController.DeleteComponent(componentName, testNamespace, false)).To(Succeed())
+		integrationTestScenarios, err := f.AsKubeAdmin.IntegrationController.GetIntegrationTestScenarios(applicationName, testNamespace)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		for _, testScenario := range *integrationTestScenarios {
+			Expect(f.AsKubeAdmin.IntegrationController.DeleteIntegrationTestScenario(&testScenario, testNamespace)).To(Succeed())
+		}
+		Expect(f.SandboxController.DeleteUserSignup(f.UserName)).To(BeTrue())
+	}
+}

--- a/tests/integration-service/integration.go
+++ b/tests/integration-service/integration.go
@@ -29,7 +29,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 	var f *framework.Framework
 	var err error
 
-	var applicationName, componentName, testNamespace string
+	var prHeadSha string
 	var integrationTestScenario *integrationv1beta2.IntegrationTestScenario
 	var newIntegrationTestScenario *integrationv1beta2.IntegrationTestScenario
 	var timeout, interval time.Duration
@@ -37,6 +37,8 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 	var pipelineRun *pipeline.PipelineRun
 	var snapshot *appstudioApi.Snapshot
 	var snapshotPush *appstudioApi.Snapshot
+	var applicationName, componentName, componentBaseBranchName, pacBranchName, testNamespace string
+
 	AfterEach(framework.ReportFailure(&f))
 
 	Describe("with happy path for general flow of Integration service", Ordered, func() {
@@ -47,7 +49,8 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 			testNamespace = f.UserNamespace
 
 			applicationName = createApp(*f, testNamespace)
-			componentName, originalComponent = createComponent(*f, testNamespace, applicationName, componentGitSourceURLForGeneralIntegration)
+			originalComponent, componentName, pacBranchName, componentBaseBranchName = createComponent(*f, testNamespace, applicationName, componentRepoNameForGeneralIntegration, componentGitSourceURLForGeneralIntegration)
+
 			integrationTestScenario, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenario("", applicationName, testNamespace, gitURL, revision, pathInRepoPass)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
@@ -57,6 +60,16 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 				cleanup(*f, testNamespace, applicationName, componentName)
 
 				Expect(f.AsKubeAdmin.IntegrationController.DeleteSnapshot(snapshotPush, testNamespace)).To(Succeed())
+			}
+
+			// Delete new branches created by PaC and a testing branch used as a component's base branch
+			err = f.AsKubeAdmin.CommonController.Github.DeleteRef(componentRepoNameForGeneralIntegration, pacBranchName)
+			if err != nil {
+				Expect(err.Error()).To(ContainSubstring(referenceDoesntExist))
+			}
+			err = f.AsKubeAdmin.CommonController.Github.DeleteRef(componentRepoNameForGeneralIntegration, componentBaseBranchName)
+			if err != nil {
+				Expect(err.Error()).To(ContainSubstring(referenceDoesntExist))
 			}
 		})
 
@@ -81,6 +94,28 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 				Expect(pipelineRun.Annotations[snapshotAnnotation]).To(Equal(""))
 				Expect(f.AsKubeDeveloper.HasController.WaitForComponentPipelineToBeFinished(originalComponent, "",
 					f.AsKubeAdmin.TektonController, &has.RetryOptions{Retries: 2, Always: true}, pipelineRun)).To(Succeed())
+			})
+
+			It("should have a related PaC init PR created", func() {
+				timeout = time.Second * 300
+				interval = time.Second * 1
+
+				Eventually(func() bool {
+					prs, err := f.AsKubeAdmin.CommonController.Github.ListPullRequests(componentRepoNameForGeneralIntegration)
+					Expect(err).ShouldNot(HaveOccurred())
+
+					for _, pr := range prs {
+						if pr.Head.GetRef() == pacBranchName {
+							prHeadSha = pr.Head.GetSHA()
+							return true
+						}
+					}
+					return false
+				}, timeout, interval).Should(BeTrue(), fmt.Sprintf("timed out when waiting for init PaC PR (branch name '%s') to be created in %s repository", pacBranchName, componentRepoNameForStatusReporting))
+
+				// in case the first pipelineRun attempt has failed and was retried, we need to update the value of pipelineRun variable
+				pipelineRun, err = f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, prHeadSha)
+				Expect(err).ShouldNot(HaveOccurred())
 			})
 		})
 
@@ -192,7 +227,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 			testNamespace = f.UserNamespace
 
 			applicationName = createApp(*f, testNamespace)
-			componentName, originalComponent = createComponent(*f, testNamespace, applicationName, componentGitSourceURLForGeneralIntegration)
+			originalComponent, componentName, pacBranchName, componentBaseBranchName = createComponent(*f, testNamespace, applicationName, componentRepoNameForGeneralIntegration, componentGitSourceURLForGeneralIntegration)
 
 			integrationTestScenario, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenario("", applicationName, testNamespace, gitURL, revision, pathInRepoFail)
 			Expect(err).ShouldNot(HaveOccurred())
@@ -201,7 +236,16 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 		AfterAll(func() {
 			if !CurrentSpecReport().Failed() {
 				cleanup(*f, testNamespace, applicationName, componentName)
+			}
 
+			// Delete new branches created by PaC and a testing branch used as a component's base branch
+			err = f.AsKubeAdmin.CommonController.Github.DeleteRef(componentRepoNameForGeneralIntegration, pacBranchName)
+			if err != nil {
+				Expect(err.Error()).To(ContainSubstring(referenceDoesntExist))
+			}
+			err = f.AsKubeAdmin.CommonController.Github.DeleteRef(componentRepoNameForGeneralIntegration, componentBaseBranchName)
+			if err != nil {
+				Expect(err.Error()).To(ContainSubstring(referenceDoesntExist))
 			}
 		})
 
@@ -210,7 +254,28 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 			Expect(pipelineRun.Annotations[snapshotAnnotation]).To(Equal(""))
 			Expect(f.AsKubeDeveloper.HasController.WaitForComponentPipelineToBeFinished(originalComponent, "", f.AsKubeAdmin.TektonController,
 				&has.RetryOptions{Retries: 2, Always: true}, pipelineRun)).To(Succeed())
+		})
 
+		It("should have a related PaC init PR created", func() {
+			timeout = time.Second * 300
+			interval = time.Second * 1
+
+			Eventually(func() bool {
+				prs, err := f.AsKubeAdmin.CommonController.Github.ListPullRequests(componentRepoNameForGeneralIntegration)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				for _, pr := range prs {
+					if pr.Head.GetRef() == pacBranchName {
+						prHeadSha = pr.Head.GetSHA()
+						return true
+					}
+				}
+				return false
+			}, timeout, interval).Should(BeTrue(), fmt.Sprintf("timed out when waiting for init PaC PR (branch name '%s') to be created in %s repository", pacBranchName, componentRepoNameForStatusReporting))
+
+			// in case the first pipelineRun attempt has failed and was retried, we need to update the value of pipelineRun variable
+			pipelineRun, err = f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, prHeadSha)
+			Expect(err).ShouldNot(HaveOccurred())
 		})
 
 		It("checks if the BuildPipelineRun have the annotation of chains signed", func() {
@@ -315,7 +380,6 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(f.AsKubeAdmin.CommonController.HaveTestsSucceeded(snapshot)).To(BeFalse(), "expected tests to fail for snapshot %s/%s", snapshot.GetNamespace(), snapshot.GetName())
 			})
-
 		})
 
 		It("creates an snapshot of push event", func() {
@@ -343,9 +407,13 @@ func createApp(f framework.Framework, testNamespace string) string {
 	return applicationName
 }
 
-func createComponent(f framework.Framework, testNamespace, applicationName, componentRepoURL string) (string, *appstudioApi.Component) {
+func createComponent(f framework.Framework, testNamespace, applicationName, componentRepoName, componentRepoURL string) (*appstudioApi.Component, string, string, string) {
+	componentName := fmt.Sprintf("%s-%s", "test-component-pac", util.GenerateRandomString(6))
+	pacBranchName := constants.PaCPullRequestBranchPrefix + componentName
+	componentBaseBranchName := fmt.Sprintf("base-%s", util.GenerateRandomString(6))
 
-	componentName := fmt.Sprintf("integration-suite-test-component-git-source-%s", util.GenerateRandomString(6))
+	err := f.AsKubeAdmin.CommonController.Github.CreateRef(componentRepoName, componentDefaultBranch, componentRevision, componentBaseBranchName)
+	Expect(err).ShouldNot(HaveOccurred())
 
 	componentObj := appstudioApi.ComponentSpec{
 		ComponentName: componentName,
@@ -354,15 +422,16 @@ func createComponent(f framework.Framework, testNamespace, applicationName, comp
 			ComponentSourceUnion: appstudioApi.ComponentSourceUnion{
 				GitSource: &appstudioApi.GitSource{
 					URL: componentRepoURL,
+					Revision: componentBaseBranchName,
 				},
 			},
 		},
 	}
 
-	originalComponent, err := f.AsKubeAdmin.HasController.CreateComponent(componentObj, testNamespace, "", "", applicationName, true, constants.DefaultDockerBuildPipelineBundle)
+	originalComponent, err := f.AsKubeAdmin.HasController.CreateComponent(componentObj, testNamespace, "", "", applicationName, false, utils.MergeMaps(utils.MergeMaps(constants.ComponentPaCRequestAnnotation, constants.ImageControllerAnnotationRequestPublicRepo), constants.DefaultDockerBuildPipelineBundle))
 	Expect(err).NotTo(HaveOccurred())
 
-	return componentName, originalComponent
+	return originalComponent, componentName, pacBranchName, componentBaseBranchName
 }
 
 func cleanup(f framework.Framework, testNamespace, applicationName, componentName string) {

--- a/tests/integration-service/status-reporting-to-pullrequest.go
+++ b/tests/integration-service/status-reporting-to-pullrequest.go
@@ -3,23 +3,19 @@ package integration
 import (
 	"fmt"
 	"os"
-	"strings"
 	"time"
 
-	"github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/devfile/library/v2/pkg/util"
-	appstudioApi "github.com/konflux-ci/application-api/api/v1alpha1"
 	"github.com/konflux-ci/e2e-tests/pkg/clients/has"
 	"github.com/konflux-ci/e2e-tests/pkg/constants"
 	"github.com/konflux-ci/e2e-tests/pkg/framework"
 	"github.com/konflux-ci/e2e-tests/pkg/utils"
-	"github.com/konflux-ci/e2e-tests/pkg/utils/build"
+
+	appstudioApi "github.com/konflux-ci/application-api/api/v1alpha1"
 	integrationv1beta2 "github.com/konflux-ci/integration-service/api/v1beta2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	pipeline "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
-	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 var _ = framework.IntegrationServiceSuiteDescribe("Status Reporting of Integration tests", Label("integration-service", "github-status-reporting"), func() {
@@ -32,11 +28,9 @@ var _ = framework.IntegrationServiceSuiteDescribe("Status Reporting of Integrati
 	var timeout, interval time.Duration
 	var prHeadSha string
 	var snapshot *appstudioApi.Snapshot
-	var snapshotPush *appstudioApi.Snapshot
 	var component *appstudioApi.Component
-	var spaceRequest *v1alpha1.SpaceRequest
 	var pipelineRun, testPipelinerun *pipeline.PipelineRun
-	var integrationTestScenarioPass, integrationTestScenarioFail, integrationTestScenarioEnv *integrationv1beta2.IntegrationTestScenario
+	var integrationTestScenarioPass, integrationTestScenarioFail *integrationv1beta2.IntegrationTestScenario
 	var applicationName, componentName, componentBaseBranchName, pacBranchName, testNamespace string
 
 	AfterEach(framework.ReportFailure(&f))
@@ -63,9 +57,6 @@ var _ = framework.IntegrationServiceSuiteDescribe("Status Reporting of Integrati
 			integrationTestScenarioFail, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenario("", applicationName, testNamespace, gitURL, revision, pathInRepoFail)
 			Expect(err).ShouldNot(HaveOccurred())
 
-			integrationTestScenarioEnv, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenario("", applicationName, testNamespace, gitURL, revision, pathIntegrationPipelineWithEnv)
-			Expect(err).ShouldNot(HaveOccurred())
-
 			componentName = fmt.Sprintf("%s-%s", "test-component-pac", util.GenerateRandomString(6))
 			pacBranchName = constants.PaCPullRequestBranchPrefix + componentName
 			componentBaseBranchName = fmt.Sprintf("base-%s", util.GenerateRandomString(6))
@@ -88,7 +79,6 @@ var _ = framework.IntegrationServiceSuiteDescribe("Status Reporting of Integrati
 			if err != nil {
 				Expect(err.Error()).To(ContainSubstring(referenceDoesntExist))
 			}
-			Expect(build.CleanupWebhooks(f, componentRepoNameForStatusReporting)).ShouldNot(HaveOccurred())
 		})
 
 		When("a new Component with specified custom branch is created", Label("custom-branch"), func() {
@@ -126,16 +116,6 @@ var _ = framework.IntegrationServiceSuiteDescribe("Status Reporting of Integrati
 			})
 			It("does not contain an annotation with a Snapshot Name", func() {
 				Expect(pipelineRun.Annotations[snapshotAnnotation]).To(Equal(""))
-			})
-			It("verifies if the build PipelineRun contains the finalizer", func() {
-				Eventually(func() error {
-					pipelineRun, err = f.AsKubeDeveloper.IntegrationController.GetBuildPipelineRun(componentName, applicationName, testNamespace, true, "")
-					Expect(err).ShouldNot(HaveOccurred())
-					if !controllerutil.ContainsFinalizer(pipelineRun, pipelinerunFinalizerByIntegrationService) {
-						return fmt.Errorf("build pipelineRun %s/%s doesn't contain the finalizer: %s yet", pipelineRun.GetNamespace(), pipelineRun.GetName(), pipelinerunFinalizerByIntegrationService)
-					}
-					return nil
-				}, 1*time.Minute, 1*time.Second).Should(Succeed(), "timeout when waiting for finalizer to be added")
 			})
 			It("should lead to build PipelineRun finishing successfully", func() {
 				Expect(f.AsKubeAdmin.HasController.WaitForComponentPipelineToBeFinished(component,
@@ -183,23 +163,6 @@ var _ = framework.IntegrationServiceSuiteDescribe("Status Reporting of Integrati
 			It("checks if the Build PipelineRun got annotated with Snapshot name", func() {
 				Expect(f.AsKubeDeveloper.IntegrationController.WaitForBuildPipelineRunToGetAnnotated(testNamespace, applicationName, componentName, snapshotAnnotation)).To(Succeed())
 			})
-
-			It("verifies that the finalizer has been removed from the build pipelinerun", func() {
-				Eventually(func() error {
-					pipelineRun, err = f.AsKubeDeveloper.IntegrationController.GetBuildPipelineRun(componentName, applicationName, testNamespace, true, "")
-					Expect(err).ShouldNot(HaveOccurred())
-					if controllerutil.ContainsFinalizer(pipelineRun, pipelinerunFinalizerByIntegrationService) {
-						return fmt.Errorf("build pipelineRun %s/%s still contains the finalizer: %s", pipelineRun.GetNamespace(), pipelineRun.GetName(), pipelinerunFinalizerByIntegrationService)
-					}
-					return nil
-				}, 60*time.Second, 1*time.Second).Should(Succeed(), "timeout when waiting for finalizer to be removed")
-			})
-
-			It(fmt.Sprintf("checks if CronJob %s exists", spaceRequestCronJobName), func() {
-				spaceRequestCleanerCronJob, err := f.AsKubeAdmin.CommonController.GetCronJob(spaceRequestCronJobNamespace, spaceRequestCronJobName)
-				Expect(err).ShouldNot(HaveOccurred())
-				Expect(strings.Contains(spaceRequestCleanerCronJob.Name, spaceRequestCronJobName)).Should(BeTrue())
-			})
 		})
 
 		When("the Snapshot was created", func() {
@@ -213,11 +176,6 @@ var _ = framework.IntegrationServiceSuiteDescribe("Status Reporting of Integrati
 				Expect(err).ToNot(HaveOccurred())
 				Expect(testPipelinerun.Labels[snapshotAnnotation]).To(ContainSubstring(snapshot.Name))
 				Expect(testPipelinerun.Labels[scenarioAnnotation]).To(ContainSubstring(integrationTestScenarioFail.Name))
-
-				testPipelinerun, err = f.AsKubeDeveloper.IntegrationController.WaitForIntegrationPipelineToGetStarted(integrationTestScenarioEnv.Name, snapshot.Name, testNamespace)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(testPipelinerun.Labels[snapshotAnnotation]).To(ContainSubstring(snapshot.Name))
-				Expect(testPipelinerun.Labels[scenarioAnnotation]).To(ContainSubstring(integrationTestScenarioEnv.Name))
 			})
 		})
 
@@ -225,16 +183,6 @@ var _ = framework.IntegrationServiceSuiteDescribe("Status Reporting of Integrati
 			It("should eventually complete successfully", func() {
 				Expect(f.AsKubeAdmin.IntegrationController.WaitForIntegrationPipelineToBeFinished(integrationTestScenarioPass, snapshot, testNamespace)).To(Succeed(), fmt.Sprintf("Error when waiting for an integration pipelinerun for snapshot %s/%s to finish", testNamespace, snapshot.GetName()))
 				Expect(f.AsKubeAdmin.IntegrationController.WaitForIntegrationPipelineToBeFinished(integrationTestScenarioFail, snapshot, testNamespace)).To(Succeed(), fmt.Sprintf("Error when waiting for an integration pipelinerun for snapshot %s/%s to finish", testNamespace, snapshot.GetName()))
-				Expect(f.AsKubeAdmin.IntegrationController.WaitForIntegrationPipelineToBeFinished(integrationTestScenarioEnv, snapshot, testNamespace)).To(Succeed(), fmt.Sprintf("Error when waiting for an integration pipelinerun for snapshot %s/%s to finish", testNamespace, snapshot.GetName()))
-			})
-
-			It("checks if space request is created in namespace", func() {
-				spaceRequestsList, err := f.AsKubeAdmin.GitOpsController.GetSpaceRequests(testNamespace)
-				Expect(err).ShouldNot(HaveOccurred())
-
-				Expect(spaceRequestsList.Items).To(HaveLen(1), "Expected spaceRequestsList.Items to have at least one item")
-				spaceRequest = &spaceRequestsList.Items[0]
-				Expect(strings.Contains(spaceRequest.Name, spaceRequestNamePrefix)).Should(BeTrue())
 			})
 		})
 
@@ -252,99 +200,6 @@ var _ = framework.IntegrationServiceSuiteDescribe("Status Reporting of Integrati
 			It("eventually leads to the status reported at Checks tab for the failed Integration PipelineRun", func() {
 				Expect(f.AsKubeAdmin.CommonController.Github.GetCheckRunConclusion(integrationTestScenarioFail.Name, componentRepoNameForStatusReporting, prHeadSha, prNumber)).To(Equal(constants.CheckrunConclusionFailure))
 			})
-
-			It("checks if the finalizer was removed from all of the related Integration pipelineRuns", func() {
-				Expect(f.AsKubeDeveloper.IntegrationController.WaitForFinalizerToGetRemovedFromAllIntegrationPipelineRuns(testNamespace, applicationName, snapshot)).To(Succeed())
-			})
-
-			It("checks that when deleting integration test scenario pipelineRun, spaceRequest is deleted too", func() {
-				testPipelinerun, err = f.AsKubeAdmin.IntegrationController.GetIntegrationPipelineRun(integrationTestScenarioEnv.Name, snapshot.Name, testNamespace)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(f.AsKubeDeveloper.TektonController.DeletePipelineRun(testPipelinerun.Name, testPipelinerun.Namespace)).To(Succeed())
-
-				timeout = time.Second * 200
-				interval = time.Second * 5
-				Eventually(func() error {
-					currentSpaceRequest, err := f.AsKubeAdmin.GitOpsController.GetSpaceRequest(testNamespace, spaceRequest.Name)
-					if err != nil {
-						if k8sErrors.IsNotFound(err) {
-							return nil
-						}
-						return fmt.Errorf("failed to get %s/%s spaceRequest: %+v", currentSpaceRequest.Namespace, currentSpaceRequest.Name, err)
-					}
-					return fmt.Errorf("spaceRequest %s/%s still exists", currentSpaceRequest.Namespace, currentSpaceRequest.Name)
-				}, timeout, interval).Should(Succeed())
-
-			})
-		})
-
-		It("creates a ReleasePlan", func() {
-			_, err = f.AsKubeAdmin.ReleaseController.CreateReleasePlan(autoReleasePlan, testNamespace, applicationName, targetReleaseNamespace, "", nil, nil)
-			Expect(err).ShouldNot(HaveOccurred())
-			testScenarios, err := f.AsKubeAdmin.IntegrationController.GetIntegrationTestScenarios(applicationName, testNamespace)
-			Expect(err).ShouldNot(HaveOccurred())
-			for _, testScenario := range *testScenarios {
-				GinkgoWriter.Printf("IntegrationTestScenario %s is found\n", testScenario.Name)
-			}
-		})
-
-		It("creates an snapshot of push event", func() {
-			sampleImage := "quay.io/redhat-appstudio/sample-image@sha256:841328df1b9f8c4087adbdcfec6cc99ac8308805dea83f6d415d6fb8d40227c1"
-			snapshotPush, err = f.AsKubeAdmin.IntegrationController.CreateSnapshotWithImage(componentName, applicationName, testNamespace, sampleImage)
-			Expect(err).ShouldNot(HaveOccurred())
-		})
-
-		When("An snapshot of push event is created", func() {
-			It("checks if the global candidate is updated after push event", func() {
-				timeout = time.Second * 600
-				interval = time.Second * 10
-				Eventually(func() error {
-					snapshotPush, err = f.AsKubeAdmin.IntegrationController.GetSnapshot(snapshotPush.Name, "", "", testNamespace)
-					Expect(err).ShouldNot(HaveOccurred())
-
-					latestComponent, err := f.AsKubeAdmin.HasController.GetComponentByApplicationName(applicationName, testNamespace)
-					Expect(err).ShouldNot(HaveOccurred())
-					Expect(latestComponent.Spec.ContainerImage).ToNot(Equal(component.Spec.ContainerImage))
-					return nil
-
-				}, timeout, interval).Should(Succeed(), fmt.Sprintf("time out when waiting for updating the global candidate in %s namespace", testNamespace))
-			})
-
-			It("checks if all of the integrationPipelineRuns created by push event passed", Label("slow"), func() {
-				Expect(f.AsKubeAdmin.IntegrationController.WaitForAllIntegrationPipelinesToBeFinished(testNamespace, applicationName, snapshotPush)).To(Succeed(), "Error when waiting for one of the integration pipelines to finish in %s namespace", testNamespace)
-			})
-
-			It("checks if a Release is created successfully", func() {
-				timeout = time.Second * 60
-				interval = time.Second * 5
-				Eventually(func() error {
-					_, err := f.AsKubeAdmin.ReleaseController.GetReleases(testNamespace)
-					return err
-				}, timeout, interval).Should(Succeed(), fmt.Sprintf("time out when waiting for release created for snapshot %s/%s", snapshotPush.GetNamespace(), snapshotPush.GetName()))
-			})
 		})
 	})
 })
-
-func createApp(f framework.Framework, testNamespace string) string {
-	applicationName := fmt.Sprintf("integ-app-%s", util.GenerateRandomString(4))
-
-	_, err := f.AsKubeAdmin.HasController.CreateApplication(applicationName, testNamespace)
-	Expect(err).NotTo(HaveOccurred())
-
-	return applicationName
-}
-
-func cleanup(f framework.Framework, testNamespace, applicationName, componentName string) {
-	if !CurrentSpecReport().Failed() {
-		Expect(f.AsKubeAdmin.HasController.DeleteApplication(applicationName, testNamespace, false)).To(Succeed())
-		Expect(f.AsKubeAdmin.HasController.DeleteComponent(componentName, testNamespace, false)).To(Succeed())
-		integrationTestScenarios, err := f.AsKubeAdmin.IntegrationController.GetIntegrationTestScenarios(applicationName, testNamespace)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		for _, testScenario := range *integrationTestScenarios {
-			Expect(f.AsKubeAdmin.IntegrationController.DeleteIntegrationTestScenario(&testScenario, testNamespace)).To(Succeed())
-		}
-		Expect(f.SandboxController.DeleteUserSignup(f.UserName)).To(BeTrue())
-	}
-}


### PR DESCRIPTION
# Description

* We are unsure of the implications of merging 3 of our test suites into 1.
* This commit reverts their deletion to ensure we return to where we were.
* Now, the:
   *  `integration.go` suite uses [redhat-appstudio-qe/hacbs-test-project-integration](https://github.com/redhat-appstudio-qe/hacbs-test-project-integration) repo
   * `integration-with-env.go` uses [redhat-appstudio-qe/test-integration-with-env](https://github.com/redhat-appstudio-qe/test-integration-with-env) repo
   * `status-reporting-to-pullrequest.go` uses [redhat-appstudio-qe/test-integration-status-report](https://github.com/redhat-appstudio-qe/test-integration-status-report) repo
* Refactor the tests to use the common [createComponent](https://github.com/konflux-ci/e2e-tests/pull/1325/files#diff-fdb9bad9e6467c3d33fe63e08637192c699c48d9e28c1d45772fdb2546810df6R410) function, to reduce code duplication and simplify the tests.

## Issue ticket number and link

[STONEINTG-1028](https://issues.redhat.com//browse/STONEINTG-1028)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Locally tested and also verified by the CI :D

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
