### PR TITLE
fix: skip creating multiple component for symlink test

### DIFF
--- a/tests/build/build_templates_scenarios.go
+++ b/tests/build/build_templates_scenarios.go
@@ -35,11 +35,12 @@ func (s ComponentScenarioSpec) DeepCopy() ComponentScenarioSpec {
 
 var componentScenarios = []ComponentScenarioSpec{
 	{
-		GitURL:              "https://github.com/konflux-qe-bd/devfile-sample-python-basic",
-		Revision:            "47fc22092005aabebce233a9b6eab994a8152bbd",
-		ContextDir:          ".",
-		DockerFilePath:      constants.DockerFilePath,
-		PipelineBundleNames: []string{"docker-build", "docker-build-oci-ta", "docker-build-multi-platform-oci-ta"},
+		GitURL:         "https://github.com/konflux-qe-bd/devfile-sample-python-basic",
+		Revision:       "47fc22092005aabebce233a9b6eab994a8152bbd",
+		ContextDir:     ".",
+		DockerFilePath: constants.DockerFilePath,
+		// "docker-build-multi-platform-oci-ta" needs to be enabled, when the issue https://issues.redhat.com/browse/KFLUXBUGS-1646 is fixed
+		PipelineBundleNames: []string{"docker-build", "docker-build-oci-ta"},
 		EnableHermetic:      false,
 		PrefetchInput:       "",
 	},


### PR DESCRIPTION
# Description

Observed that multiple component/pipelineruns getting created for the symlink component test after [this PR](https://github.com/konflux-ci/e2e-tests/pull/1384) got merged, we expect to run symlink component with only one pipeline bundle `docker-build`, since it is just a negative scenario

## Issue ticket number and link
NA

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Locally

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
