### PR TITLE
fix(RELEASE-1149): e2e keeps checking pipelinerun even if it failed

### DIFF
--- a/tests/release/pipelines/fbc_release.go
+++ b/tests/release/pipelines/fbc_release.go
@@ -205,42 +205,32 @@ func assertReleasePipelineRunSucceeded(devFw, managedFw *framework.Framework, de
 		return nil
 	}, 5*time.Minute, releasecommon.DefaultInterval).Should(Succeed(), "timed out when waiting for Release being created")
 
-	managedFw = releasecommon.NewFramework(managedWorkspace)
-	// Create a ticker that ticks every 3 minutes
-	ticker := time.NewTicker(3 * time.Minute)
-	// Schedule the stop of the ticker after 30 minutes
-	time.AfterFunc(30*time.Minute, func() {
-		ticker.Stop()
-		fmt.Println("Stopped executing every 3 minutes.")
-	})
-	// Run a goroutine to handle the ticker ticks
-	go func() {
-		for range ticker.C {
-			managedFw = releasecommon.NewFramework(managedWorkspace)
-		}
-	}()
-
 	Eventually(func() error {
 		pipelineRun, err := managedFw.AsKubeAdmin.ReleaseController.GetPipelineRunInNamespace(managedNamespace, releaseCR.GetName(), releaseCR.GetNamespace())
 		if err != nil {
 			return fmt.Errorf("PipelineRun has not been created yet for release %s/%s", releaseCR.GetNamespace(), releaseCR.GetName())
 		}
+
 		for _, condition := range pipelineRun.Status.Conditions {
 			GinkgoWriter.Printf("PipelineRun %s reason: %s\n", pipelineRun.Name, condition.Reason)
 		}
 
-		if !pipelineRun.IsDone() {
+		if !pipelineRun.IsDone(){
 			return fmt.Errorf("PipelineRun %s has still not finished yet", pipelineRun.Name)
 		}
 
 		if pipelineRun.GetStatusCondition().GetCondition(apis.ConditionSucceeded).IsTrue() {
 			return nil
 		} else {
-			var prLogs string
+			prLogs := ""
 			if prLogs, err = tekton.GetFailedPipelineRunLogs(managedFw.AsKubeAdmin.ReleaseController.KubeRest(), managedFw.AsKubeAdmin.ReleaseController.KubeInterface(), pipelineRun); err != nil {
-				return fmt.Errorf("failed to get PLR logs: %+v", err)
+				GinkgoWriter.Printf("failed to get PLR logs: %+v", err)
+				Expect(err).ShouldNot(HaveOccurred())
+				return nil
 			}
-			return fmt.Errorf("%s", prLogs)
+			GinkgoWriter.Printf("logs: %s", prLogs)
+			Expect(prLogs).To(Equal(""), fmt.Sprintf("PipelineRun %s failed", pipelineRun.Name))
+			return nil
 		}
 	}, releasecommon.BuildPipelineRunCompletionTimeout, releasecommon.DefaultInterval).Should(Succeed(), fmt.Sprintf("timed out when waiting for the release PipelineRun to be finished for the release %s/%s", releaseCR.GetName(), releaseCR.GetNamespace()))
 }
@@ -252,17 +242,26 @@ func assertReleaseCRSucceeded(devFw *framework.Framework, devNamespace, managedN
 		if err != nil {
 			return err
 		}
+		GinkgoWriter.Printf("releaseCR: %s", releaseCR.Name)
 		conditions := releaseCR.Status.Conditions
+		GinkgoWriter.Printf("len of conditions: %d", len(conditions))
 		if len(conditions) > 0 {
 			for _, c := range conditions {
-				if c.Type == "Released" && c.Status == "True" {
-					GinkgoWriter.Println("Release CR is released")
+				GinkgoWriter.Printf("type of c: %s", c.Type)
+				if c.Type == "Released" {
+					GinkgoWriter.Printf("status of c: %s", c.Status)
+					if c.Status == "True" {
+						GinkgoWriter.Println("Release CR is released")
+						return nil
+					} else if c.Status == "False" {
+						GinkgoWriter.Println("Release CR failed")
+						Expect(string(c.Status)).To(Equal("True"), fmt.Sprintf("Release %s failed", releaseCR.Name))
+						return nil
+					} else {
+						return fmt.Errorf("release %s/%s is not marked as finished yet", releaseCR.GetNamespace(), releaseCR.GetName())
+					}
 				}
 			}
-		}
-
-		if !releaseCR.IsReleased() {
-			return fmt.Errorf("release %s/%s is not marked as finished yet", releaseCR.GetNamespace(), releaseCR.GetName())
 		}
 		return nil
 	}, releasecommon.ReleaseCreationTimeout, releasecommon.DefaultInterval).Should(Succeed())

--- a/tests/release/releaseLib.go
+++ b/tests/release/releaseLib.go
@@ -32,7 +32,7 @@ func NewFramework(workspace string) *framework.Framework {
 	// Create a ticker that ticks every 3 minutes
 	ticker := time.NewTicker(3 * time.Minute)
 	// Schedule the stop of the ticker after 30 minutes
-	time.AfterFunc(30*time.Minute, func() {
+	time.AfterFunc(60*time.Minute, func() {
 		ticker.Stop()
 		fmt.Println("Stopped executing every 3 minutes.")
 	})


### PR DESCRIPTION
1. Remove useless left code 
2. Change the way of handling failure in the loop of waiting pipelineRun finished
3. Increase the duration of refreshing token

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
