### PR TITLE
fix: Use new location for golden-container image

### DIFF
--- a/tests/enterprise-contract/contract.go
+++ b/tests/enterprise-contract/contract.go
@@ -310,7 +310,7 @@ var _ = framework.EnterpriseContractSuiteDescribe("Enterprise Contract E2E tests
 
 			Context("ec-cli command", func() {
 				It("verifies ec cli has error handling", func() {
-					generator.WithComponentImage("quay.io/redhat-appstudio/ec-golden-image:latest")
+					generator.WithComponentImage("quay.io/konflux-ci/ec-golden-image:latest")
 					pr, err := fwk.AsKubeAdmin.TektonController.RunPipeline(generator, namespace, pipelineRunTimeout)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(fwk.AsKubeAdmin.TektonController.WatchPipelineRun(pr.Name, namespace, pipelineRunTimeout)).To(Succeed())
@@ -354,8 +354,8 @@ var _ = framework.EnterpriseContractSuiteDescribe("Enterprise Contract E2E tests
 						})
 					Expect(fwk.AsKubeAdmin.TektonController.CreateOrUpdatePolicyConfiguration(namespace, policy)).To(Succeed())
 
-					generator.WithComponentImage("quay.io/redhat-appstudio/ec-golden-image:latest")
-					generator.AppendComponentImage("quay.io/redhat-appstudio/ec-golden-image:e2e-test-unacceptable-task")
+					generator.WithComponentImage("quay.io/konflux-ci/ec-golden-image:latest")
+					generator.AppendComponentImage("quay.io/konflux-ci/ec-golden-image:e2e-test-unacceptable-task")
 					pr, err := fwk.AsKubeAdmin.TektonController.RunPipeline(generator, namespace, pipelineRunTimeout)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(fwk.AsKubeAdmin.TektonController.WatchPipelineRun(pr.Name, namespace, pipelineRunTimeout)).To(Succeed())
@@ -401,7 +401,7 @@ var _ = framework.EnterpriseContractSuiteDescribe("Enterprise Contract E2E tests
 						})
 					Expect(fwk.AsKubeAdmin.TektonController.CreateOrUpdatePolicyConfiguration(namespace, policy)).To(Succeed())
 
-					generator.WithComponentImage("quay.io/redhat-appstudio/ec-golden-image:latest")
+					generator.WithComponentImage("quay.io/konflux-ci/ec-golden-image:latest")
 					pr, err := fwk.AsKubeAdmin.TektonController.RunPipeline(generator, namespace, pipelineRunTimeout)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(fwk.AsKubeAdmin.TektonController.WatchPipelineRun(pr.Name, namespace, pipelineRunTimeout)).To(Succeed())
@@ -437,7 +437,7 @@ var _ = framework.EnterpriseContractSuiteDescribe("Enterprise Contract E2E tests
 					)
 					Expect(fwk.AsKubeAdmin.TektonController.CreateOrUpdatePolicyConfiguration(namespace, policy)).To(Succeed())
 
-					generator.WithComponentImage("quay.io/redhat-appstudio/ec-golden-image:e2e-test-unacceptable-task")
+					generator.WithComponentImage("quay.io/konflux-ci/ec-golden-image:e2e-test-unacceptable-task")
 					pr, err := fwk.AsKubeAdmin.TektonController.RunPipeline(generator, namespace, pipelineRunTimeout)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(fwk.AsKubeAdmin.TektonController.WatchPipelineRun(pr.Name, namespace, pipelineRunTimeout)).To(Succeed())


### PR DESCRIPTION
# Description

The golden-container image is no longer built into the quay.io/redhat-appstudio organization. Instead, it is now built into quay.io/konflux-ci. The image from the redhat-appstudio organization is now stale.

## Issue ticket number and link

https://issues.redhat.com/browse/KFLUXBUGS-1575

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [x] I have updated labels (if needed)
