### PR TITLE
fix(KFLUXBUGS-1416): FBC fragment released to the wrong OCP version

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -167,9 +167,9 @@ const (
 
 	ReleasePipelineImageRef = "quay.io/hacbs-release/pipeline-release:0.20"
 
-	FromIndex   = "registry-proxy.engineering.redhat.com/rh-osbs/iib-preview-rhtap:v4.13"
-	TargetIndex = "quay.io/redhat/redhat----preview-operator-index:v4.13"
-	BinaryImage = "registry.redhat.io/openshift4/ose-operator-registry:v4.13"
+	FromIndex   = "registry-proxy.engineering.redhat.com/rh-osbs/iib-preview-rhtap:{{ OCP_VERSION }}"
+	TargetIndex = "quay.io/redhat/redhat----preview-operator-index:{{ OCP_VERSION }}"
+	BinaryImage = "registry.redhat.io/openshift4/ose-operator-registry:{{ OCP_VERSION }}"
 
 	StrategyConfigsRepo          = "strategy-configs"
 	StrategyConfigsDefaultBranch = "main"

--- a/tests/release/const.go
+++ b/tests/release/const.go
@@ -59,5 +59,5 @@ var ManagednamespaceSecret = []corev1.ObjectReference{
 // Pipelines variables
 var (
 	RelSvcCatalogURL      string = utils.GetEnv("RELEASE_SERVICE_CATALOG_URL", "https://github.com/konflux-ci/release-service-catalog")
-	RelSvcCatalogRevision string = utils.GetEnv("RELEASE_SERVICE_CATALOG_REVISION", "development")
+	RelSvcCatalogRevision string = utils.GetEnv("RELEASE_SERVICE_CATALOG_REVISION", "staging")
 )

--- a/tests/release/const.go
+++ b/tests/release/const.go
@@ -59,5 +59,5 @@ var ManagednamespaceSecret = []corev1.ObjectReference{
 // Pipelines variables
 var (
 	RelSvcCatalogURL      string = utils.GetEnv("RELEASE_SERVICE_CATALOG_URL", "https://github.com/konflux-ci/release-service-catalog")
-	RelSvcCatalogRevision string = utils.GetEnv("RELEASE_SERVICE_CATALOG_REVISION", "staging")
+	RelSvcCatalogRevision string = utils.GetEnv("RELEASE_SERVICE_CATALOG_REVISION", "development")
 )


### PR DESCRIPTION
This commit adds the placeholder {{ OCP_VERSION }} to the indexes used by the FBC Release pipeline e2e test.

Required by https://github.com/konflux-ci/release-service-catalog/pull/502

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
