### PR TITLE
chore: Mount konflux test infra volume to access oci storage

### DIFF
--- a/integration-tests/tasks/konflux-e2e-tests-task.yaml
+++ b/integration-tests/tasks/konflux-e2e-tests-task.yaml
@@ -50,6 +50,9 @@ spec:
     - name: konflux-secret-volume
       secret:
         secretName: konflux-e2e-secrets
+    - name: konflux-test-infra-volume
+      secret:
+        secretName: konflux-test-infra
   steps:
     - name: e2e-test
       computeResources:
@@ -63,6 +66,8 @@ spec:
       volumeMounts:
         - name: konflux-secret-volume
           mountPath: /usr/local/konflux-ci-secrets
+        - name:  konflux-test-infra-volume
+          mountPath: /usr/local/konflux-test-infra
       workingDir: /workspace
       env:
         - name: JOB_NAME


### PR DESCRIPTION
# Description

Instead of creating oras-credentials secret in every namespace, start to use the credentials stored in vault to push to OCI- Registry. 

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
