### PR TITLE
feat(RELEASE-1147): update repository to registry.redhat.io in rpa

### DIFF
--- a/tests/release/pipelines/multiarch_advisories.go
+++ b/tests/release/pipelines/multiarch_advisories.go
@@ -26,11 +26,11 @@ import (
 )
 
 const (
-	multiarchServiceAccountName  = "release-service-account"
-	multiarchCatalogPathInRepo   = "pipelines/rh-advisories/rh-advisories.yaml"
-	multiarchGitSourceURL        = "https://github.com/redhat-appstudio-qe/multi-platform-test-prod"
-	multiarchGitSourceRepoName   = "multi-platform-test-prod"
-	multiarchGitSrcSHA           = "fd4b6c28329ab3df77e7ad7beebac1829836561d"
+	multiarchServiceAccountName = "release-service-account"
+	multiarchCatalogPathInRepo  = "pipelines/rh-advisories/rh-advisories.yaml"
+	multiarchGitSourceURL       = "https://github.com/redhat-appstudio-qe/multi-platform-test-prod"
+	multiarchGitSourceRepoName  = "multi-platform-test-prod"
+	multiarchGitSrcSHA          = "fd4b6c28329ab3df77e7ad7beebac1829836561d"
 )
 
 var multiarchComponentName = "e2e-multi-platform-test"
@@ -225,7 +225,6 @@ func createMultiArchReleasePlan(multiarchReleasePlanName string, devFw framework
 	Expect(err).NotTo(HaveOccurred())
 }
 
-
 func createMultiArchReleasePlanAdmission(multiarchRPAName string, managedFw framework.Framework, devNamespace, managedNamespace, multiarchAppName, multiarchECPName, pathInRepoValue string) {
 	var err error
 
@@ -233,9 +232,9 @@ func createMultiArchReleasePlanAdmission(multiarchRPAName string, managedFw fram
 		"mapping": map[string]interface{}{
 			"components": []map[string]interface{}{
 				{
-					"name": multiarchComponentName,
-					"repository": "quay.io/redhat-pending/rhtap----konflux-release-e2e",
-					"tags": []string{"latest", "latest-{{ timestamp }}"},
+					"name":       multiarchComponentName,
+					"repository": "registry.stage.redhat.io/rhtap/konflux-release-e2e",
+					"tags":       []string{"latest", "latest-{{ timestamp }}"},
 					"source": map[string]interface{}{
 						"git": map[string]interface{}{
 							"url": multiarchGitSourceURL,

--- a/tests/release/pipelines/rh_advisories.go
+++ b/tests/release/pipelines/rh_advisories.go
@@ -8,23 +8,23 @@ import (
 	"regexp"
 	"time"
 
-	appservice "github.com/konflux-ci/application-api/api/v1alpha1"
-	corev1 "k8s.io/api/core/v1"
 	ecp "github.com/enterprise-contract/enterprise-contract-controller/api/v1alpha1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	appservice "github.com/konflux-ci/application-api/api/v1alpha1"
 	releasecommon "github.com/konflux-ci/e2e-tests/tests/release"
 	releaseapi "github.com/konflux-ci/release-service/api/v1alpha1"
 	tektonutils "github.com/konflux-ci/release-service/tekton/utils"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/devfile/library/v2/pkg/util"
 	"github.com/konflux-ci/e2e-tests/pkg/constants"
 	"github.com/konflux-ci/e2e-tests/pkg/framework"
 	"github.com/konflux-ci/e2e-tests/pkg/utils"
 	"github.com/konflux-ci/e2e-tests/pkg/utils/tekton"
-	"knative.dev/pkg/apis"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"knative.dev/pkg/apis"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -84,7 +84,7 @@ var _ = framework.ReleasePipelinesSuiteDescribe("e2e tests for rh-advisories pip
 			Expect(err).ToNot(HaveOccurred())
 
 			pyxisSecret, err := managedFw.AsKubeAdmin.CommonController.GetSecret(managedNamespace, "pyxis")
-			if pyxisSecret == nil || errors.IsNotFound(err){
+			if pyxisSecret == nil || errors.IsNotFound(err) {
 				secret := &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "pyxis",
@@ -114,7 +114,7 @@ var _ = framework.ReleasePipelinesSuiteDescribe("e2e tests for rh-advisories pip
 			createADVSEnterpriseContractPolicy(advsEnterpriseContractPolicyName, *managedFw, devNamespace, managedNamespace)
 
 			snapshotPush, err = releasecommon.CreateSnapshotWithImageSource(*devFw, advsComponentName, advsApplicationName, devNamespace, sampleImage, advsGitSourceURL, advsGitSrcSHA, "", "", "", "")
-                        Expect(err).ShouldNot(HaveOccurred())
+			Expect(err).ShouldNot(HaveOccurred())
 		})
 
 		AfterAll(func() {
@@ -237,7 +237,7 @@ func createADVSReleasePlanAdmission(advsRPAName string, managedFw framework.Fram
 			"components": []map[string]interface{}{
 				{
 					"name":       advsComponentName,
-					"repository": "quay.io/redhat-pending/rhtap----konflux-release-e2e",
+					"repository": "registry.stage.redhat.io/rhtap/konflux-release-e2e",
 					"tags": []string{"latest", "latest-{{ timestamp }}", "testtag",
 						"testtag-{{ timestamp }}", "testtag2", "testtag2-{{ timestamp }}"},
 				},
@@ -256,7 +256,7 @@ func createADVSReleasePlanAdmission(advsRPAName string, managedFw framework.Fram
 			"type":            "RHSA",
 		},
 		"sign": map[string]interface{}{
-			"configMapName": "hacbs-signing-pipeline-config-redhatbeta2",
+			"configMapName":    "hacbs-signing-pipeline-config-redhatbeta2",
 			"cosignSecretName": "test-cosign-secret",
 		},
 	})

--- a/tests/release/pipelines/rh_push_to_redhat_io.go
+++ b/tests/release/pipelines/rh_push_to_redhat_io.go
@@ -80,7 +80,7 @@ var _ = framework.ReleasePipelinesSuiteDescribe("e2e tests for rh-push-to-redhat
 			Expect(err).ToNot(HaveOccurred())
 
 			pyxisSecret, err := managedFw.AsKubeAdmin.CommonController.GetSecret(managedNamespace, "pyxis")
-			if pyxisSecret == nil || errors.IsNotFound(err){
+			if pyxisSecret == nil || errors.IsNotFound(err) {
 				secret := &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "pyxis",
@@ -112,7 +112,7 @@ var _ = framework.ReleasePipelinesSuiteDescribe("e2e tests for rh-push-to-redhat
 
 			snapshotPush, err = releasecommon.CreateSnapshotWithImageSource(*devFw, rhioComponentName, rhioApplicationName, devNamespace, sampleImage, rhioGitSourceURL, rhioGitSrcSHA, "", "", "", "")
 			GinkgoWriter.Println("snapshotPush.Name: %s", snapshotPush.GetName())
-                        Expect(err).ShouldNot(HaveOccurred())
+			Expect(err).ShouldNot(HaveOccurred())
 		})
 
 		AfterAll(func() {
@@ -202,7 +202,7 @@ func createRHIOReleasePlanAdmission(rhioRPAName string, managedFw framework.Fram
 			"components": []map[string]interface{}{
 				{
 					"name":       rhioComponentName,
-					"repository": "quay.io/redhat-pending/rhtap----konflux-release-e2e",
+					"repository": "registry.stage.redhat.io/rhtap/konflux-release-e2e",
 					"tags": []string{"latest", "latest-{{ timestamp }}", "testtag",
 						"testtag-{{ timestamp }}", "testtag2", "testtag2-{{ timestamp }}"},
 				},
@@ -232,7 +232,7 @@ func createRHIOReleasePlanAdmission(rhioRPAName string, managedFw framework.Fram
 			},
 		},
 		"sign": map[string]interface{}{
-			"configMapName": "hacbs-signing-pipeline-config-redhatbeta2",
+			"configMapName":    "hacbs-signing-pipeline-config-redhatbeta2",
 			"cosignSecretName": "test-cosign-secret",
 		},
 	})

--- a/tests/release/pipelines/rhtap_service_push.go
+++ b/tests/release/pipelines/rhtap_service_push.go
@@ -8,22 +8,22 @@ import (
 	"strings"
 	"time"
 
-	appservice "github.com/konflux-ci/application-api/api/v1alpha1"
-	corev1 "k8s.io/api/core/v1"
+	"github.com/devfile/library/v2/pkg/util"
 	ecp "github.com/enterprise-contract/enterprise-contract-controller/api/v1alpha1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	releasecommon "github.com/konflux-ci/e2e-tests/tests/release"
-	releaseapi "github.com/konflux-ci/release-service/api/v1alpha1"
-	tektonutils "github.com/konflux-ci/release-service/tekton/utils"
+	appservice "github.com/konflux-ci/application-api/api/v1alpha1"
 	"github.com/konflux-ci/e2e-tests/pkg/clients/github"
 	"github.com/konflux-ci/e2e-tests/pkg/constants"
 	"github.com/konflux-ci/e2e-tests/pkg/framework"
 	"github.com/konflux-ci/e2e-tests/pkg/utils"
 	"github.com/konflux-ci/e2e-tests/pkg/utils/tekton"
-	"github.com/devfile/library/v2/pkg/util"
-	"knative.dev/pkg/apis"
+	releasecommon "github.com/konflux-ci/e2e-tests/tests/release"
+	releaseapi "github.com/konflux-ci/release-service/api/v1alpha1"
+	tektonutils "github.com/konflux-ci/release-service/tekton/utils"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"knative.dev/pkg/apis"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -126,7 +126,7 @@ var _ = framework.ReleasePipelinesSuiteDescribe("e2e tests for rhtap-service-pus
 			createRHTAPEnterpriseContractPolicy(rhtapEnterpriseContractPolicyName, *managedFw, devNamespace, managedNamespace)
 
 			snapshot, err = releasecommon.CreateSnapshotWithImageSource(*devFw, rhtapComponentName, rhtapApplicationName, devNamespace, sampleImage, rhtapGitSourceURL, rhtapGitSrcSHA, "", "", "", "")
-                        Expect(err).ShouldNot(HaveOccurred())
+			Expect(err).ShouldNot(HaveOccurred())
 		})
 
 		AfterAll(func() {
@@ -245,7 +245,7 @@ func createRHTAPReleasePlanAdmission(rhtapRPAName string, managedFw framework.Fr
 			"components": []map[string]interface{}{
 				{
 					"name":       rhtapComponentName,
-					"repository": "quay.io/redhat-pending/rhtap----konflux-release-e2e",
+					"repository": "registry.stage.redhat.io/rhtap/konflux-release-e2e",
 					"tags": []string{"latest", "latest-{{ timestamp }}", "testtag",
 						"testtag-{{ timestamp }}", "testtag2", "testtag2-{{ timestamp }}"},
 					"source": map[string]interface{}{


### PR DESCRIPTION
 This commit change the repository value from quay* to registry*
 in RPA mapping. This was implemented in release-238.

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
