### PR TITLE
fix(KONFLUX-997): Check for handling 100% error rate scenario in max-concurrency load-test

### DIFF
--- a/tests/load-tests/evaluate.py
+++ b/tests/load-tests/evaluate.py
@@ -89,6 +89,7 @@ def count_stats_when(data):
 def main():
     input_file = sys.argv[1]
     output_file = sys.argv[2]
+    concurrency = int(sys.argv[3])
 
     stats_raw = {}
 
@@ -137,12 +138,16 @@ def main():
             stats[m]["error_rate"] = stats[m]["fail"]["duration"]["samples"] / s
             kpi_errors += stats[m]["fail"]["duration"]["samples"]
 
-    stats["KPI"] = {}
-    stats["KPI"]["mean"] = kpi_sum
-    stats["KPI"]["errors"] = kpi_errors
+    if concurrency != kpi_errors:
+        stats["KPI"] = {}
+        stats["KPI"]["mean"] = kpi_sum
+        stats["KPI"]["errors"] = kpi_errors
 
-    print(f"KPI mean: {stats['KPI']['mean']}")
-    print(f"KPI errors: {stats['KPI']['errors']}")
+        print(f"KPI mean: {stats['KPI']['mean']}")
+        print(f"KPI errors: {stats['KPI']['errors']}")
+    else:
+        print("Skipping KPI metric calculation.")
+        print(f"100% of {concurrency} concurrent run(s) failed.")
 
     with open(output_file, "w") as fp:
         json.dump(stats, fp, indent=4)

--- a/tests/load-tests/run-max-concurrency.sh
+++ b/tests/load-tests/run-max-concurrency.sh
@@ -84,7 +84,7 @@ load_test() {
     set -u
 
     echo "[$(date --utc -Ins)] Create summary JSON with timings"
-    ./evaluate.py "$workdir/load-test-timings.csv" "$workdir/load-test-timings.json"
+    ./evaluate.py "$workdir/load-test-timings.csv" "$workdir/load-test-timings.json" "$threads"
 
     echo "[$(date --utc -Ins)] Creating main status data file"
     STATUS_DATA_FILE="$workdir/load-test.json"


### PR DESCRIPTION
# Description
When there is 100% build failures, the max-concurrency load script fails to capture this error and adds the KPI metrics to results file. This PR adds a new check to handle the 100% error rate scenario and avoid adding the KPI metrics into results, while also failing the test overall in CI.

## Issue ticket number and link
https://issues.redhat.com/browse/KONFLUX-997

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Individual changes has been manually tested and following are the different output results for 2 scenarios that  code changes handles:

**Case 1: 100% Error Rate**:
```
Raw stats: {'HandleUser': {'pass': {'duration': [4.3467], 'when': [datetime.datetime(2024, 9, 4, 10, 12, 1, 870502, tzinfo=datetime.timezone.utc)]}, 'fail': {'duration': [], 'when': []}}, 'createApplication': {'pass': {'duration': [0.341772], 'when': [datetime.datetime(2024, 9, 4, 10, 12, 3, 829988, tzinfo=datetime.timezone.utc)]}, 'fail': {'duration': [], 'when': []}}, 'validateApplication': {'pass': {'duration': [0.084771], 'when': [datetime.datetime(2024, 9, 4, 10, 12, 3, 914802, tzinfo=datetime.timezone.utc)]}, 'fail': {'duration': [], 'when': []}}, 'createIntegrationTestScenario': {'pass': {'duration': [0.173253], 'when': [datetime.datetime(2024, 9, 4, 10, 12, 4, 88147, tzinfo=datetime.timezone.utc)]}, 'fail': {'duration': [], 'when': []}}, 'validateIntegrationTestScenario': {'pass': {'duration': [20.11397], 'when': [datetime.datetime(2024, 9, 4, 10, 12, 24, 202164, tzinfo=datetime.timezone.utc)]}, 'fail': {'duration': [], 'when': []}}, 'createComponent': {'pass': {'duration': [3.607354], 'when': [datetime.datetime(2024, 9, 4, 10, 12, 29, 287212, tzinfo=datetime.timezone.utc)]}, 'fail': {'duration': [], 'when': []}}, 'validatePipelineRunCreation': {'pass': {'duration': [], 'when': []}, 'fail': {'duration': [1800.087519], 'when': [datetime.datetime(2024, 9, 4, 10, 42, 29, 374790, tzinfo=datetime.timezone.utc)]}}, 'validatePipelineRunCondition': {'pass': {'duration': [], 'when': []}, 'fail': {'duration': [], 'when': []}}, 'validatePipelineRunSignature': {'pass': {'duration': [], 'when': []}, 'fail': {'duration': [], 'when': []}}, 'validateSnapshotCreation': {'pass': {'duration': [], 'when': []}, 'fail': {'duration': [], 'when': []}}, 'validateTestPipelineRunCreation': {'pass': {'duration': [], 'when': []}, 'fail': {'duration': [], 'when': []}}, 'validateTestPipelineRunCondition': {'pass': {'duration': [], 'when': []}, 'fail': {'duration': [], 'when': []}}}
Skipping KPI metric calculation.
100% of 1 concurrent run(s) failed.
Stats dumped to result.json
```

**Case 2: Error Rate is not 100%**:
```
Raw stats: {'HandleUser': {'pass': {'duration': [3.347294], 'when': [datetime.datetime(2024, 8, 8, 23, 31, 47, 352282, tzinfo=datetime.timezone.utc)]}, 'fail': {'duration': [], 'when': []}}, 'createApplication': {'pass': {'duration': [0.333625], 'when': [datetime.datetime(2024, 8, 8, 23, 31, 49, 198603, tzinfo=datetime.timezone.utc)]}, 'fail': {'duration': [], 'when': []}}, 'validateApplication': {'pass': {'duration': [0.084817], 'when': [datetime.datetime(2024, 8, 8, 23, 31, 49, 283465, tzinfo=datetime.timezone.utc)]}, 'fail': {'duration': [], 'when': []}}, 'createIntegrationTestScenario': {'pass': {'duration': [0.175019], 'when': [datetime.datetime(2024, 8, 8, 23, 31, 49, 458622, tzinfo=datetime.timezone.utc)]}, 'fail': {'duration': [], 'when': []}}, 'validateIntegrationTestScenario': {'pass': {'duration': [20.084653], 'when': [datetime.datetime(2024, 8, 8, 23, 32, 9, 543324, tzinfo=datetime.timezone.utc)]}, 'fail': {'duration': [], 'when': []}}, 'createComponent': {'pass': {'duration': [3.609442], 'when': [datetime.datetime(2024, 8, 8, 23, 32, 14, 638730, tzinfo=datetime.timezone.utc)]}, 'fail': {'duration': [], 'when': []}}, 'validatePipelineRunCreation': {'pass': {'duration': [20.087334], 'when': [datetime.datetime(2024, 8, 8, 23, 32, 34, 726113, tzinfo=datetime.timezone.utc)]}, 'fail': {'duration': [], 'when': []}}, 'validatePipelineRunCondition': {'pass': {'duration': [300.092429], 'when': [datetime.datetime(2024, 8, 8, 23, 37, 34, 818573, tzinfo=datetime.timezone.utc)]}, 'fail': {'duration': [], 'when': []}}, 'validatePipelineRunSignature': {'pass': {'duration': [0.085492], 'when': [datetime.datetime(2024, 8, 8, 23, 37, 34, 904092, tzinfo=datetime.timezone.utc)]}, 'fail': {'duration': [], 'when': []}}, 'validateSnapshotCreation': {'pass': {'duration': [0.080346], 'when': [datetime.datetime(2024, 8, 8, 23, 37, 34, 984491, tzinfo=datetime.timezone.utc)]}, 'fail': {'duration': [], 'when': []}}, 'validateTestPipelineRunCreation': {'pass': {'duration': [0.088817], 'when': [datetime.datetime(2024, 8, 8, 23, 37, 35, 73343, tzinfo=datetime.timezone.utc)]}, 'fail': {'duration': [], 'when': []}}, 'validateTestPipelineRunCondition': {'pass': {'duration': [20.085929], 'when': [datetime.datetime(2024, 8, 8, 23, 37, 55, 159325, tzinfo=datetime.timezone.utc)]}, 'fail': {'duration': [], 'when': []}}}
KPI mean: 368.15519700000004
KPI errors: 0
Stats dumped to result.json
```

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
