### PR TITLE
fix: skip the dockerfile check for hermatic and fbc scenarios

### DIFF
--- a/tests/build/build_templates.go
+++ b/tests/build/build_templates.go
@@ -348,7 +348,10 @@ var _ = framework.BuildSuiteDescribe("Build templates E2E test", Label("build", 
 			})
 
 			It("should push Dockerfile to registry", Label(buildTemplatesTestLabel), func() {
-				ensureOriginalDockerfileIsPushed(kubeadminClient, pr)
+				// Once https://issues.redhat.com/browse/STONEBLD-2795 is resolved, apply this check for hermetic scenario as well
+				if !IsHermeticScenario(gitUrl) && !IsFBCBuild(gitUrl) {
+					ensureOriginalDockerfileIsPushed(kubeadminClient, pr)
+				}
 			})
 
 			It("floating tags are created successfully", func() {

--- a/tests/build/build_templates_scenarios.go
+++ b/tests/build/build_templates_scenarios.go
@@ -129,6 +129,15 @@ func IsFBCBuild(gitUrl string) bool {
 	return false
 }
 
+func IsHermeticScenario(gitUrl string) bool {
+	for _, componentScenario := range componentScenarios {
+		if utils.GetRepoName(componentScenario.GitURL) == utils.GetRepoName(gitUrl) && componentScenario.EnableHermetic {
+			return true
+		}
+	}
+	return false
+}
+
 func GetComponentScenarioDetailsFromGitUrl(gitUrl string) (string, string, string, bool, string, bool) {
 	for _, componentScenario := range componentScenarios {
 		//check repo name for both the giturls is same


### PR DESCRIPTION
# Description

for hermetic builds, the original Dockerfile is modified and the one pushed to quay with `.dockerfile` tag is the modified one, does not match the original Dockerfile in the repo, so skipped the check till the issue [STONEBLD-2795](https://issues.redhat.com//browse/STONEBLD-2795) is fixed

## Issue ticket number and link
https://issues.redhat.com/browse/STONEBLD-2795

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

https://github.com/konflux-ci/build-definitions/pull/1410

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
