### PR TITLE
fix(STONEINTG-1028): correct the name of GL repo

### DIFF
--- a/magefiles/rulesengine/repos/e2e_repo.go
+++ b/magefiles/rulesengine/repos/e2e_repo.go
@@ -236,10 +236,10 @@ var IntegrationTestsFileChangeRule = rulesengine.Rule{Name: "E2E PR Integration 
 	})}}
 
 var IntegrationTestsConstFileChangeRule = rulesengine.Rule{Name: "E2E PR Integration TestFile Change Rule",
-	Description: "Map integration tests files when integration const files are changed in the e2e-repo PR",
+	Description: "Map all integration tests files when integration const files are changed in the e2e-repo PR",
 	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) bool {
 
-		return len(rctx.DiffFiles.FilterByDirGlob("tests/integration-*/const.go")) != 0 && len(rctx.DiffFiles.FilterByDirGlob("tests/integration-*/*.go")) == 0
+		return len(rctx.DiffFiles.FilterByDirGlob("tests/integration-*/const.go")) != 0
 	}),
 	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
 

--- a/tests/integration-service/const.go
+++ b/tests/integration-service/const.go
@@ -45,6 +45,6 @@ var (
 	componentGitSourceURLForIntegrationWithEnv    = fmt.Sprintf("https://github.com/%s/%s", utils.GetEnv(constants.GITHUB_E2E_ORGANIZATION_ENV, "redhat-appstudio-qe"), componentRepoNameForIntegrationWithEnv)
 	componentGitSourceURLForStatusReporting       = fmt.Sprintf("https://github.com/%s/%s", utils.GetEnv(constants.GITHUB_E2E_ORGANIZATION_ENV, "redhat-appstudio-qe"), componentRepoNameForStatusReporting)
 	gitlabOrg                                     = utils.GetEnv(constants.GITLAB_QE_ORG_ENV, constants.DefaultGitLabQEOrg)
-	gitlabProjectIDForStatusReporting             = fmt.Sprintf("%s/%s", gitlabOrg, componentRepoNameForStatusReporting)
-	gitlabComponentGitSourceURLForStatusReporting = fmt.Sprintf("https://gitlab.com/%s/%s", gitlabOrg, componentRepoNameForStatusReporting)
+	gitlabProjectIDForStatusReporting             = fmt.Sprintf("%s/%s", gitlabOrg, componentRepoNameForGeneralIntegration)
+	gitlabComponentGitSourceURLForStatusReporting = fmt.Sprintf("https://gitlab.com/%s/%s", gitlabOrg, componentRepoNameForGeneralIntegration)
 )


### PR DESCRIPTION
# Description

* The GitLab e2e-test of Integration service was failing because the test was creating a component using an non-existent GitLab repo.
* This commit updates the repo name.


## Issue ticket number and link

[STONEINTG-1028](https://issues.redhat.com//browse/STONEINTG-1028)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
