### PR TITLE
feat: enable dockerfile check for hermetic builds

### DIFF
--- a/tests/build/build_templates.go
+++ b/tests/build/build_templates.go
@@ -362,8 +362,7 @@ var _ = framework.BuildSuiteDescribe("Build templates E2E test", Label("build", 
 			})
 
 			It("should push Dockerfile to registry", Label(buildTemplatesTestLabel), func() {
-				// Once https://issues.redhat.com/browse/STONEBLD-2795 is resolved, apply this check for hermetic scenario as well
-				if !scenario.EnableHermetic && !IsFBCBuildPipeline(pipelineBundleName) {
+				if !IsFBCBuildPipeline(pipelineBundleName) {
 					ensureOriginalDockerfileIsPushed(kubeadminClient, pr)
 				}
 			})

--- a/tests/build/build_templates.go
+++ b/tests/build/build_templates.go
@@ -844,7 +844,7 @@ func ensureOriginalDockerfileIsPushed(hub *framework.ControllerHub, pr *tektonpi
 	}.String()
 	exists, err := build.DoesTagExistsInQuay(dockerfileImage)
 	Expect(err).Should(Succeed())
-	Expect(exists).Should(BeTrue())
+	Expect(exists).Should(BeTrue(), fmt.Sprintf("image doesn't exist: %s", dockerfileImage))
 
 	// Ensure the original Dockerfile used for build was pushed
 	c := hub.CommonController.KubeRest()
@@ -859,7 +859,7 @@ func ensureOriginalDockerfileIsPushed(hub *framework.ControllerHub, pr *tektonpi
 		if entry.Type().IsRegular() && entry.Name() == "Dockerfile" {
 			content, err := os.ReadFile(filepath.Join(storePath, entry.Name()))
 			Expect(err).Should(Succeed())
-			Expect(content).Should(Equal(originDockerfileContent))
+			Expect(string(content)).Should(Equal(string(originDockerfileContent)))
 			return
 		}
 	}


### PR DESCRIPTION
[STONEBLD-2795](https://issues.redhat.com//browse/STONEBLD-2795)

Hermetic builds should now push the original dockerfile, not the modified one. Enable the check.

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
