### PR TITLE
fix(KFLUXBUGS-1487): Duplicated build PLRs in GitLab e2e test

### DIFF
--- a/tests/integration-service/gitlab-integration-reporting.go
+++ b/tests/integration-service/gitlab-integration-reporting.go
@@ -82,12 +82,14 @@ var _ = framework.IntegrationServiceSuiteDescribe("Gitlab Status Reporting of In
 
 		AfterAll(func() {
 			if !CurrentSpecReport().Failed() {
-				// Cleanup test: close MR if opened, delete created branch, delete associated Webhooks and delete usersignup
-				Expect(f.AsKubeAdmin.CommonController.Gitlab.CloseMergeRequest(projectID, mrID)).NotTo(HaveOccurred())
-				Expect(f.AsKubeAdmin.CommonController.Gitlab.DeleteBranch(projectID, componentBaseBranchName)).NotTo(HaveOccurred())
-				Expect(f.AsKubeAdmin.CommonController.Gitlab.DeleteWebhooks(projectID, f.ClusterAppDomain)).NotTo(HaveOccurred())
+				Expect(f.AsKubeAdmin.HasController.DeleteApplication(applicationName, testNamespace, false)).To(Succeed())
 				Expect(f.SandboxController.DeleteUserSignup(f.UserName)).To(BeTrue())
 			}
+
+			// Cleanup test: close MR if opened, delete created branch, delete associated Webhooks
+			Expect(f.AsKubeAdmin.CommonController.Gitlab.CloseMergeRequest(projectID, mrID)).NotTo(HaveOccurred())
+			Expect(f.AsKubeAdmin.CommonController.Gitlab.DeleteBranch(projectID, componentBaseBranchName)).NotTo(HaveOccurred())
+			Expect(f.AsKubeAdmin.CommonController.Gitlab.DeleteWebhooks(projectID, f.ClusterAppDomain)).NotTo(HaveOccurred())
 		})
 
 		When("a new Component with specified custom branch is created", Label("custom-branch"), func() {

--- a/tests/integration-service/gitlab-integration-reporting.go
+++ b/tests/integration-service/gitlab-integration-reporting.go
@@ -15,9 +15,6 @@ import (
 	"github.com/konflux-ci/e2e-tests/pkg/framework"
 	"github.com/konflux-ci/e2e-tests/pkg/utils"
 
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	appstudioApi "github.com/konflux-ci/application-api/api/v1alpha1"
 	integrationv1beta2 "github.com/konflux-ci/integration-service/api/v1beta2"
 	. "github.com/onsi/ginkgo/v2"
@@ -81,21 +78,6 @@ var _ = framework.IntegrationServiceSuiteDescribe("Gitlab Status Reporting of In
 
 			err = build.CreateGitlabBuildSecret(f, "gitlab-build-secret", secretAnnotations, gitlabToken)
 			Expect(err).ShouldNot(HaveOccurred())
-
-			secret := &v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "pipelines-as-code-secret",
-					Namespace: testNamespace,
-				},
-				Type: v1.SecretTypeOpaque,
-				StringData: map[string]string{
-					"password": gitlabToken,
-				},
-			}
-
-			// create a pipeline-as-code-secret in testNamespace
-			_, err = f.AsKubeAdmin.CommonController.CreateSecret(f.UserNamespace, secret)
-			Expect(err).NotTo(HaveOccurred())
 		})
 
 		AfterAll(func() {


### PR DESCRIPTION
# Description

* Removes the unused PaC secret in the GitLab test suite.
* But that is not the root cause, still finding that one...

## Issue ticket number and link

[KFLUXBUGS-1487](https://issues.redhat.com//browse/KFLUXBUGS-1487)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
