### PR TITLE
fix(KFLUXBUGS-1556): skipInitialCheck for selective test suites of Integration service

### DIFF
--- a/tests/integration-service/integration-with-env.go
+++ b/tests/integration-service/integration-with-env.go
@@ -46,7 +46,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 			testNamespace = f.UserNamespace
 
 			applicationName = createApp(*f, testNamespace)
-			originalComponent, componentName, pacBranchName, componentBaseBranchName = createComponent(*f, testNamespace, applicationName, componentRepoNameForIntegrationWithEnv, componentGitSourceURLForIntegrationWithEnv)
+			originalComponent, componentName, pacBranchName, componentBaseBranchName = createComponent(*f, testNamespace, applicationName, componentRepoNameForIntegrationWithEnv, componentGitSourceURLForIntegrationWithEnv, true)
 			integrationTestScenario, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenario("", applicationName, testNamespace, gitURL, revision, pathIntegrationPipelineWithEnv, []string{})
 			Expect(err).ShouldNot(HaveOccurred())
 		})

--- a/tests/integration-service/integration.go
+++ b/tests/integration-service/integration.go
@@ -50,7 +50,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 			testNamespace = f.UserNamespace
 
 			applicationName = createApp(*f, testNamespace)
-			originalComponent, componentName, pacBranchName, componentBaseBranchName = createComponent(*f, testNamespace, applicationName, componentRepoNameForGeneralIntegration, componentGitSourceURLForGeneralIntegration)
+			originalComponent, componentName, pacBranchName, componentBaseBranchName = createComponent(*f, testNamespace, applicationName, componentRepoNameForGeneralIntegration, componentGitSourceURLForGeneralIntegration, false)
 
 			integrationTestScenario, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenario("", applicationName, testNamespace, gitURL, revision, pathInRepoPass, []string{"application"})
 			Expect(err).ShouldNot(HaveOccurred())
@@ -241,7 +241,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 			testNamespace = f.UserNamespace
 
 			applicationName = createApp(*f, testNamespace)
-			originalComponent, componentName, pacBranchName, componentBaseBranchName = createComponent(*f, testNamespace, applicationName, componentRepoNameForGeneralIntegration, componentGitSourceURLForGeneralIntegration)
+			originalComponent, componentName, pacBranchName, componentBaseBranchName = createComponent(*f, testNamespace, applicationName, componentRepoNameForGeneralIntegration, componentGitSourceURLForGeneralIntegration, false)
 
 			integrationTestScenario, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenario("", applicationName, testNamespace, gitURL, revision, pathInRepoFail, []string{"pull_request"})
 			Expect(err).ShouldNot(HaveOccurred())
@@ -434,7 +434,7 @@ func createApp(f framework.Framework, testNamespace string) string {
 	return applicationName
 }
 
-func createComponent(f framework.Framework, testNamespace, applicationName, componentRepoName, componentRepoURL string) (*appstudioApi.Component, string, string, string) {
+func createComponent(f framework.Framework, testNamespace, applicationName, componentRepoName, componentRepoURL string, skipInitialChecks bool) (*appstudioApi.Component, string, string, string) {
 	componentName := fmt.Sprintf("%s-%s", "test-component-pac", util.GenerateRandomString(6))
 	pacBranchName := constants.PaCPullRequestBranchPrefix + componentName
 	componentBaseBranchName := fmt.Sprintf("base-%s", util.GenerateRandomString(6))
@@ -455,7 +455,7 @@ func createComponent(f framework.Framework, testNamespace, applicationName, comp
 		},
 	}
 
-	originalComponent, err := f.AsKubeAdmin.HasController.CreateComponent(componentObj, testNamespace, "", "", applicationName, false, utils.MergeMaps(utils.MergeMaps(constants.ComponentPaCRequestAnnotation, constants.ImageControllerAnnotationRequestPublicRepo), constants.DefaultDockerBuildPipelineBundle))
+	originalComponent, err := f.AsKubeAdmin.HasController.CreateComponent(componentObj, testNamespace, "", "", applicationName, skipInitialChecks, utils.MergeMaps(utils.MergeMaps(constants.ComponentPaCRequestAnnotation, constants.ImageControllerAnnotationRequestPublicRepo), constants.DefaultDockerBuildPipelineBundle))
 	Expect(err).NotTo(HaveOccurred())
 
 	return originalComponent, componentName, pacBranchName, componentBaseBranchName

--- a/tests/integration-service/status-reporting-to-pullrequest.go
+++ b/tests/integration-service/status-reporting-to-pullrequest.go
@@ -49,7 +49,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Status Reporting of Integrati
 			}
 
 			applicationName = createApp(*f, testNamespace)
-			component, componentName, pacBranchName, componentBaseBranchName = createComponent(*f, testNamespace, applicationName, componentRepoNameForStatusReporting, componentGitSourceURLForStatusReporting)
+			component, componentName, pacBranchName, componentBaseBranchName = createComponent(*f, testNamespace, applicationName, componentRepoNameForStatusReporting, componentGitSourceURLForStatusReporting, true)
 
 			integrationTestScenarioPass, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenario("", applicationName, testNamespace, gitURL, revision, pathInRepoPass, []string{})
 			Expect(err).ShouldNot(HaveOccurred())


### PR DESCRIPTION
# Description

* We are skipping the initial checks for some of the test suites because when all 4 of these test suites run in parallel within a smaller cluster,
* All 4 of the suites timeout while waiting for the build PLRs to get created.
* But they never get created as parallel execution of the suites is too memory- intensive for the smaller cluster.

## Issue ticket number and link

[KFLUXBUGS-1556](https://issues.redhat.com//browse/KFLUXBUGS-1556)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This change cannot be test locally as I need to test this change against the CI cluster of integration service, so using branch pairing feature here to test.

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
