### PR TITLE
feat: Test different Pipeline variants

### DIFF
--- a/pkg/clients/tekton/bundles.go
+++ b/pkg/clients/tekton/bundles.go
@@ -13,8 +13,10 @@ import (
 )
 
 type Bundles struct {
-	DockerBuildBundle string
-	FBCBuilderBundle  string
+	DockerBuildBundle                   string
+	DockerBuildMultiPlatformOCITABundle string
+	DockerBuildOCITABundle              string
+	FBCBuilderBundle                    string
 }
 
 // NewBundles returns new Bundles.
@@ -40,6 +42,10 @@ func (t *TektonController) NewBundles() (*Bundles, error) {
 		switch pipeline.Name {
 		case "docker-build":
 			bundles.DockerBuildBundle = pipeline.Bundle
+		case "docker-build-multi-platform-oci-ta":
+			bundles.DockerBuildMultiPlatformOCITABundle = pipeline.Bundle
+		case "docker-build-oci-ta":
+			bundles.DockerBuildOCITABundle = pipeline.Bundle
 		case "fbc-builder":
 			bundles.FBCBuilderBundle = pipeline.Bundle
 		}

--- a/tests/build/build_templates.go
+++ b/tests/build/build_templates.go
@@ -334,19 +334,6 @@ var _ = framework.BuildSuiteDescribe("Build templates E2E test", Label("build", 
 				}
 			})
 
-			It(fmt.Sprintf("should ensure show-summary task ran for component with Git source URL %s", gitUrl), Label(buildTemplatesTestLabel), func() {
-				pr, err = kubeadminClient.HasController.GetComponentPipelineRun(componentNames[i], applicationName, testNamespace, "")
-				Expect(err).ShouldNot(HaveOccurred())
-				Expect(pr).ToNot(BeNil(), fmt.Sprintf("PipelineRun for the component %s/%s not found", testNamespace, componentNames[i]))
-
-				logs, err := kubeadminClient.TektonController.GetTaskRunLogs(pr.GetName(), "show-summary", testNamespace)
-				Expect(err).ShouldNot(HaveOccurred())
-				Expect(logs).To(HaveLen(1))
-				buildSummaryLog := logs["step-appstudio-summary"]
-				binaryImage := build.GetBinaryImage(pr)
-				Expect(buildSummaryLog).To(ContainSubstring(binaryImage))
-			})
-
 			It("should push Dockerfile to registry", Label(buildTemplatesTestLabel), func() {
 				ensureOriginalDockerfileIsPushed(kubeadminClient, pr)
 			})

--- a/tests/build/build_templates_scenarios.go
+++ b/tests/build/build_templates_scenarios.go
@@ -1,6 +1,8 @@
 package build
 
 import (
+	"strings"
+
 	"github.com/konflux-ci/e2e-tests/pkg/constants"
 	"github.com/konflux-ci/e2e-tests/pkg/utils"
 )
@@ -10,94 +12,109 @@ type ComponentScenarioSpec struct {
 	Revision            string
 	ContextDir          string
 	DockerFilePath      string
-	PipelineBundleName  string
+	PipelineBundleNames []string
 	EnableHermetic      bool
 	PrefetchInput       string
 	CheckAdditionalTags bool
 }
 
+func (s ComponentScenarioSpec) DeepCopy() ComponentScenarioSpec {
+	pipelineBundleNames := make([]string, len(s.PipelineBundleNames))
+	copy(pipelineBundleNames, s.PipelineBundleNames)
+	return ComponentScenarioSpec{
+		GitURL:              s.GitURL,
+		Revision:            s.Revision,
+		ContextDir:          s.ContextDir,
+		DockerFilePath:      s.DockerFilePath,
+		PipelineBundleNames: pipelineBundleNames,
+		EnableHermetic:      s.EnableHermetic,
+		PrefetchInput:       s.PrefetchInput,
+		CheckAdditionalTags: s.CheckAdditionalTags,
+	}
+}
+
 var componentScenarios = []ComponentScenarioSpec{
 	{
-		GitURL:             "https://github.com/konflux-qe-bd/devfile-sample-python-basic",
-		Revision:           "47fc22092005aabebce233a9b6eab994a8152bbd",
-		ContextDir:         ".",
-		DockerFilePath:     constants.DockerFilePath,
-		PipelineBundleName: "docker-build",
-		EnableHermetic:     false,
-		PrefetchInput:      "",
+		GitURL:              "https://github.com/konflux-qe-bd/devfile-sample-python-basic",
+		Revision:            "47fc22092005aabebce233a9b6eab994a8152bbd",
+		ContextDir:          ".",
+		DockerFilePath:      constants.DockerFilePath,
+		PipelineBundleNames: []string{"docker-build", "docker-build-oci-ta", "docker-build-multi-platform-oci-ta"},
+		EnableHermetic:      false,
+		PrefetchInput:       "",
 	},
 	{
-		GitURL:             "https://github.com/konflux-qe-bd/retrodep",
-		Revision:           "d8e3195d1ab9dbee1f621e3b0625a589114ac80f",
-		ContextDir:         ".",
-		DockerFilePath:     "Dockerfile",
-		PipelineBundleName: "docker-build",
-		EnableHermetic:     true,
-		PrefetchInput:      "gomod",
+		GitURL:              "https://github.com/konflux-qe-bd/retrodep",
+		Revision:            "d8e3195d1ab9dbee1f621e3b0625a589114ac80f",
+		ContextDir:          ".",
+		DockerFilePath:      "Dockerfile",
+		PipelineBundleNames: []string{"docker-build"},
+		EnableHermetic:      true,
+		PrefetchInput:       "gomod",
 	},
 	{
 		GitURL:              "https://github.com/konflux-qe-bd/pip-e2e-test",
 		Revision:            "1ecda839ba9ca55070d75c86c26a1bb07d777bba",
 		ContextDir:          ".",
 		DockerFilePath:      "Dockerfile",
-		PipelineBundleName:  "docker-build",
+		PipelineBundleNames: []string{"docker-build"},
 		EnableHermetic:      true,
 		PrefetchInput:       "pip",
 		CheckAdditionalTags: true,
 	},
 	{
-		GitURL:             "https://github.com/konflux-qe-bd/fbc-sample-repo",
-		Revision:           "8e374e107fecf03f3c64c528bb53798039661414",
-		ContextDir:         "4.13",
-		DockerFilePath:     "catalog.Dockerfile",
-		PipelineBundleName: "fbc-builder",
-		EnableHermetic:     false,
-		PrefetchInput:      "",
+		GitURL:              "https://github.com/konflux-qe-bd/fbc-sample-repo",
+		Revision:            "8e374e107fecf03f3c64c528bb53798039661414",
+		ContextDir:          "4.13",
+		DockerFilePath:      "catalog.Dockerfile",
+		PipelineBundleNames: []string{"fbc-builder"},
+		EnableHermetic:      false,
+		PrefetchInput:       "",
 	},
 	{
-		GitURL:             "https://github.com/konflux-qe-bd/docker-file-from-scratch",
-		Revision:           "34de8caa4952b6214700699e6df4bb53d6f799e6",
-		ContextDir:         ".",
-		DockerFilePath:     "Dockerfile",
-		PipelineBundleName: "docker-build",
-		EnableHermetic:     false,
-		PrefetchInput:      "",
+		GitURL:              "https://github.com/konflux-qe-bd/docker-file-from-scratch",
+		Revision:            "34de8caa4952b6214700699e6df4bb53d6f799e6",
+		ContextDir:          ".",
+		DockerFilePath:      "Dockerfile",
+		PipelineBundleNames: []string{"docker-build"},
+		EnableHermetic:      false,
+		PrefetchInput:       "",
 	},
 	{
-		GitURL:             "https://github.com/konflux-qe-bd/source-build-parent-image-with-digest-only",
-		Revision:           "a4f744581c0768eb84a4345f11d04090bb14bdff",
-		ContextDir:         ".",
-		DockerFilePath:     "Dockerfile",
-		PipelineBundleName: "docker-build",
-		EnableHermetic:     false,
-		PrefetchInput:      "",
+		GitURL:              "https://github.com/konflux-qe-bd/source-build-parent-image-with-digest-only",
+		Revision:            "a4f744581c0768eb84a4345f11d04090bb14bdff",
+		ContextDir:          ".",
+		DockerFilePath:      "Dockerfile",
+		PipelineBundleNames: []string{"docker-build"},
+		EnableHermetic:      false,
+		PrefetchInput:       "",
 	},
 	{
-		GitURL:             "https://github.com/konflux-qe-bd/source-build-use-latest-parent-image",
-		Revision:           "b4584ac47e1df84114a10debf262b6d40f6a95f8",
-		ContextDir:         ".",
-		DockerFilePath:     "Dockerfile",
-		PipelineBundleName: "docker-build",
-		EnableHermetic:     false,
-		PrefetchInput:      "",
+		GitURL:              "https://github.com/konflux-qe-bd/source-build-use-latest-parent-image",
+		Revision:            "b4584ac47e1df84114a10debf262b6d40f6a95f8",
+		ContextDir:          ".",
+		DockerFilePath:      "Dockerfile",
+		PipelineBundleNames: []string{"docker-build"},
+		EnableHermetic:      false,
+		PrefetchInput:       "",
 	},
 	{
-		GitURL:             "https://github.com/konflux-qe-bd/source-build-parent-image-from-registry-rh-io",
-		Revision:           "3f5dcac703a35dcb7b29312be72f86221d0f10ee",
-		ContextDir:         ".",
-		DockerFilePath:     "Dockerfile",
-		PipelineBundleName: "docker-build",
-		EnableHermetic:     false,
-		PrefetchInput:      "",
+		GitURL:              "https://github.com/konflux-qe-bd/source-build-parent-image-from-registry-rh-io",
+		Revision:            "3f5dcac703a35dcb7b29312be72f86221d0f10ee",
+		ContextDir:          ".",
+		DockerFilePath:      "Dockerfile",
+		PipelineBundleNames: []string{"docker-build"},
+		EnableHermetic:      false,
+		PrefetchInput:       "",
 	},
 	{
-		GitURL:             "https://github.com/konflux-qe-bd/source-build-base-on-konflux-image",
-		Revision:           "86c4d160cfafb8976a23030d4bbc1216bfe8e14f",
-		ContextDir:         ".",
-		DockerFilePath:     "Dockerfile",
-		PipelineBundleName: "docker-build",
-		EnableHermetic:     false,
-		PrefetchInput:      "",
+		GitURL:              "https://github.com/konflux-qe-bd/source-build-base-on-konflux-image",
+		Revision:            "86c4d160cfafb8976a23030d4bbc1216bfe8e14f",
+		ContextDir:          ".",
+		DockerFilePath:      "Dockerfile",
+		PipelineBundleNames: []string{"docker-build"},
+		EnableHermetic:      false,
+		PrefetchInput:       "",
 	},
 }
 
@@ -111,30 +128,36 @@ func GetGitRevision(gitUrl string) string {
 	return ""
 }
 
-func IsDockerBuild(gitUrl string) bool {
+func IsDockerBuildGitURL(gitURL string) bool {
 	for _, componentScenario := range componentScenarios {
-		if utils.GetRepoName(componentScenario.GitURL) == utils.GetRepoName(gitUrl) && componentScenario.PipelineBundleName == "docker-build" {
+		//check repo name for both the giturls is same
+		if utils.GetRepoName(componentScenario.GitURL) == utils.GetRepoName(gitURL) {
+			for _, pipeline := range componentScenario.PipelineBundleNames {
+				if !strings.HasPrefix(pipeline, "docker-build") {
+					return false
+				}
+			}
 			return true
 		}
 	}
 	return false
 }
 
-func IsFBCBuild(gitUrl string) bool {
-	for _, componentScenario := range componentScenarios {
-		if utils.GetRepoName(componentScenario.GitURL) == utils.GetRepoName(gitUrl) && componentScenario.PipelineBundleName == "fbc-builder" {
-			return true
-		}
-	}
-	return false
+func IsDockerBuildPipeline(pipelineName string) bool {
+	return strings.HasPrefix(pipelineName, "docker-build")
 }
 
-func GetComponentScenarioDetailsFromGitUrl(gitUrl string) (string, string, string, bool, string, bool) {
+func IsFBCBuildPipeline(pipelineName string) bool {
+	return pipelineName == "fbc-builder"
+}
+
+// TODO: check calls to this function. They should be checking the return. Maybe it should return an error? Yes.
+func GetComponentScenarioDetailsFromGitUrl(gitUrl string) ComponentScenarioSpec {
 	for _, componentScenario := range componentScenarios {
 		//check repo name for both the giturls is same
 		if utils.GetRepoName(componentScenario.GitURL) == utils.GetRepoName(gitUrl) {
-			return componentScenario.ContextDir, componentScenario.DockerFilePath, componentScenario.PipelineBundleName, componentScenario.EnableHermetic, componentScenario.PrefetchInput, componentScenario.CheckAdditionalTags
+			return componentScenario.DeepCopy()
 		}
 	}
-	return "", "", "", false, "", false
+	return ComponentScenarioSpec{}
 }

--- a/tests/build/const.go
+++ b/tests/build/const.go
@@ -60,7 +60,6 @@ const (
 var (
 	additionalTags                     = []string{"test-tag1", "test-tag2"}
 	componentUrls                      = strings.Split(utils.GetEnv(COMPONENT_REPO_URLS_ENV, pythonComponentGitHubURL), ",") //multiple urls
-	componentNames                     []string
 	githubOrg                          = utils.GetEnv(constants.GITHUB_E2E_ORGANIZATION_ENV, "redhat-appstudio-qe")
 	gitlabOrg                          = utils.GetEnv(constants.GITLAB_QE_ORG_ENV, constants.DefaultGitLabQEOrg)
 	helloWorldComponentGitHubURL       = fmt.Sprintf(githubUrlFormat, githubOrg, helloWorldComponentGitSourceRepoName)

--- a/tests/build/source_build.go
+++ b/tests/build/source_build.go
@@ -34,7 +34,7 @@ func CheckParentSources(c client.Client, tektonController *tekton.TektonControll
 	Expect(err).ShouldNot(HaveOccurred())
 
 	var baseImagesDigests []string
-	if IsDockerBuild(gitUrl) {
+	if IsDockerBuildGitURL(gitUrl) {
 		parsedDockerfile := parseDockerfileUsedForBuild(c, tektonController, pr)
 		if parsedDockerfile.IsBuildFromScratch() {
 			Expect(buildResult.BaseImageSourceIncluded).Should(BeFalse())


### PR DESCRIPTION
# Description

Modify the structure of the component test scenarios to allow them to be executed by different build Pipelines.

Also... 

In newer build Pipelines, the show-summary Task is no longer included. As such, remove the test that ensures the show-summary Task was included in the build Pipeline.

## Issue ticket number and link

Ref: https://issues.redhat.com/browse/EC-715

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
