### PR TITLE
feat: integration-service repo CI rule

### DIFF
--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -128,6 +128,7 @@ func (ci CI) init() error {
 	rctx.JobType = jobType
 	rctx.PrRemoteName = pr.RemoteName
 	rctx.PrBranchName = pr.BranchName
+	rctx.PrCommitSha = pr.CommitSHA
 	return nil
 }
 
@@ -292,7 +293,7 @@ func (ci CI) TestE2E() error {
 		return fmt.Errorf("error when running ci init: %v", err)
 	}
 	// Eventually we'll introduce mage rules for all repositories, so this condition won't be needed anymore
-	if pr.RepoName == "e2e-tests" {
+	if pr.RepoName == "e2e-tests" || pr.RepoName == "integration-service" {
 		return engine.MageEngine.RunRulesOfCategory("ci", rctx)
 	}
 

--- a/magefiles/rulesengine/engine/engine.go
+++ b/magefiles/rulesengine/engine/engine.go
@@ -16,7 +16,8 @@ var MageEngine = rulesengine.RuleEngine{
 	},
 
 	"ci": {
-		"e2e-repo": repos.E2ECIChainCatalog,
+		"e2e-repo":            repos.E2ECIChainCatalog,
+		"integration-service": repos.IntegrationServiceCICatalog,
 		// TODO: to be implemented in a follow-up PR
 		//"infra-deployments": repos.InfraDeploymentsCIChainCatalog,
 	},

--- a/magefiles/rulesengine/repos/common.go
+++ b/magefiles/rulesengine/repos/common.go
@@ -381,6 +381,11 @@ var BootstrapClusterRuleChain = rulesengine.Rule{Name: "BoostrapCluster RuleChai
 	Condition:   rulesengine.All{&InstallKonfluxRule, &RegisterKonfluxToSprayProxyRule, &SetupMultiPlatformTestsRule},
 }
 
+var BootstrapClusterWithSprayProxyRuleChain = rulesengine.Rule{Name: "BoostrapCluster with SprayProxy RuleChain",
+	Description: "Rule Chain that installs Konflux in preview mode and registers it with SprayProxy",
+	Condition:   rulesengine.All{&InstallKonfluxRule, &RegisterKonfluxToSprayProxyRule},
+}
+
 func registerPacServer() error {
 	var err error
 	var pacHost string

--- a/magefiles/rulesengine/repos/common.go
+++ b/magefiles/rulesengine/repos/common.go
@@ -508,3 +508,16 @@ func SetupMultiPlatformTests() error {
 
 	return nil
 }
+
+func SetEnvVarsForComponentImageDeployment(rctx *rulesengine.RuleCtx) error {
+	componentImage := os.Getenv("COMPONENT_IMAGE")
+	sp := strings.Split(componentImage, "@")
+	if len(sp) != 2 {
+		return fmt.Errorf("component image ref expected in format 'quay.io/<org>/<repository>@sha256:<sha256-value>', got %s", componentImage)
+	}
+	os.Setenv(fmt.Sprintf("%s_IMAGE_REPO", rctx.ComponentEnvVarPrefix), sp[0])
+	os.Setenv(fmt.Sprintf("%s_IMAGE_TAG", rctx.ComponentEnvVarPrefix), rctx.ComponentImageTag)
+	os.Setenv(fmt.Sprintf("%s_PR_OWNER", rctx.ComponentEnvVarPrefix), rctx.PrRemoteName)
+	os.Setenv(fmt.Sprintf("%s_PR_SHA", rctx.ComponentEnvVarPrefix), rctx.PrCommitSha)
+	return nil
+}

--- a/magefiles/rulesengine/repos/integration_service.go
+++ b/magefiles/rulesengine/repos/integration_service.go
@@ -22,11 +22,6 @@ var IntegrationServiceCIRule = rulesengine.Rule{Name: "Integration-service repo 
 	Actions: []rulesengine.Action{rulesengine.ActionFunc(ExecuteTestAction)},
 }
 
-var BootstrapClusterWithSprayProxyRuleChain = rulesengine.Rule{Name: "BoostrapCluster with SprayProxy RuleChain",
-	Description: "Rule Chain that installs Konflux in preview mode and registers it with SprayProxy",
-	Condition:   rulesengine.All{&InstallKonfluxRule, &RegisterKonfluxToSprayProxyRule},
-}
-
 var IntegrationServiceRepoSetDefaultSettingsRule = rulesengine.Rule{Name: "General Required Settings for integration-service repository jobs",
 	Description: "Set SprayProxy settings to true for integration-service jobs before bootstrap",
 	Condition: rulesengine.Any{

--- a/magefiles/rulesengine/repos/integration_service.go
+++ b/magefiles/rulesengine/repos/integration_service.go
@@ -17,7 +17,6 @@ var IntegrationServiceCIRule = rulesengine.Rule{Name: "Integration-service repo 
 		rulesengine.Any{&InfraDeploymentsPRPairingRule, rulesengine.None{&InfraDeploymentsPRPairingRule}},
 		&PreflightInstallGinkgoRule,
 		&BootstrapClusterWithSprayProxyRuleChain,
-		&IntegrationServiceRepoRunTestsRule,
 	},
 	Actions: []rulesengine.Action{rulesengine.ActionFunc(ExecuteTestAction)},
 }
@@ -47,14 +46,6 @@ var IntegrationServiceRepoSetDefaultSettingsRule = rulesengine.Rule{Name: "Gener
 		}
 		return SetEnvVarsForComponentImageDeployment(rctx)
 	})},
-}
-
-var IntegrationServiceRepoRunTestsRule = rulesengine.Rule{Name: "Run integration-service specific tests",
-	Description: "Run integration-service specific tests if the repository is integration-service",
-	Condition: rulesengine.Any{
-		IsIntegrationServiceRepoPR,
-	},
-	Actions: []rulesengine.Action{rulesengine.ActionFunc(ExecuteTestAction)},
 }
 
 var IsIntegrationServiceRepoPR = rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) (bool, error) {

--- a/magefiles/rulesengine/repos/integration_service.go
+++ b/magefiles/rulesengine/repos/integration_service.go
@@ -1,0 +1,68 @@
+package repos
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/konflux-ci/e2e-tests/magefiles/rulesengine"
+	"k8s.io/klog"
+)
+
+var IntegrationServiceCICatalog = rulesengine.RuleCatalog{IntegrationServiceCIRule}
+
+var IntegrationServiceCIRule = rulesengine.Rule{Name: "Integration-service repo CI Workflow Rule",
+	Description: "Execute the full workflow for e2e-tests repo in CI",
+	Condition: rulesengine.All{
+		&IntegrationServiceRepoSetDefaultSettingsRule,
+		rulesengine.Any{&InfraDeploymentsPRPairingRule, rulesengine.None{&InfraDeploymentsPRPairingRule}},
+		&PreflightInstallGinkgoRule,
+		&BootstrapClusterWithSprayProxyRuleChain,
+		&IntegrationServiceRepoRunTestsRule,
+	},
+	Actions: []rulesengine.Action{rulesengine.ActionFunc(ExecuteTestAction)},
+}
+
+var BootstrapClusterWithSprayProxyRuleChain = rulesengine.Rule{Name: "BoostrapCluster with SprayProxy RuleChain",
+	Description: "Rule Chain that installs Konflux in preview mode and registers it with SprayProxy",
+	Condition:   rulesengine.All{&InstallKonfluxRule, &RegisterKonfluxToSprayProxyRule},
+}
+
+var IntegrationServiceRepoSetDefaultSettingsRule = rulesengine.Rule{Name: "General Required Settings for integration-service repository jobs",
+	Description: "Set SprayProxy settings to true for integration-service jobs before bootstrap",
+	Condition: rulesengine.Any{
+		IsIntegrationServiceRepoPR,
+	},
+	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
+		rctx.RequiresSprayProxyRegistering = true
+		klog.Info("require sprayproxy registering is set to TRUE")
+
+		rctx.LabelFilter = "integration-service"
+		klog.Info("setting 'integration-service' test label")
+
+		if rctx.DryRun {
+			klog.Info("setting up env vars for deploying component image")
+			return nil
+		}
+		rctx.ComponentEnvVarPrefix = "INTEGRATION_SERVICE"
+		// TODO keep only "KONFLUX_CI" option once we migrate off openshift-ci
+		if os.Getenv("KONFLUX_CI") == "true" {
+			rctx.ComponentImageTag = fmt.Sprintf("on-pr-%s", rctx.PrCommitSha)
+		} else {
+			rctx.ComponentImageTag = "redhat-appstudio-integration-service-image"
+		}
+		return SetEnvVarsForComponentImageDeployment(rctx)
+	})},
+}
+
+var IntegrationServiceRepoRunTestsRule = rulesengine.Rule{Name: "Run integration-service specific tests",
+	Description: "Run integration-service specific tests if the repository is integration-service",
+	Condition: rulesengine.Any{
+		IsIntegrationServiceRepoPR,
+	},
+	Actions: []rulesengine.Action{rulesengine.ActionFunc(ExecuteTestAction)},
+}
+
+var IsIntegrationServiceRepoPR = rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) (bool, error) {
+	klog.Info("checking if repository is integration-service")
+	return rctx.RepoName == "integration-service", nil
+})


### PR DESCRIPTION
# Description

* follow-up on https://github.com/konflux-ci/e2e-tests/pull/1344
* added integration-service repository specific CI rule
* updated `runLoadedCatalog` method to fix the bug when iterating over rule catalog wasn't terminated right away after rule chain evaluation passed

## Issue ticket number and link
[KONFLUX-3902](https://issues.redhat.com//browse/KONFLUX-3902)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

```
export KONFLUX_CI=true
export COMPONENT_IMAGE=quay.io/redhat-user-workloads/rhtap-integration-tenant/integration-service/integration-service@sha256:75c4356e8fdefea826e067b18e0f8d816911d547f48bd876e5b9fa89c50d517f
export JOB_SPEC='{
                "container_image": "quay.io/redhat-user-workloads/konflux-qe-team-tenant/konflux-e2e/konflux-e2e-tests@sha256:70adb47a4e050232cbc53cbcd3b1e8db07e806e5cf083f355afbcebbf9cfba01",
                "konflux_component": "konflux-e2e-tests",
                "git": {
                    "pull_request_number": 1,
                    "pull_request_author": "psturc",
                    "git_org": "psturc",
                    "git_repo": "integration-service",
                    "commit_sha": "92860473d11b3b5d90558dc8e84e83c9e365395d",
                    "event_type": "pull_request",
                    "source_repo_url": "https://github.com/psturc/integration-service",
                    "source_repo_branch": "test"
                }
            }'
# + export all required env vars for running the bootstrap and e2e tests
make ci/test/e2e
```
I also created a PR for testing the pairing [here](https://github.com/konflux-ci/integration-service/pull/849) (to validate this in openshift-ci)

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
