### PR TITLE
chore: update GH repo name to prevent auto-cleanup

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -96,9 +96,9 @@ In that case, before you run the test, make sure you have created
   * https://github.com/redhat-appstudio-qe/devfile-sample-hello-world (for running build-service tests)
   * https://github.com/redhat-appstudio-qe/hacbs-test-project (for konflux-demo test)
   * https://github.com/redhat-appstudio-qe/strategy-configs (for konflux-demo test)
-  * https://github.com/redhat-appstudio-qe/hacbs-test-project-integration (for integration test)
-  * https://github.com/redhat-appstudio-qe/test-integration-status-report (for status-reporting-to-pullrequest test)
-  * https://github.com/redhat-appstudio-qe/test-integration-with-env (for integration-with-env test)
+  * https://github.com/redhat-appstudio-qe/konflux-test-integration (for integration test)
+  * https://github.com/redhat-appstudio-qe/konflux-test-integration-with-env (for integration-with-env test)
+  * https://github.com/redhat-appstudio-qe/konflux-test-integration-status-report (for status-reporting-to-pullrequest test)
 
 Note: All Environments used in all e2e-tests are in [default.env](../default.env) file. In case you need to run a specific tests, not all environments are necessary to be defined.
 

--- a/tests/integration-service/const.go
+++ b/tests/integration-service/const.go
@@ -20,6 +20,7 @@ const (
 	componentRepoNameForGeneralIntegration    = "konflux-test-integration"
 	componentRepoNameForIntegrationWithEnv    = "konflux-test-integration-with-env"
 	componentRepoNameForStatusReporting       = "konflux-test-integration-status-report"
+	gitlabComponentRepoName                   = "hacbs-test-project-integration"
 	componentDefaultBranch                    = "main"
 	componentRevision                         = "34da5a8f51fba6a8b7ec75a727d3c72ebb5e1274"
 	referenceDoesntExist                      = "Reference does not exist"
@@ -45,6 +46,6 @@ var (
 	componentGitSourceURLForIntegrationWithEnv    = fmt.Sprintf("https://github.com/%s/%s", utils.GetEnv(constants.GITHUB_E2E_ORGANIZATION_ENV, "redhat-appstudio-qe"), componentRepoNameForIntegrationWithEnv)
 	componentGitSourceURLForStatusReporting       = fmt.Sprintf("https://github.com/%s/%s", utils.GetEnv(constants.GITHUB_E2E_ORGANIZATION_ENV, "redhat-appstudio-qe"), componentRepoNameForStatusReporting)
 	gitlabOrg                                     = utils.GetEnv(constants.GITLAB_QE_ORG_ENV, constants.DefaultGitLabQEOrg)
-	gitlabProjectIDForStatusReporting             = fmt.Sprintf("%s/%s", gitlabOrg, componentRepoNameForGeneralIntegration)
-	gitlabComponentGitSourceURLForStatusReporting = fmt.Sprintf("https://gitlab.com/%s/%s", gitlabOrg, componentRepoNameForGeneralIntegration)
+	gitlabProjectIDForStatusReporting             = fmt.Sprintf("%s/%s", gitlabOrg, gitlabComponentRepoName)
+	gitlabComponentGitSourceURLForStatusReporting = fmt.Sprintf("https://gitlab.com/%s/%s", gitlabOrg, gitlabComponentRepoName)
 )

--- a/tests/integration-service/const.go
+++ b/tests/integration-service/const.go
@@ -17,9 +17,9 @@ const (
 	autoReleasePlan                = "auto-releaseplan"
 	targetReleaseNamespace         = "default"
 
-	componentRepoNameForGeneralIntegration    = "hacbs-test-project-integration"
-	componentRepoNameForIntegrationWithEnv    = "test-integration-with-env"
-	componentRepoNameForStatusReporting       = "test-integration-status-report"
+	componentRepoNameForGeneralIntegration    = "konflux-test-integration"
+	componentRepoNameForIntegrationWithEnv    = "konflux-test-integration-with-env"
+	componentRepoNameForStatusReporting       = "konflux-test-integration-status-report"
 	componentDefaultBranch                    = "main"
 	componentRevision                         = "34da5a8f51fba6a8b7ec75a727d3c72ebb5e1274"
 	referenceDoesntExist                      = "Reference does not exist"

--- a/tests/integration-service/gitlab-integration-reporting.go
+++ b/tests/integration-service/gitlab-integration-reporting.go
@@ -103,9 +103,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Gitlab Status Reporting of In
 				Expect(f.AsKubeAdmin.CommonController.Gitlab.DeleteBranch(projectID, componentBaseBranchName)).NotTo(HaveOccurred())
 				Expect(f.AsKubeAdmin.CommonController.Gitlab.DeleteWebhooks(projectID, f.ClusterAppDomain)).NotTo(HaveOccurred())
 				Expect(f.SandboxController.DeleteUserSignup(f.UserName)).To(BeTrue())
-
 			}
-
 		})
 
 		When("a new Component with specified custom branch is created", Label("custom-branch"), func() {


### PR DESCRIPTION
# Description

* the previous repo names matched [the regex string](https://github.com/konflux-ci/e2e-tests/blob/ef7f3a7b3f5e1e495ecf415f151a5b573d633109/magefiles/magefile.go#L58) that which is used to delete stale GH repos.
* so this commit, renames the repos in a way to not get matched with it
* here are the new repos:
   * https://github.com/redhat-appstudio-qe/konflux-test-integration
   * https://github.com/redhat-appstudio-qe/konflux-test-integration-with-env
   * https://github.com/redhat-appstudio-qe/konflux-test-integration-status-report

## Issue ticket number and link

[STONEINTG-1028](https://issues.redhat.com/browse/STONEINTG-1028)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I tested the new repo names on regex101.com with [this regex expression](https://github.com/konflux-ci/e2e-tests/blob/ef7f3a7b3f5e1e495ecf415f151a5b573d633109/magefiles/magefile.go#L58) which is used to auto-delete GH repos, and the new names don't get matched.

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
