### PR TITLE
fix(KFLUXBUGS-1533): GitLab build PLR fails on retrigger due to empty projectID

### DIFF
--- a/pkg/clients/has/components.go
+++ b/pkg/clients/has/components.go
@@ -407,7 +407,8 @@ func (h *HasController) RetriggerComponentPipelineRun(component *appservice.Comp
 		}
 
 		if gitProvider == "gitlab" {
-			projectID := utils.GetEnv(constants.GITLAB_PROJECT_ID_ENV, "")
+			gitlabOrg := utils.GetEnv(constants.GITLAB_QE_ORG_ENV, constants.DefaultGitLabQEOrg)
+			projectID := fmt.Sprintf("%s/%s", gitlabOrg, constants.DefaultGitLabRepoName)
 			_, err := h.GitLab.CreateFile(projectID, util.GenerateRandomString(5), "test", branchName)
 			if err != nil {
 				return "", fmt.Errorf("failed to retrigger PipelineRun %s in %s namespace: %+v", pr.GetName(), pr.GetNamespace(), err)

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -141,8 +141,9 @@ const (
 
 	DefaultQuayOrg = "redhat-appstudio-qe"
 
-	DefaultGitLabAPIURL = "https://gitlab.com/api/v4"
-	DefaultGitLabQEOrg  = "konflux-qe"
+	DefaultGitLabAPIURL   = "https://gitlab.com/api/v4"
+	DefaultGitLabQEOrg    = "konflux-qe"
+	DefaultGitLabRepoName = "hacbs-test-project-integration"
 
 	RegistryAuthSecretName = "redhat-appstudio-registry-pull-secret"
 	ComponentSecretName    = "comp-secret"


### PR DESCRIPTION
# Description

* When a build PLR, due to some reason, fails, we have a util function that retriggers it if we like.
* But when a GitLab-based build PLR fails, that retrigger function throws an error.
* This is because the projectID, used to create a dummy file in the comp branch, is an empty string.
* This PR fixes this situation by pointing the projectID to the 'hacbs-test-project-integration' GitLab repo

Note: This does mean that when a different GitLab repo is used as a component URL and it fails on its 1st attempt, then the retrigger call would fail too due to the URL conflict with the 'hacbs-test-project-integration' GitLab repo.

## Issue ticket number and link

[KFLUXBUGS-1533](https://issues.redhat.com/browse/KFLUXBUGS-1533)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
