### PR TITLE
fix: do not overwrite the global public key

### DIFF
--- a/tests/release/service/happy_path.go
+++ b/tests/release/service/happy_path.go
@@ -67,23 +67,14 @@ var _ = framework.ReleaseServiceSuiteDescribe("Release service happy path", Labe
                                         "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEocSG/SnE0vQ20wRfPltlXrY4Ib9B\n" +
                                         "CRnFUCg/fndZsXdz0IX5sfzIyspizaTbu4rapV85KirmSBU6XUaLY347xg==\n" +
                                         "-----END PUBLIC KEY-----")
-/*
-		releasePublicKey := []byte(os.Getenv("RELEASE_PUBLIC_KEY"))
-		Expect(releasePublicKey).ToNot(BeEmpty())
-
-		releasePublicKeyDecoded, err := base64.StdEncoding.DecodeString(string(releasePublicKey))
-		Expect(err).ToNot(HaveOccurred())
-*/
 		Expect(fw.AsKubeAdmin.TektonController.CreateOrUpdateSigningSecret(
 			releasePublicKeyDecoded, releasecommon.PublicSecretNameAuth, managedNamespace)).To(Succeed())
-		Expect(fw.AsKubeAdmin.TektonController.CreateOrUpdateSigningSecret(
-			releasePublicKeyDecoded, "public-key", constants.TEKTON_CHAINS_NS)).To(Succeed())
 
 		defaultEcPolicy, err := fw.AsKubeAdmin.TektonController.GetEnterpriseContractPolicy("default", "enterprise-contract-service")
 		Expect(err).NotTo(HaveOccurred())
 		defaultEcPolicySpec := ecp.EnterpriseContractPolicySpec{
 			Description: "Red Hat's enterprise requirements",
-			PublicKey:   "k8s://openshift-pipelines/public-key",
+			PublicKey:   fmt.Sprintf("k8s://%s/%s", managedNamespace, releasecommon.PublicSecretNameAuth),
 			Sources:     defaultEcPolicy.Spec.Sources,
 			Configuration: &ecp.EnterpriseContractPolicyConfiguration{
 				Collections: []string{"@slsa3"},


### PR DESCRIPTION
# Description

We should not be replacing the global public key, there are tests that rely that the `public-key` Secret corresponds to the `signing-secrets` Secret in the `openshift-pipelines` namespace.

## Issue ticket number and link

[KFLUXBUGS-1555](https://issues.redhat.com/browse/KFLUXBUGS-1555)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

It was not

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
