### PR TITLE
fix: If all the journeys failed, do not compute avg KPI time

### DIFF
--- a/tests/load-tests/evaluate.py
+++ b/tests/load-tests/evaluate.py
@@ -127,8 +127,14 @@ def main():
         stats[m]["pass"]["when"] = count_stats_when(stats_raw[m]["pass"]["when"])
         stats[m]["fail"]["when"] = count_stats_when(stats_raw[m]["fail"]["when"])
 
-        if "mean" in stats[m]["pass"]["duration"]:
-            kpi_sum += stats[m]["pass"]["duration"]["mean"]
+        if stats[m]["pass"]["duration"]["samples"] == 0:
+            # If we had 0 measurements in some metric, that means not a single
+            # build made it through all steps, so kpi_sum metric does not make
+            # sense as it would only cover part of the journey
+            kpi_sum = -1
+        else:
+            if kpi_sum != -1:
+                kpi_sum += stats[m]["pass"]["duration"]["mean"]
 
         s = stats[m]["pass"]["duration"]["samples"] + stats[m]["fail"]["duration"]["samples"]
         if s == 0:

--- a/tests/load-tests/run-max-concurrency.sh
+++ b/tests/load-tests/run-max-concurrency.sh
@@ -206,7 +206,7 @@ max_concurrency() {
             if [ -z "$workloadKPI" ] || [ -z "$workloadKPIerrors" ] || [ "$workloadKPI" = "null" ] || [ "$workloadKPIerrors" = "null" ]; then
                 echo "[$(date --utc -Ins)] Error getting test iteration results: $workloadKPI/$workloadKPIerrors"
                 exit 1
-            elif awk "BEGIN { exit !($workloadKPI > $threshold_sec || $workloadKPIerrors / $t * 100 > $threshold_err)}"; then
+            elif awk "BEGIN { exit !($workloadKPI == -1 || $workloadKPI > $threshold_sec || $workloadKPIerrors / $t * 100 > $threshold_err)}"; then
                 echo "[$(date --utc -Ins)] The average time a workload took to succeed (${workloadKPI}s) or error rate (${workloadKPIerrors}/${t}) has exceeded a threshold of ${threshold_sec}s or ${threshold_err} error rate with $t threads."
                 workloadKPIOld=$(jq '.workloadKPI' "$output")
                 threadsOld=$(jq '.maxConcurrencyReached' "$output")


### PR DESCRIPTION
# Description
If all the journeys failed, do not compute avg KPI time.

If we had 0 measurements in some metric, that means not a single build made it through all steps, so kpi_sum metric does not make sense as it would only cover part of the journey.

## Issue ticket number and link
N/A

## Type of change
- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Just local run of the script on data that trigger the issue.