### PR TITLE
fix: re-trigger pipeline run failure issue

### DIFF
--- a/pkg/clients/has/components.go
+++ b/pkg/clients/has/components.go
@@ -410,7 +410,7 @@ func (h *HasController) RetriggerComponentPipelineRun(component *appservice.Comp
 			gitlabOrg := utils.GetEnv(constants.GITLAB_QE_ORG_ENV, constants.DefaultGitLabQEOrg)
 			projectID, ok := prLabels["pipelinesascode.tekton.dev/source-project-id"]
 			if !ok {
-				projectID = fmt.Sprintf("%s/%s", gitlabOrg, constants.DefaultGitLabRepoName)
+				projectID = fmt.Sprintf("%s/%s", gitlabOrg, repoName)
 			}
 			_, err := h.GitLab.CreateFile(projectID, util.GenerateRandomString(5), "test", branchName)
 			if err != nil {


### PR DESCRIPTION
# Description

`RetriggerComponentPipelineRun` was failing for gitlab build test with below error
```
unable to retrigger pipelinerun for component build-e2e-vulo-tenant:gl-test-custom-branch-evasji: failed to retrigger PipelineRun gl-test-custom-branch-evasji-on-pull-request-t4t8p in build-e2e-vulo-tenant namespace: error when creating file contents: response (&{0xc0015f9950 0 0 0 0 0 0    }) and error: POST XXXXXXXXXXXXXXXXXXXXXXXXX/projects/konflux-qe/hacbs-test-project-integration/repository/files/aweow: 400 {message: You can only create or edit files when you are on a branch}
```

## Issue ticket number and link

https://issues.redhat.com/browse/KFLUXBUGS-1615

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
