### PR TITLE
feat(KONFLUX-3187): infra-deployments test selection fix 

### DIFF
--- a/magefiles/rulesengine/repos/infra_deployments.go
+++ b/magefiles/rulesengine/repos/infra_deployments.go
@@ -40,7 +40,6 @@ var InfraDeploymentsComponentsRule = rulesengine.Rule{Name: "Infra-deployments P
 		&InfraDeploymentsBuildServiceComponentChangeRule,
 		&InfraDeploymentsReleaseServiceComponentChangeRule,
 		&InfraDeploymentsEnterpriseControllerComponentChangeRule,
-		&InfraDeploymentsBuildServiceTemplatesComponentChangeRule,
 		&InfraDeploymentsJVMComponentChangeRule},
 	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
 		// Adding "konflux" to the label filter when component is updated
@@ -107,39 +106,31 @@ var InfraDeploymentsMultiPlatformComponentChangeRule = rulesengine.Rule{Name: "I
 	})}}
 
 var InfraDeploymentsBuildTemplatesComponentChangeRule = rulesengine.Rule{Name: "Infra-deployments PR Build-templates component File Change Rule",
-	Description: "Map build-templates tests files when Build-templates component files are changed in the infra-deployments PR",
+	Description: "Map build-templates tests files when build-pipeline-config.yaml is changed",
+	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) (bool, error) {
+		return len(rctx.DiffFiles.FilterByDirGlob("components/build-service/base/build-pipeline-config/build-pipeline-config.yaml")) != 0, nil
+	}),
+	Actions: []rulesengine.Action{
+		rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
+			AddLabelToLabelFilter(rctx, "build-templates")
+			return nil
+		}),
+	},
+}
+
+var InfraDeploymentsBuildServiceComponentChangeRule = rulesengine.Rule{Name: "Infra-deployments PR Build Service component File Change Rule (excluding build-pipeline-config)",
+	Description: "Map build service tests files when files in build-service are changed except build-pipeline-config.yaml",
 	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) (bool, error) {
 
-		return len(rctx.DiffFiles.FilterByDirGlob("components/build-service/base/build-pipeline-config/*")) != 0, nil
+		return len(rctx.DiffFiles.FilterByDirGlob("components/build-service/**/*")) > len(rctx.DiffFiles.FilterByDirGlob("components/build-service/base/build-pipeline-config/*")), nil
 	}),
-	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
-		AddLabelToLabelFilter(rctx, "build-templates")
-		return nil
-	})}}
-
-var InfraDeploymentsBuildServiceComponentChangeRule = rulesengine.Rule{Name: "Infra-deployments PR Build service component File Change Rule",
-	Description: "Map build service tests files when Build service component files are changed in the infra-deployments PR",
-	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) (bool, error) {
-
-		return len(rctx.DiffFiles.FilterByDirGlob("components/build-service/**/*")) != 0 &&
-			len(rctx.DiffFiles.FilterByDirGlob("components/build-service/base/build-pipeline-config/*")) == 0, nil
-	}),
-	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
-		AddLabelToLabelFilter(rctx, "build-service")
-		return nil
-	})}}
-
-var InfraDeploymentsBuildServiceTemplatesComponentChangeRule = rulesengine.Rule{Name: "Infra-deployments PR Build service component and templates File Change Rule",
-	Description: "Map build service tests files when Build service component and templates files are changed in the infra-deployments PR",
-	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) (bool, error) {
-
-		return len(rctx.DiffFiles.FilterByDirGlob("components/build-service/**/*")) != 0 &&
-			len(rctx.DiffFiles.FilterByDirGlob("components/build-service/base/build-pipeline-config/*")) != 0, nil
-	}),
-	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
-		AddLabelToLabelFilter(rctx, "build-service")
-		return nil
-	})}}
+	Actions: []rulesengine.Action{
+		rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
+			AddLabelToLabelFilter(rctx, "build-service")
+			return nil
+		}),
+	},
+}
 
 var InfraDeploymentsReleaseServiceComponentChangeRule = rulesengine.Rule{Name: "Infra-deployments PR Release service component File Change Rule",
 	Description: "Map release service tests files when Release service component files are changed in the infra-deployments PR",


### PR DESCRIPTION
This PR fixes the scenario that was not triggering the right test suites  : 

- any file in `components/build-service `  was changed 

lead to applying `build-service` label even when only files under components/build-service/base/build-pipeline-config/* are changed

also the fix is for the scenario where : 
- any files `components/build-service/base/build-pipeline-config/* `are changed 
- any file unde build-service and not in `components/build-service/base/build-pipeline-config/*`  

it will add the `build-service`  and  `build-templates` label as expected 





## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
