### PR TITLE
feat(KONFLUX-852): Monitor pods which use more memory than requests

### DIFF
--- a/tests/load-tests/cluster_read_config.yaml
+++ b/tests/load-tests/cluster_read_config.yaml
@@ -200,3 +200,22 @@
 {{ monitor_pod('openshift-pipelines', 'tekton-pipelines-controller', 15) }}
 {{ monitor_pod('tekton-results', 'tekton-results-watcher', 1, '-.*') }}
 {{ monitor_pod_container('tekton-results', 'tekton-results-watcher', 'watcher', 1, '-.*') }}
+
+# Gathering pods used memory and requests if used > requests
+{% macro monitor_pod_memory(namespace, pod, step=15) -%}
+# Gather monitoring data about the pod's memory used
+- name: measurements.{{ namespace }}.pod[{{ pod }}].memory.used
+  monitoring_query: sum(container_memory_working_set_bytes{namespace='{{namespace}}',pod='{{pod}}'})
+  monitoring_step: {{ step }}
+# Gather monitoring data about the pod's memory requests
+- name: measurements.{{ namespace }}.pod[{{ pod }}].memory.requests
+  monitoring_query: sum(kube_pod_container_resource_requests{namespace='{{namespace}}',pod='{{pod}}'})
+  monitoring_step: {{ step }}
+{%- endmacro %}
+
+{% if pods_use_requests is defined and pods_use_requests|length %}
+  {% for row in pods_use_requests.split(';') %}
+    {% set fields = row.split(',') %}
+    {{ monitor_pod_memory(fields[0], fields[1]) }}
+  {% endfor %}
+{% endif %}


### PR DESCRIPTION
# Description

This capture pods which consumes more memory than their "requests" settings during perf testing.

The pods which consumes more memory than their "requests" settings might be evicted from cluster and restarted if the cluster suffers from memory pressure.

First of all, we have a Prometheus query[1] to get all pods which consumes memory more than their "requests" settings.

Then, query those pod memory usage and requests, and write those monitoring to csv files.

[1] Prometheus query: sum by (namespace,pod) (avg_over_time(container_memory_working_set_bytes{namespace!\~"openshift-.\*|kube-.\*|.\*-tenant",container!="POD",container!=""}[1d]))- sum by (namespace,pod)(kube_pod_container_resource_requests{resource="memory",namespace!\~"openshift-.\*|kube-*|*-tenant"}) >0

## Issue ticket number and link
[KONFLUX-852](https://issues.redhat.com/browse/KONFLUX-852)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Manually evaluated part of the code change by running through success and failure scenarios.

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
