### PR TITLE
fix: unregister PaC server after konflux-ci test run

### DIFF
--- a/integration-tests/scripts/konflux-e2e-runner.sh
+++ b/integration-tests/scripts/konflux-e2e-runner.sh
@@ -2,20 +2,19 @@
 
 function postActions() {
     local EXIT_CODE=$?
-    
-    cd /workspace || exit 1
-
-    # Save artifacts
-    oras login -u "$ORAS_USERNAME" -p "$ORAS_PASSWORD" quay.io
-    echo '{"doc": "README.md"}' > config.json
-    
-    oras push "$ORAS_CONTAINER" --config config.json:application/vnd.acme.rocket.config.v1+json \
-        ./test-artifacts/:application/vnd.acme.rocket.docs.layer.v1+tar
 
     # Unregister PaC Server from SprayProxy
     if [ "$UNREGISTER_PAC" == "true" ]; then
         make ci/sprayproxy/unregister || true
     fi
+
+    # Save artifacts
+    cd /workspace || exit 1
+    oras login -u "$ORAS_USERNAME" -p "$ORAS_PASSWORD" quay.io
+    echo '{"doc": "README.md"}' > config.json
+    
+    oras push "$ORAS_CONTAINER" --config config.json:application/vnd.acme.rocket.config.v1+json \
+        ./test-artifacts/:application/vnd.acme.rocket.docs.layer.v1+tar
     
     exit "$EXIT_CODE"
 }


### PR DESCRIPTION
# Description

openshift-ci takes care of unregistering PaC server in a [separate step](https://github.com/openshift/release/blob/1cafdb8605e559c8b2f174d25927eaa401bbf212/ci-operator/step-registry/konflux-ci/unregister-sprayproxy/konflux-ci-unregister-sprayproxy-commands.sh#L16). So we need to update the e2e script to take care of it

## Issue ticket number and link
N/A

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
in CI 🤷 

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
