### PR TITLE
feat: e2e-tests repo CI rule chain

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.25.2
 	github.com/aws/aws-sdk-go-v2/config v1.27.4
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.135.0
+	github.com/bmatcuk/doublestar/v4 v4.6.1
 	github.com/codeready-toolchain/api v0.0.0-20231217224957-34f7cb3fcbf7
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20220523142428-2558e76260fb
 	github.com/codeready-toolchain/toolchain-e2e v0.0.0-20220525131508-60876bfb99d3
@@ -126,7 +127,6 @@ require (
 	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/blendle/zapdriver v1.3.1 // indirect
-	github.com/bmatcuk/doublestar/v4 v4.6.1 // indirect
 	github.com/bombsimon/logrusr/v2 v2.0.1 // indirect
 	github.com/bradleyfalzon/ghinstallation/v2 v2.10.0 // indirect
 	github.com/census-instrumentation/opencensus-proto v0.4.1 // indirect

--- a/magefiles/rulesengine/engine/engine.go
+++ b/magefiles/rulesengine/engine/engine.go
@@ -7,11 +7,17 @@ import (
 
 var MageEngine = rulesengine.RuleEngine{
 	"tests": {
-		"e2e-repo":          repos.E2ETestRulesCatalog,
-		"infra-deployments": repos.InfraDeploymentsRulesCatalog,
-		"release-catalog":   repos.ReleaseServiceCatalogTestRulesCatalog,
+		"e2e-repo":                repos.E2ETestRulesCatalog,
+		"infra-deployments":       repos.InfraDeploymentsRulesCatalog,
+		"release-service-catalog": repos.ReleaseServiceCatalogTestRulesCatalog,
 	},
 	"demo": {
 		"local-workflow": repos.DemoCatalog,
+	},
+
+	"ci": {
+		"e2e-repo": repos.E2ECIChainCatalog,
+		// TODO: to be implemented in a follow-up PR
+		//"infra-deployments": repos.InfraDeploymentsCIChainCatalog,
 	},
 }

--- a/magefiles/rulesengine/readme.md
+++ b/magefiles/rulesengine/readme.md
@@ -100,7 +100,7 @@ This will help reuse existing rules to create broader flows.
 var InfraDeploymentsTestRulesCatalog = rulesengine.RuleCatalog{
 	rulesengine.Rule{Name: "Infra Deployments Default Test Execution",
 		Description: "Run the default test suites which include the demo and components suites.",
-		Condition:    rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) bool {
+		Condition:    rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) (bool, error) {
 			if rctx.RepoName == "infra-deployments" {
 				return true
 			}
@@ -117,7 +117,7 @@ var InfraDeploymentsTestRulesCatalog = rulesengine.RuleCatalog{
 
  ### Registering a rule catalog to the engine
 
- Here I've created a catagory called tests within the MageEngine and I've assigned infra-deployments catalog to the infra-deployments key
+ Here I've created a category called tests within the MageEngine and I've assigned infra-deployments catalog to the infra-deployments key
  under the tests category
 
  ```go
@@ -172,7 +172,7 @@ rulesengine.Rule{Name: "Release Catalog PR paired Test Execution",
 
 ...
 
-var isRehearse = func(rctx *rulesengine.RuleCtx) bool {
+var isRehearse = func(rctx *rulesengine.RuleCtx) (bool, error) {
 	if strings.Contains(rctx.JobName, "rehearse") {
 		return true
 	}
@@ -181,7 +181,7 @@ var isRehearse = func(rctx *rulesengine.RuleCtx) bool {
 }
 
 // Demo of func isPRPairingRequired() for testing purposes
-var isPaired = func(rctx *rulesengine.RuleCtx) bool {
+var isPaired = func(rctx *rulesengine.RuleCtx) (bool, error) {
 	if true {
 		return true
 	}
@@ -190,7 +190,7 @@ var isPaired = func(rctx *rulesengine.RuleCtx) bool {
 }
 
 
-func releaseCatalogRepoCondition(rctx *rulesengine.RuleCtx) bool {
+func releaseCatalogRepoCondition(rctx *rulesengine.RuleCtx) (bool, error) {
 
 	if rctx.RepoName == "release-service-catalog" {
 		return true

--- a/magefiles/rulesengine/repos/common.go
+++ b/magefiles/rulesengine/repos/common.go
@@ -1,10 +1,34 @@
 package repos
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/devfile/library/v2/pkg/util"
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	remoteimg "github.com/google/go-containerregistry/pkg/v1/remote"
+	gh "github.com/google/go-github/v44/github"
+	"github.com/konflux-ci/e2e-tests/magefiles/installation"
 	"github.com/konflux-ci/e2e-tests/magefiles/rulesengine"
+	"github.com/konflux-ci/e2e-tests/pkg/clients/slack"
+	"github.com/konflux-ci/e2e-tests/pkg/clients/sprayproxy"
+	"github.com/konflux-ci/e2e-tests/pkg/constants"
+	"github.com/konflux-ci/e2e-tests/pkg/utils"
+	"github.com/konflux-ci/e2e-tests/pkg/utils/tekton"
 	"github.com/magefile/mage/sh"
 	gtypes "github.com/onsi/ginkgo/v2/types"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog"
+	"sigs.k8s.io/yaml"
+
+	tektonapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 )
 
 func ExecuteTestAction(rctx *rulesengine.RuleCtx) error {
@@ -13,6 +37,13 @@ func ExecuteTestAction(rctx *rulesengine.RuleCtx) error {
 	the command args i.e. '--ginkgo.xx' || '--test.xx' || '--go.xx'
 	we let ginkgo handle that when we actually run the ginkgo cmd.
 	We just want the user ginkgo CLI flags we can pass to ginkgo command */
+
+	if rctx.DryRun {
+		rctx.Parallel = false
+	} else {
+		// Set the number of parallel test processes
+		rctx.CLIConfig.Procs = 20
+	}
 
 	var suiteConfig = rctx.SuiteConfig
 	var reporterConfig = rctx.ReporterConfig
@@ -55,4 +86,425 @@ func ExecuteTestAction(rctx *rulesengine.RuleCtx) error {
 	argsToRun = append(argsToRun, "./cmd", "--")
 	return sh.RunV("ginkgo", argsToRun...)
 
+}
+
+func IsPeriodicJob(rctx *rulesengine.RuleCtx) (bool, error) {
+
+	return rctx.JobType == "periodic", nil
+}
+
+func IsRehearseJob(rctx *rulesengine.RuleCtx) (bool, error) {
+
+	return strings.Contains(rctx.JobName, "rehearse"), nil
+}
+
+func IsSprayProxyRequired(rctx *rulesengine.RuleCtx) (bool, error) {
+
+	return rctx.RequiresSprayProxyRegistering, nil
+}
+
+func IsMultiPlatformConfigRequired(rctx *rulesengine.RuleCtx) (bool, error) {
+
+	return rctx.RequiresMultiPlatformTests, nil
+}
+
+func IsLoadTestJob(rctx *rulesengine.RuleCtx) (bool, error) {
+
+	return strings.Contains(rctx.JobName, "-load-test"), nil
+}
+
+func IsSprayProxyHostSet(rctx *rulesengine.RuleCtx) (bool, error) {
+
+	if rctx.DryRun {
+		klog.Info("checking if env var QE_SPRAYPROXY_HOST is set")
+		return true, nil
+	}
+
+	if os.Getenv("QE_SPRAYPROXY_HOST") == "" {
+		return false, fmt.Errorf("env var QE_SPRAYPROXY_HOST is not set")
+	}
+
+	return true, nil
+}
+
+func IsSprayProxyTokenSet(rctx *rulesengine.RuleCtx) (bool, error) {
+
+	if rctx.DryRun {
+		klog.Info("checking if env var QE_SPRAYPROXY_TOKEN is set")
+		return true, nil
+	}
+
+	if os.Getenv("QE_SPRAYPROXY_TOKEN") == "" {
+
+		return false, fmt.Errorf("env var QE_SPRAYPROXY_TOKEN is not set")
+	}
+
+	return true, nil
+}
+
+func GitCheckoutRemoteBranch(remoteName, branchName string) error {
+	var git = sh.RunCmd("git")
+	for _, arg := range [][]string{
+		{"remote", "add", remoteName, fmt.Sprintf("https://github.com/%s/e2e-tests.git", remoteName)},
+		{"fetch", remoteName},
+		{"checkout", branchName},
+		{"pull", "--rebase", "upstream", "main"},
+	} {
+		if err := git(arg...); err != nil {
+			return fmt.Errorf("error when checkout out remote branch %s from remote %s: %v", branchName, remoteName, err)
+		}
+	}
+	return nil
+}
+
+func IsPRPairingRequired(repoForPairing string, remoteName string, branchName string) bool {
+	var pullRequests []gh.PullRequest
+
+	url := fmt.Sprintf("https://api.github.com/repos/redhat-appstudio/%s/pulls?per_page=100", repoForPairing)
+	if err := sendHttpRequestAndParseResponse(url, "GET", &pullRequests); err != nil {
+		klog.Infof("cannot determine %s Github branches for author %s: %v. will stick with the redhat-appstudio/%s main branch for running tests", repoForPairing, remoteName, err, repoForPairing)
+		return false
+	}
+
+	for _, pull := range pullRequests {
+		if pull.GetHead().GetRef() == branchName && pull.GetUser().GetLogin() == remoteName {
+			return true
+		}
+	}
+
+	return false
+}
+
+func IsPrelightChecked(rctx *rulesengine.RuleCtx) (bool, error) {
+
+	if rctx.DryRun {
+
+		klog.Info("All Environment Variables have been set!")
+		klog.Info("All tools and commands have been found!")
+	} else {
+		requiredEnv := []string{
+			"GITHUB_TOKEN",
+			"QUAY_TOKEN",
+			"DEFAULT_QUAY_ORG",
+			"DEFAULT_QUAY_ORG_TOKEN",
+		}
+		missingEnv := []string{}
+		for _, env := range requiredEnv {
+			if os.Getenv(env) == "" {
+				missingEnv = append(missingEnv, env)
+			}
+		}
+		if len(missingEnv) != 0 {
+			return false, fmt.Errorf("required env vars containing secrets (%s) not defined or empty", strings.Join(missingEnv, ","))
+		}
+
+		for _, binaryName := range rctx.RequiredBinaries {
+			if err := sh.Run("which", binaryName); err != nil {
+				return false, fmt.Errorf("binary %s not found in PATH - please install it first", binaryName)
+			}
+		}
+	}
+
+	return true, nil
+}
+
+func sendHttpRequestAndParseResponse(url, method string, v interface{}) error {
+	req, err := http.NewRequestWithContext(context.Background(), method, url, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", fmt.Sprintf("token %s", os.Getenv("GITHUB_TOKEN")))
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("error when sending request to '%s': %+v", url, err)
+	}
+	defer res.Body.Close()
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return fmt.Errorf("error when reading the response body from URL '%s': %+v", url, err)
+	}
+	if res.StatusCode > 299 {
+		return fmt.Errorf("unexpected status code: %d, response body: %s", res.StatusCode, string(body))
+	}
+
+	if err := json.Unmarshal(body, v); err != nil {
+		return fmt.Errorf("error when unmarshalling the response body from URL '%s': %+v", url, err)
+	}
+
+	return nil
+}
+
+func InstallKonflux() error {
+	ic, err := installation.NewAppStudioInstallController()
+	if err != nil {
+		return fmt.Errorf("failed to initialize installation controller: %+v", err)
+	}
+
+	if err := ic.InstallAppStudioPreviewMode(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func retry(f func() error, attempts int, delay time.Duration) error {
+	var err error
+	for i := 0; i < attempts; i++ {
+		if i > 0 {
+			klog.Infof("got an error: %+v - will retry in %v", err, delay)
+			time.Sleep(delay)
+		}
+		err = f()
+		if err != nil {
+			continue
+		} else {
+			return nil
+		}
+	}
+	return fmt.Errorf("reached maximum number of attempts (%d). error: %+v", attempts, err)
+}
+
+//Common Rules that can be used to chain into more specific repo rules
+
+var PrepareBranchRule = rulesengine.Rule{Name: "Prepare E2E branch for CI",
+	Description: "Checkout the e2e-tests repo for CI when the PR is paired with e2e-tests repo",
+	Condition: rulesengine.All{rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) (bool, error) {
+
+		if rctx.DryRun {
+
+			if true {
+				klog.Infof("Found e2e-tests branch %s for author %s", rctx.PrBranchName, rctx.PrRemoteName)
+				return true, nil
+			}
+		}
+
+		return IsPRPairingRequired("e2e-tests", rctx.PrRemoteName, rctx.PrBranchName), nil
+	}), rulesengine.None{rulesengine.ConditionFunc(IsPeriodicJob),
+		rulesengine.ConditionFunc(IsRehearseJob)}},
+	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
+
+		if rctx.DryRun {
+
+			for _, arg := range [][]string{
+				{"remote", "add", rctx.PrRemoteName, fmt.Sprintf("https://github.com/%s/e2e-tests.git", rctx.PrRemoteName)},
+				{"fetch", rctx.PrRemoteName},
+				{"checkout", rctx.PrCommitSha},
+				{"pull", "--rebase", "upstream", "main"},
+			} {
+				klog.Infof("git %s", arg)
+			}
+
+			return nil
+		}
+
+		return GitCheckoutRemoteBranch(rctx.PrRemoteName, rctx.PrBranchName)
+	})}}
+
+var PreflightInstallGinkgoRule = rulesengine.Rule{Name: "Preflight Check",
+	Description: "Check the envroniment has all the minimal pre-req variables/tools installed and install ginkgo.",
+	Condition:   rulesengine.ConditionFunc(IsPrelightChecked),
+	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
+
+		if rctx.DryRun {
+			klog.Info("Installing Ginkgo Test Runner")
+			klog.Info("Running command: go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo")
+			klog.Info("Ginkgo Installation Complete.")
+			return nil
+		}
+		return sh.RunV("go", "install", "-mod=mod", "github.com/onsi/ginkgo/v2/ginkgo")
+	}),
+	},
+}
+
+var InstallKonfluxRule = rulesengine.Rule{Name: "Install Konflux",
+	Description: "Install Konflux in preview mode on a cluster.",
+	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) (bool, error) {
+		return os.Getenv("SKIP_BOOTSTRAP") != "true", nil
+	}),
+	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
+
+		if rctx.DryRun {
+			klog.Info("Installing Konflux in Preview mode.")
+			klog.Info("Konflux Installation Complete.")
+			return nil
+		}
+		return retry(InstallKonflux, 2, 10*time.Second)
+	}),
+	},
+}
+
+var RegisterKonfluxToSprayProxyRule = rulesengine.Rule{Name: "Register SprayProxy",
+	Description: "Register Konflux with a SprayProxy.",
+	Condition: rulesengine.Any{
+		rulesengine.ConditionFunc(IsSprayProxyRequired),
+	},
+	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
+
+		if rctx.DryRun {
+			klog.Info("Registering Konflux to SprayProxy.")
+			klog.Info("Registration Complete.")
+			return nil
+		}
+
+		err := registerPacServer()
+		if err != nil {
+			os.Setenv(constants.SKIP_PAC_TESTS_ENV, "true")
+			if alertErr := HandleErrorWithAlert(fmt.Errorf("failed to register SprayProxy: %+v", err), slack.ErrorSeverityLevelError); alertErr != nil {
+				return alertErr
+			}
+		}
+		return nil
+	}),
+	},
+}
+
+var SetupMultiPlatformTestsRule = rulesengine.Rule{Name: "Setup multi-platform tests",
+	Description: "Configure tekton tasks for multi-platform tests",
+	Condition: rulesengine.Any{
+		rulesengine.ConditionFunc(IsMultiPlatformConfigRequired),
+	},
+	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
+
+		if rctx.DryRun {
+			klog.Info("Setting up multi platform tests.")
+			klog.Info("Multi platform tests configured.")
+			return nil
+		}
+
+		return SetupMultiPlatformTests()
+	}),
+	},
+}
+
+var BootstrapClusterRuleChain = rulesengine.Rule{Name: "BoostrapCluster RuleChain",
+	Description: "Rule Chain that installs Konflux in preview mode and when required, registers it with a SprayProxy and sets up MP tests",
+	Condition:   rulesengine.All{&InstallKonfluxRule, &RegisterKonfluxToSprayProxyRule, &SetupMultiPlatformTestsRule},
+}
+
+func registerPacServer() error {
+	var err error
+	var pacHost string
+	sprayProxyConfig, err := newSprayProxy()
+	if err != nil {
+		return fmt.Errorf("failed to set up SprayProxy credentials: %+v", err)
+	}
+
+	pacHost, err = sprayproxy.GetPaCHost()
+	if err != nil {
+		return fmt.Errorf("failed to get PaC host: %+v", err)
+	}
+	_, err = sprayProxyConfig.RegisterServer(pacHost)
+	if err != nil {
+		return fmt.Errorf("error when registering PaC server %s to SprayProxy server %s: %+v", pacHost, sprayProxyConfig.BaseURL, err)
+	}
+	klog.Infof("Registered PaC server: %s", pacHost)
+	// for debugging purposes
+	err = printRegisteredPacServers(sprayProxyConfig)
+	if err != nil {
+		klog.Error(err)
+	}
+	return nil
+}
+
+func newSprayProxy() (*sprayproxy.SprayProxyConfig, error) {
+	var sprayProxyUrl, sprayProxyToken string
+	if sprayProxyUrl = os.Getenv("QE_SPRAYPROXY_HOST"); sprayProxyUrl == "" {
+		return nil, fmt.Errorf("env var QE_SPRAYPROXY_HOST is not set")
+	}
+	if sprayProxyToken = os.Getenv("QE_SPRAYPROXY_TOKEN"); sprayProxyToken == "" {
+		return nil, fmt.Errorf("env var QE_SPRAYPROXY_TOKEN is not set")
+	}
+	return sprayproxy.NewSprayProxyConfig(sprayProxyUrl, sprayProxyToken)
+}
+
+func printRegisteredPacServers(cfg *sprayproxy.SprayProxyConfig) error {
+	servers, err := cfg.GetServers()
+	if err != nil {
+		return fmt.Errorf("failed to get registered PaC servers from SprayProxy: %+v", err)
+	}
+	klog.Infof("The PaC servers registered in Sprayproxy: %v", servers)
+	return nil
+}
+
+func HandleErrorWithAlert(err error, errLevel slack.ErrorSeverityLevel) error {
+	klog.Warning(err.Error() + " - this issue will be reported to a dedicated Slack channel")
+
+	if slackErr := slack.ReportIssue(err.Error(), errLevel); slackErr != nil {
+		return fmt.Errorf("failed report an error (%s) to a Slack channel: %s", err, slackErr)
+	}
+	return nil
+}
+
+func SetupMultiPlatformTests() error {
+	var platforms = []string{"linux/arm64", "linux/s390x", "linux/ppc64le"}
+
+	klog.Infof("going to create new Tekton bundle remote-build for the purpose of testing multi-platform-controller PR")
+	var err error
+	var defaultBundleRef string
+	var tektonObj runtime.Object
+
+	for _, platformType := range platforms {
+		tag := fmt.Sprintf("%d-%s", time.Now().Unix(), util.GenerateRandomString(4))
+		quayOrg := utils.GetEnv(constants.DEFAULT_QUAY_ORG_ENV, constants.DefaultQuayOrg)
+		newMultiPlatformBuilderPipelineImg := strings.ReplaceAll(constants.DefaultImagePushRepo, constants.DefaultQuayOrg, quayOrg)
+		var newRemotePipeline, _ = name.ParseReference(fmt.Sprintf("%s:pipeline-bundle-%s", newMultiPlatformBuilderPipelineImg, tag))
+		var newPipelineYaml []byte
+
+		if err = utils.CreateDockerConfigFile(os.Getenv("QUAY_TOKEN")); err != nil {
+			return fmt.Errorf("failed to create docker config file: %+v", err)
+		}
+		if defaultBundleRef, err = tekton.GetDefaultPipelineBundleRef(constants.BuildPipelineConfigConfigMapYamlURL, "docker-build"); err != nil {
+			return fmt.Errorf("failed to get the pipeline bundle ref: %+v", err)
+		}
+		if tektonObj, err = tekton.ExtractTektonObjectFromBundle(defaultBundleRef, "pipeline", "docker-build"); err != nil {
+			return fmt.Errorf("failed to extract the Tekton Pipeline from bundle: %+v", err)
+		}
+		dockerPipelineObject := tektonObj.(*tektonapi.Pipeline)
+
+		var currentBuildahTaskRef string
+		for i := range dockerPipelineObject.PipelineSpec().Tasks {
+			t := &dockerPipelineObject.PipelineSpec().Tasks[i]
+			params := t.TaskRef.Params
+			var lastBundle *tektonapi.Param
+			var lastName *tektonapi.Param
+			buildahTask := false
+			for i, param := range params {
+				if param.Name == "bundle" {
+					lastBundle = &t.TaskRef.Params[i]
+				} else if param.Name == "name" && param.Value.StringVal == "buildah" {
+					lastName = &t.TaskRef.Params[i]
+					buildahTask = true
+				}
+			}
+			if buildahTask {
+				currentBuildahTaskRef = lastBundle.Value.StringVal
+				klog.Infof("Found current task ref %s", currentBuildahTaskRef)
+				//TODO: current use pinned sha?
+				lastBundle.Value = *tektonapi.NewStructuredValues("quay.io/redhat-appstudio-tekton-catalog/task-buildah-remote:0.1-ac185e95bbd7a25c1c4acf86995cbaf30eebedc4")
+				lastName.Value = *tektonapi.NewStructuredValues("buildah-remote")
+				t.Params = append(t.Params, tektonapi.Param{Name: "PLATFORM", Value: *tektonapi.NewStructuredValues("$(params.PLATFORM)")})
+				dockerPipelineObject.Spec.Params = append(dockerPipelineObject.PipelineSpec().Params, tektonapi.ParamSpec{Name: "PLATFORM", Default: tektonapi.NewStructuredValues(platformType)})
+				dockerPipelineObject.Name = "buildah-remote-pipeline"
+				break
+			}
+		}
+		if currentBuildahTaskRef == "" {
+			return fmt.Errorf("failed to extract the Tekton Task from bundle: %+v", err)
+		}
+		if newPipelineYaml, err = yaml.Marshal(dockerPipelineObject); err != nil {
+			return fmt.Errorf("error when marshalling a new pipeline to YAML: %v", err)
+		}
+
+		keychain := authn.NewMultiKeychain(authn.DefaultKeychain)
+		authOption := remoteimg.WithAuthFromKeychain(keychain)
+
+		if err = tekton.BuildAndPushTektonBundle(newPipelineYaml, newRemotePipeline, authOption); err != nil {
+			return fmt.Errorf("error when building/pushing a tekton pipeline bundle: %v", err)
+		}
+		platform := strings.ToUpper(strings.Split(platformType, "/")[1])
+		klog.Infof("SETTING ENV VAR %s to value %s\n", constants.CUSTOM_BUILDAH_REMOTE_PIPELINE_BUILD_BUNDLE_ENV+"_"+platform, newRemotePipeline.String())
+		os.Setenv(constants.CUSTOM_BUILDAH_REMOTE_PIPELINE_BUILD_BUNDLE_ENV+"_"+platform, newRemotePipeline.String())
+	}
+
+	return nil
 }

--- a/magefiles/rulesengine/repos/e2e_repo.go
+++ b/magefiles/rulesengine/repos/e2e_repo.go
@@ -1,10 +1,14 @@
 package repos
 
 import (
+	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/konflux-ci/e2e-tests/magefiles/rulesengine"
+	"github.com/konflux-ci/e2e-tests/pkg/utils"
+	"k8s.io/klog"
 )
 
 var NonTestFilesRule = rulesengine.Rule{Name: "E2E Default PR Test Exectuion",
@@ -16,7 +20,8 @@ var NonTestFilesRule = rulesengine.Rule{Name: "E2E Default PR Test Exectuion",
 		rulesengine.ConditionFunc(CheckNoFilesChanged),
 		rulesengine.ConditionFunc(CheckTektonFilesChanged),
 	},
-	Actions: []rulesengine.Action{rulesengine.ActionFunc(ExecuteDefaultTestAction)}}
+	Actions: []rulesengine.Action{rulesengine.ActionFunc(ExecuteDefaultTestAction)},
+}
 
 var TestFilesOnlyRule = rulesengine.Rule{Name: "E2E PR Test File Diff Execution",
 	Description: "Runs specific tests when test files are the only changes in the e2e-repo PR",
@@ -43,19 +48,19 @@ var TestFilesOnlyRule = rulesengine.Rule{Name: "E2E PR Test File Diff Execution"
 	},
 	Actions: []rulesengine.Action{rulesengine.ActionFunc(ExecuteTestAction)}}
 
-func CheckTektonFilesChanged(rctx *rulesengine.RuleCtx) bool {
+func CheckTektonFilesChanged(rctx *rulesengine.RuleCtx) (bool, error) {
 
-	return len(rctx.DiffFiles.FilterByDirString("integration-tests/")) != 0 || len(rctx.DiffFiles.FilterByDirString(".tekton/")) != 0
+	return len(rctx.DiffFiles.FilterByDirString("integration-tests/")) != 0 || len(rctx.DiffFiles.FilterByDirString(".tekton/")) != 0, nil
 
 }
 
 var BuildTestFileChangeOnlyRule = rulesengine.Rule{Name: "E2E PR Build Test File Change Only Rule",
 	Description: "Map build tests files when build test file are only changed in the e2e-repo PR",
-	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) bool {
+	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) (bool, error) {
 
 		return len(rctx.DiffFiles.FilterByDirString("tests/build/build_templates_scenario.go")) == 0 &&
 			len(rctx.DiffFiles.FilterByDirString("tests/build/const.go")) == 0 &&
-			len(rctx.DiffFiles.FilterByDirString("tests/build/source_build.go")) == 0
+			len(rctx.DiffFiles.FilterByDirString("tests/build/source_build.go")) == 0, nil
 	}),
 	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
 
@@ -70,9 +75,9 @@ var BuildTestFileChangeOnlyRule = rulesengine.Rule{Name: "E2E PR Build Test File
 
 var BuildTemplateScenarioFileChangeRule = rulesengine.Rule{Name: "E2E PR Build Template Scenario File Changed Rule",
 	Description: "Map build tests files when build template scenario file is changed in the e2e-repo PR",
-	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) bool {
+	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) (bool, error) {
 
-		return len(rctx.DiffFiles.FilterByDirString("tests/build/build_templates_scenario.go")) != 0
+		return len(rctx.DiffFiles.FilterByDirString("tests/build/build_templates_scenario.go")) != 0, nil
 	}),
 	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
 
@@ -96,9 +101,9 @@ var BuildTemplateScenarioFileChangeRule = rulesengine.Rule{Name: "E2E PR Build T
 
 var BuildNonTestFileChangeRule = rulesengine.Rule{Name: "E2E PR Build Test Helper Files Change Rule",
 	Description: "Map build tests files when const.go or source_build.go file is changed in the e2e-repo PR",
-	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) bool {
+	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) (bool, error) {
 
-		return len(rctx.DiffFiles.FilterByDirGlob("tests/build/const.go")) != 0 || len(rctx.DiffFiles.FilterByDirGlob("tests/build/source_build.go")) != 0
+		return len(rctx.DiffFiles.FilterByDirGlob("tests/build/const.go")) != 0 || len(rctx.DiffFiles.FilterByDirGlob("tests/build/source_build.go")) != 0, nil
 	}),
 	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
 
@@ -119,9 +124,9 @@ var BuildNonTestFileChangeRule = rulesengine.Rule{Name: "E2E PR Build Test Helpe
 
 var ReleaseTestTestFilesChangeRule = rulesengine.Rule{Name: "E2E PR Release Test File Change Rule",
 	Description: "Map release test files if they are changed in the e2e-repo PR",
-	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) bool {
+	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) (bool, error) {
 
-		return len(rctx.DiffFiles.FilterByDirGlob("tests/release/*/*.go")) != 0
+		return len(rctx.DiffFiles.FilterByDirGlob("tests/release/*/*.go")) != 0, nil
 	}),
 	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
 
@@ -137,9 +142,9 @@ var ReleaseTestTestFilesChangeRule = rulesengine.Rule{Name: "E2E PR Release Test
 
 var ReleaseTestHelperFilesChangeOnlyRule = rulesengine.Rule{Name: "E2E PR Release Test Helper File CHange Rule",
 	Description: "Map release tests files when only the release helper go files in root of release directory are changed in the e2e-repo PR",
-	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) bool {
+	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) (bool, error) {
 
-		return len(rctx.DiffFiles.FilterByDirGlob("tests/release/*.go")) != 0 && len(rctx.DiffFiles.FilterByDirGlob("tests/release/*/*.go")) == 0
+		return len(rctx.DiffFiles.FilterByDirGlob("tests/release/*.go")) != 0 && len(rctx.DiffFiles.FilterByDirGlob("tests/release/*/*.go")) == 0, nil
 	}),
 	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
 
@@ -159,9 +164,9 @@ var ReleaseTestHelperFilesChangeOnlyRule = rulesengine.Rule{Name: "E2E PR Releas
 
 var KonfluxDemoTestFileChangedRule = rulesengine.Rule{Name: "E2E PR Konflux-Demo Test File Diff Map",
 	Description: "Map demo tests files when konflux-demo test files are changed in the e2e-repo PR",
-	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) bool {
+	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) (bool, error) {
 
-		return len(rctx.DiffFiles.FilterByDirGlob("tests/*-demo/*.go")) != 0
+		return len(rctx.DiffFiles.FilterByDirGlob("tests/*-demo/*.go")) != 0, nil
 	}),
 	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
 
@@ -176,9 +181,9 @@ var KonfluxDemoTestFileChangedRule = rulesengine.Rule{Name: "E2E PR Konflux-Demo
 
 var KonfluxDemoConfigsFileOnlyChangeRule = rulesengine.Rule{Name: "E2E PR Konflux-Demo Config File Change Only Rule",
 	Description: "Map demo tests files when konflux-demo config.go|type.go test files are changed in the e2e-repo PR",
-	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) bool {
+	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) (bool, error) {
 
-		return len(rctx.DiffFiles.FilterByDirGlob("tests/*-demo/*.go")) == 0 && len(rctx.DiffFiles.FilterByDirGlob("tests/*-demo/*/*")) != 0
+		return len(rctx.DiffFiles.FilterByDirGlob("tests/*-demo/*.go")) == 0 && len(rctx.DiffFiles.FilterByDirGlob("tests/*-demo/*/*")) != 0, nil
 	}),
 	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
 
@@ -198,9 +203,9 @@ var KonfluxDemoConfigsFileOnlyChangeRule = rulesengine.Rule{Name: "E2E PR Konflu
 
 var IntegrationTestsFileChangeRule = rulesengine.Rule{Name: "E2E PR Integration TestFile Change Rule",
 	Description: "Map integration tests files when integration test files are changed in the e2e-repo PR",
-	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) bool {
+	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) (bool, error) {
 
-		return len(rctx.DiffFiles.FilterByDirGlob("tests/integration-*/*.go")) != 0
+		return len(rctx.DiffFiles.FilterByDirGlob("tests/integration-*/*.go")) != 0, nil
 	}),
 	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
 
@@ -222,9 +227,9 @@ var IntegrationTestsFileChangeRule = rulesengine.Rule{Name: "E2E PR Integration 
 
 var IntegrationTestsConstFileChangeRule = rulesengine.Rule{Name: "E2E PR Integration TestFile Change Rule",
 	Description: "Map all integration tests files when integration const files are changed in the e2e-repo PR",
-	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) bool {
+	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) (bool, error) {
 
-		return len(rctx.DiffFiles.FilterByDirGlob("tests/integration-*/const.go")) != 0
+		return len(rctx.DiffFiles.FilterByDirGlob("tests/integration-*/const.go")) != 0, nil
 	}),
 	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
 
@@ -251,9 +256,8 @@ var IntegrationTestsConstFileChangeRule = rulesengine.Rule{Name: "E2E PR Integra
 
 var EcTestFileChangeRule = rulesengine.Rule{Name: "E2E PR EC Test File Change Rule",
 	Description: "Map EC tests files when EC test files are changed in the e2e-repo PR",
-	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) bool {
-
-		return len(rctx.DiffFiles.FilterByDirGlob("tests/enterprise-*/*.go")) != 0
+	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) (bool, error) {
+		return len(rctx.DiffFiles.FilterByDirGlob("tests/enterprise-*/*.go")) != 0, nil
 	}),
 	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
 
@@ -267,33 +271,128 @@ var EcTestFileChangeRule = rulesengine.Rule{Name: "E2E PR EC Test File Change Ru
 
 	})}}
 
+var E2ERepoPrepareBranchRule = rulesengine.Rule{Name: "E2E prepare branch for CI",
+	Description: "Checkout the e2e-tests repo using commit SHA in CI",
+	Condition: rulesengine.All{
+		rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) (bool, error) {
+			return rctx.RepoName == "e2e-tests", nil
+		}),
+		rulesengine.None{
+			rulesengine.ConditionFunc(IsPeriodicJob),
+			rulesengine.ConditionFunc(IsRehearseJob),
+		},
+	},
+	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
+
+		if rctx.DryRun {
+
+			for _, arg := range [][]string{
+				{"remote", "add", rctx.PrRemoteName, fmt.Sprintf("https://github.com/%s/e2e-tests.git", rctx.PrRemoteName)},
+				{"fetch", rctx.PrRemoteName},
+				{"checkout", rctx.PrCommitSha},
+				{"pull", "--rebase", "upstream", "main"},
+			} {
+				klog.Infof("git %s", arg)
+			}
+
+			return nil
+		}
+
+		return GitCheckoutRemoteBranch(rctx.PrRemoteName, rctx.PrCommitSha)
+	})},
+}
+
+var E2ERepoSetRequiredSettingsForPRRule = rulesengine.Rule{Name: "Set Required Settings for E2E Repo PR Paired Job",
+	Description: "Set up required infra-deployments variables for e2e-tests repo PR paired job before bootstrap ",
+	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) (bool, error) {
+		if rctx.DryRun {
+
+			if true {
+				klog.Infof("Found infra deployments branch %s for author %s", rctx.PrBranchName, rctx.PrRemoteName)
+				return true, nil
+			} else {
+				return false, fmt.Errorf("cannot determine infra-deployments Github branches for author %s: none. will stick with the redhat-appstudio/infra-deployments main branch for running tests", rctx.PrRemoteName)
+			}
+		}
+
+		return IsPRPairingRequired("infra-deployments", rctx.PrRemoteName, rctx.PrBranchName), nil
+	}),
+	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
+
+		if rctx.DryRun {
+
+			klog.Infof("Set INFRA_DEPLOYMENTS_ORG: %s", rctx.PrRemoteName)
+			klog.Infof("Set INFRA_DEPLOYMENTS_BRANCH: %s", rctx.PrBranchName)
+			return nil
+		}
+
+		klog.Infof("pairing with infra-deployments org %q and branch %q", rctx.PrRemoteName, rctx.PrBranchName)
+		os.Setenv("INFRA_DEPLOYMENTS_ORG", rctx.PrRemoteName)
+		os.Setenv("INFRA_DEPLOYMENTS_BRANCH", rctx.PrBranchName)
+		return nil
+	})},
+}
+
+var E2ERepoCIRuleChain = rulesengine.Rule{Name: "E2E Repo CI Workflow Rule Chain",
+	Description: "Execute the full workflow for e2e-tests repo in CI",
+	Condition: rulesengine.All{
+		&E2ERepoSetDefaultSettingsRule,
+		rulesengine.Any{&E2ERepoSetRequiredSettingsForPRRule, rulesengine.None{&E2ERepoSetRequiredSettingsForPRRule}},
+		&PreflightInstallGinkgoRule,
+		&BootstrapClusterRuleChain,
+		rulesengine.Any{&NonTestFilesRule, &TestFilesOnlyRule}},
+}
+
+var E2ERepoSetDefaultSettingsRule = rulesengine.Rule{Name: "General Required Settings for E2E Repo Jobs",
+	Description: "Set multiplatform and SprayProxy settings to true for e2e-tests jobs before bootstrap",
+	Condition: rulesengine.Any{
+		IsE2ETestsRepoPR,
+	},
+	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
+		var err error
+
+		rctx.RequiresMultiPlatformTests = true
+		rctx.RequiresSprayProxyRegistering = true
+		klog.Info("multi-platform tests and require sprayproxy registering are set to TRUE")
+
+		rctx.DiffFiles, err = utils.GetChangedFiles(rctx.RepoName)
+		return err
+	})},
+}
+
+var E2ECIChainCatalog = rulesengine.RuleCatalog{E2ERepoCIRuleChain}
+
 var E2ETestRulesCatalog = rulesengine.RuleCatalog{NonTestFilesRule, TestFilesOnlyRule}
 
-func CheckNoFilesChanged(rctx *rulesengine.RuleCtx) bool {
+var IsE2ETestsRepoPR = rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) (bool, error) {
+	klog.Info("checking if repository is e2e-tests")
+	return rctx.RepoName == "e2e-tests", nil
+})
 
-	return len(rctx.DiffFiles) == 0
+func CheckNoFilesChanged(rctx *rulesengine.RuleCtx) (bool, error) {
+
+	return len(rctx.DiffFiles) == 0, nil
 }
 
-func CheckPkgFilesChanged(rctx *rulesengine.RuleCtx) bool {
+func CheckPkgFilesChanged(rctx *rulesengine.RuleCtx) (bool, error) {
 
-	return len(rctx.DiffFiles.FilterByDirString("pkg/")) != 0
-
-}
-
-func CheckMageFilesChanged(rctx *rulesengine.RuleCtx) bool {
-
-	return len(rctx.DiffFiles.FilterByDirString("magefiles/")) != 0
+	return len(rctx.DiffFiles.FilterByDirString("pkg/")) != 0, nil
 
 }
 
-func CheckCmdFilesChanged(rctx *rulesengine.RuleCtx) bool {
+func CheckMageFilesChanged(rctx *rulesengine.RuleCtx) (bool, error) {
 
-	return len(rctx.DiffFiles.FilterByDirString("cmd/")) != 0
+	return len(rctx.DiffFiles.FilterByDirString("magefiles/")) != 0, nil
+
+}
+
+func CheckCmdFilesChanged(rctx *rulesengine.RuleCtx) (bool, error) {
+
+	return len(rctx.DiffFiles.FilterByDirString("cmd/")) != 0, nil
 
 }
 
 func ExecuteDefaultTestAction(rctx *rulesengine.RuleCtx) error {
-
 	rctx.LabelFilter = "!upgrade-create && !upgrade-verify && !upgrade-cleanup && !release-pipelines"
 	return ExecuteTestAction(rctx)
 

--- a/magefiles/rulesengine/repos/infra_deployments.go
+++ b/magefiles/rulesengine/repos/infra_deployments.go
@@ -52,9 +52,9 @@ var InfraDeploymentsComponentsRule = rulesengine.Rule{Name: "Infra-deployments P
 
 var InfraDeploymentsIntegrationComponentChangeRule = rulesengine.Rule{Name: "Infra-deployments PR Integration component File Change Rule",
 	Description: "Map Integration tests files when Integration component files are changed in the infra-deployments PR",
-	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) bool {
+	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) (bool, error) {
 
-		return len(rctx.DiffFiles.FilterByDirGlob("components/integration/**/*")) != 0
+		return len(rctx.DiffFiles.FilterByDirGlob("components/integration/**/*")) != 0, nil
 
 	}),
 	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
@@ -64,9 +64,9 @@ var InfraDeploymentsIntegrationComponentChangeRule = rulesengine.Rule{Name: "Inf
 
 var InfraDeploymentsEnterpriseControllerComponentChangeRule = rulesengine.Rule{Name: "Infra-deployments PR Enterprise Controller component File Change Rule",
 	Description: "Map Enterprise Controller tests files when EC component files are changed in the infra-deployments PR",
-	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) bool {
+	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) (bool, error) {
 
-		return len(rctx.DiffFiles.FilterByDirGlob("components/enterprise-contract/**/*")) != 0
+		return len(rctx.DiffFiles.FilterByDirGlob("components/enterprise-contract/**/*")) != 0, nil
 	}),
 	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
 		AddLabelToLabelFilter(rctx, "ec")
@@ -75,9 +75,9 @@ var InfraDeploymentsEnterpriseControllerComponentChangeRule = rulesengine.Rule{N
 
 var InfraDeploymentsJVMComponentChangeRule = rulesengine.Rule{Name: "Infra-deployments PR Jvm-build-service component File Change Rule",
 	Description: "Map jvm-build-service tests files when Jvm-build-service component files are changed in the infra-deployments PR",
-	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) bool {
+	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) (bool, error) {
 
-		return len(rctx.DiffFiles.FilterByDirGlob("components/jvm-build-service/**/*")) != 0
+		return len(rctx.DiffFiles.FilterByDirGlob("components/jvm-build-service/**/*")) != 0, nil
 	}),
 	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
 		AddLabelToLabelFilter(rctx, "jvm-build-service")
@@ -86,9 +86,9 @@ var InfraDeploymentsJVMComponentChangeRule = rulesengine.Rule{Name: "Infra-deplo
 
 var InfraDeploymentsImageControllerComponentChangeRule = rulesengine.Rule{Name: "Infra-deployments PR Image Controller component File Change Rule",
 	Description: "Map image-controller tests files when Image Controller component files are changed in the infra-deployments PR",
-	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) bool {
+	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) (bool, error) {
 
-		return len(rctx.DiffFiles.FilterByDirGlob("components/image-controller/**/*")) != 0
+		return len(rctx.DiffFiles.FilterByDirGlob("components/image-controller/**/*")) != 0, nil
 	}),
 	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
 		AddLabelToLabelFilter(rctx, "image-controller")
@@ -97,9 +97,9 @@ var InfraDeploymentsImageControllerComponentChangeRule = rulesengine.Rule{Name: 
 
 var InfraDeploymentsMultiPlatformComponentChangeRule = rulesengine.Rule{Name: "Infra-deployments PR Multi Controller component File Change Rule",
 	Description: "Map multi platform tests files when Multi Controller component files are changed in the infra-deployments PR",
-	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) bool {
+	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) (bool, error) {
 
-		return len(rctx.DiffFiles.FilterByDirGlob("components/multi-platform-controller/**/*")) != 0
+		return len(rctx.DiffFiles.FilterByDirGlob("components/multi-platform-controller/**/*")) != 0, nil
 	}),
 	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
 		AddLabelToLabelFilter(rctx, "multi-platform")
@@ -108,9 +108,9 @@ var InfraDeploymentsMultiPlatformComponentChangeRule = rulesengine.Rule{Name: "I
 
 var InfraDeploymentsBuildTemplatesComponentChangeRule = rulesengine.Rule{Name: "Infra-deployments PR Build-templates component File Change Rule",
 	Description: "Map build-templates tests files when Build-templates component files are changed in the infra-deployments PR",
-	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) bool {
+	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) (bool, error) {
 
-		return len(rctx.DiffFiles.FilterByDirGlob("components/build-service/base/build-pipeline-config/*")) != 0
+		return len(rctx.DiffFiles.FilterByDirGlob("components/build-service/base/build-pipeline-config/*")) != 0, nil
 	}),
 	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
 		AddLabelToLabelFilter(rctx, "build-templates")
@@ -119,10 +119,10 @@ var InfraDeploymentsBuildTemplatesComponentChangeRule = rulesengine.Rule{Name: "
 
 var InfraDeploymentsBuildServiceComponentChangeRule = rulesengine.Rule{Name: "Infra-deployments PR Build service component File Change Rule",
 	Description: "Map build service tests files when Build service component files are changed in the infra-deployments PR",
-	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) bool {
+	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) (bool, error) {
 
 		return len(rctx.DiffFiles.FilterByDirGlob("components/build-service/**/*")) != 0 &&
-			len(rctx.DiffFiles.FilterByDirGlob("components/build-service/base/build-pipeline-config/*")) == 0
+			len(rctx.DiffFiles.FilterByDirGlob("components/build-service/base/build-pipeline-config/*")) == 0, nil
 	}),
 	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
 		AddLabelToLabelFilter(rctx, "build-service")
@@ -131,10 +131,10 @@ var InfraDeploymentsBuildServiceComponentChangeRule = rulesengine.Rule{Name: "In
 
 var InfraDeploymentsBuildServiceTemplatesComponentChangeRule = rulesengine.Rule{Name: "Infra-deployments PR Build service component and templates File Change Rule",
 	Description: "Map build service tests files when Build service component and templates files are changed in the infra-deployments PR",
-	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) bool {
+	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) (bool, error) {
 
 		return len(rctx.DiffFiles.FilterByDirGlob("components/build-service/**/*")) != 0 &&
-			len(rctx.DiffFiles.FilterByDirGlob("components/build-service/base/build-pipeline-config/*")) != 0
+			len(rctx.DiffFiles.FilterByDirGlob("components/build-service/base/build-pipeline-config/*")) != 0, nil
 	}),
 	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
 		AddLabelToLabelFilter(rctx, "build-service")
@@ -143,9 +143,9 @@ var InfraDeploymentsBuildServiceTemplatesComponentChangeRule = rulesengine.Rule{
 
 var InfraDeploymentsReleaseServiceComponentChangeRule = rulesengine.Rule{Name: "Infra-deployments PR Release service component File Change Rule",
 	Description: "Map release service tests files when Release service component files are changed in the infra-deployments PR",
-	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) bool {
+	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) (bool, error) {
 
-		return len(rctx.DiffFiles.FilterByDirGlob("components/release/**/*")) != 0
+		return len(rctx.DiffFiles.FilterByDirGlob("components/release/**/*")) != 0, nil
 	}),
 	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
 		AddLabelToLabelFilter(rctx, "release-service")

--- a/magefiles/rulesengine/repos/release_service_catalog.go
+++ b/magefiles/rulesengine/repos/release_service_catalog.go
@@ -2,13 +2,14 @@ package repos
 
 import (
 	"strings"
-	"strconv"
+
 	"github.com/konflux-ci/e2e-tests/magefiles/rulesengine"
 )
 
 var ReleaseCatalogPairedRule = rulesengine.Rule{Name: "Release Catalog PR paired Test Execution",
 	Description: "Runs release catalog tests except for the fbc tests on release-service-catalog repo when PR paired and not a rehearsal job",
-	Condition: rulesengine.All{rulesengine.ConditionFunc(releaseCatalogRepoCondition),
+	Condition: rulesengine.All{
+		rulesengine.ConditionFunc(releaseCatalogRepoCondition),
 		rulesengine.ConditionFunc(isPaired),
 		rulesengine.None{
 			rulesengine.ConditionFunc(isRehearse),
@@ -18,9 +19,10 @@ var ReleaseCatalogPairedRule = rulesengine.Rule{Name: "Release Catalog PR paired
 
 var ReleaseServiceCatalogRule = rulesengine.Rule{Name: "Release Service Catalog Test Execution",
 	Description: "Runs all release catalog tests on release-service-catalog repo on PR/rehearsal jobs",
-	Condition: rulesengine.All{rulesengine.ConditionFunc(releaseCatalogRepoCondition),
+	Condition: rulesengine.All{
+		rulesengine.ConditionFunc(releaseCatalogRepoCondition),
 		rulesengine.Any{
-			rulesengine.None{rulesengine.ConditionFunc(isPaired),},
+			rulesengine.None{rulesengine.ConditionFunc(isPaired)},
 			rulesengine.ConditionFunc(isRehearse),
 		},
 	},
@@ -28,22 +30,18 @@ var ReleaseServiceCatalogRule = rulesengine.Rule{Name: "Release Service Catalog 
 
 var ReleaseServiceCatalogTestRulesCatalog = rulesengine.RuleCatalog{ReleaseServiceCatalogRule, ReleaseCatalogPairedRule}
 
-var isRehearse = func(rctx *rulesengine.RuleCtx) bool {
+var isRehearse = func(rctx *rulesengine.RuleCtx) (bool, error) {
 
-	return strings.Contains(rctx.JobName, "rehearse")
+	return strings.Contains(rctx.JobName, "rehearse"), nil
 }
 
-var isPaired = func(rctx *rulesengine.RuleCtx) bool {
-
-	if boolValue, err := strconv.ParseBool(rctx.IsPaired); err == nil && boolValue {
-		return true
-	}
-	return false
+var isPaired = func(rctx *rulesengine.RuleCtx) (bool, error) {
+	return rctx.IsPaired, nil
 }
 
-func releaseCatalogRepoCondition(rctx *rulesengine.RuleCtx) bool {
+func releaseCatalogRepoCondition(rctx *rulesengine.RuleCtx) (bool, error) {
 
-	return rctx.RepoName == "release-service-catalog"
+	return rctx.RepoName == "release-service-catalog", nil
 }
 
 func ExecuteReleasePairedAction(rctx *rulesengine.RuleCtx) error {

--- a/magefiles/utils.go
+++ b/magefiles/utils.go
@@ -21,7 +21,6 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 	plumbingHttp "github.com/go-git/go-git/v5/plumbing/transport/http"
 	sprig "github.com/go-task/slim-sprig"
-	"github.com/konflux-ci/e2e-tests/magefiles/rulesengine"
 	"github.com/konflux-ci/e2e-tests/pkg/clients/slack"
 	"github.com/konflux-ci/e2e-tests/pkg/utils"
 	"github.com/konflux-ci/image-controller/pkg/quay"
@@ -439,39 +438,4 @@ func HandleErrorWithAlert(err error, errLevel slack.ErrorSeverityLevel) error {
 		return fmt.Errorf("failed report an error (%s) to a Slack channel: %s", err, slackErr)
 	}
 	return nil
-}
-
-func getChangedFiles(repo string) (rulesengine.Files, error) {
-	var gitDiff = sh.OutCmd("git", "diff")
-	// If the repo is infra-deployments then we check changed files in path tmp/infra-deployments
-	// else it will run locally which is from e2e-tests directory
-	if repo == "infra-deployments" {
-		wd, _ := os.Getwd()
-		gitDiff = sh.OutCmd("git", "-C", fmt.Sprintf("%s/tmp/%s", wd, repo), "diff")
-	}
-	output, err := gitDiff("--name-status", "upstream/main")
-
-	if err != nil {
-		klog.Error("Failed to run git status locally")
-		return nil, err
-	}
-
-	if output == "" {
-		klog.Info("Found no changed files.")
-		return rulesengine.Files{}, nil
-	}
-	var changes rulesengine.Files
-	var file rulesengine.File
-	for _, line := range strings.Split(output, "\n") {
-
-		fileAttr := strings.Split(line, "\t")
-		file = rulesengine.File{Status: fileAttr[0], Name: fileAttr[1]}
-
-		changes = append(changes, file)
-	}
-
-	klog.Infof("The following files, %s, were changed!", changes.String())
-
-	return changes, nil
-
 }


### PR DESCRIPTION
# Description

* introduced CI Rule Chain **for e2e-tests repo** (CI Rule Chains for other repositories - infra-deployments, integration-service etc. - will follow in other PRs) that replaces the messy code in `magefile.go`
* updated the [`Eval` method signature](https://github.com/konflux-ci/e2e-tests/compare/main...psturc:[KONFLUX-3902](https://issues.redhat.com//browse/KONFLUX-3902)-e2e-tests?expand=1#diff-2435cc2f992f298a556c7d35d119ae02f1899dbd6d0715106267bc5fbfe5760bR307) to return also an `error` type when evaluating conditions
* eventually we will create rules for every repository where we run e2e tests, and once it's done, duplicated code from magefile.go will be removed

## Issue ticket number and link
[KONFLUX-3902](https://issues.redhat.com//browse/KONFLUX-3902)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

locally by mocking the CI-provided values:
```
export KONFLUX_CI=true
export JOB_SPEC='{
                "container_image": "quay.io/redhat-user-workloads/konflux-qe-team-tenant/konflux-e2e/konflux-e2e-tests@sha256:70adb47a4e050232cbc53cbcd3b1e8db07e806e5cf083f355afbcebbf9cfba01",
                "konflux_component": "konflux-e2e-tests",
                "git": {
                    "pull_request_number": 1344,
                    "pull_request_author": "psturc",
                    "git_org": "konflux-ci",
                    "git_repo": "e2e-tests",
                    "commit_sha": "632593323899578bf5979cbddcf736447043422c",
                    "event_type": "pull_request",
                    "source_repo_url": "https://github.com/psturc/e2e-tests",
                    "source_repo_branch": "KONFLUX-3902-e2e-tests"
                }
            }'
# + export all required env vars for running the bootstrap and e2e tests
make ci/test/e2e
```
also the initial CI run [worked as expected](https://gist.github.com/psturc/8046e6b8252a892ead94455a9d59b197#file-konflux-e2e-pod-log-L388-L389)

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
