### PR TITLE
chore: update OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -24,6 +24,7 @@ aliases:
   ec-team:
   - simonbaird
   - lcarva
+  - mbestavros
   - zregvart
   - joejstuart
   - robnester-rh
@@ -34,6 +35,8 @@ aliases:
   - Josh-Everett
   - sonam1412
   - 14rcole
+  - chipspeak
+  - jencull
   release-team:
   - davidmogar
   - scoheb

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -6,15 +6,11 @@ aliases:
   - flacatus
   - psturc
   - jkopriva
-  - sawood14012
-  - albarbaro
   - kasemAlem
   - jinqi7
   - tisutisu
-  - srivickynesh
   - cuipinghuo
   - dheerajodha
-  - naftalysh
   - Dannyb48
   - pmacik
   - siddardh-ra
@@ -25,7 +21,6 @@ aliases:
   - mmorhun
   - rcerven
   - tkdchen
-  - stuartwdouglas
   ec-team:
   - simonbaird
   - lcarva
@@ -38,7 +33,6 @@ aliases:
   - hongweiliu17
   - Josh-Everett
   - sonam1412
-  - MartinBasti
   - 14rcole
   release-team:
   - davidmogar

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -24,7 +24,6 @@ aliases:
   ec-team:
   - simonbaird
   - lcarva
-  - mbestavros
   - zregvart
   - joejstuart
   - robnester-rh

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -39,7 +39,6 @@ aliases:
   - jencull
   release-team:
   - davidmogar
-  - scoheb
   - theflockers
   - happybhati
   - johnbieren


### PR DESCRIPTION
# Description

Remove people from `OWNERS_ALIASES` who are no longer e2e-tests owners. And add new members

## Issue ticket number and link
[KONFLUX-3992](https://issues.redhat.com/browse/KONFLUX-3992)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
N/A

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
