### PR TITLE
feat(RELEASE-1102): remove unused data.fbc params

### DIFF
--- a/tests/release/pipelines/fbc_release.go
+++ b/tests/release/pipelines/fbc_release.go
@@ -295,8 +295,6 @@ func createFBCReleasePlanAdmission(fbcRPAName string, managedFw framework.Framew
 			"targetIndex":                     constants.TargetIndex,
 			"binaryImage":                     constants.BinaryImage,
 			"publishingCredentials":           "fbc-preview-publishing-credentials",
-			"iibServiceConfigSecret":          "iib-preview-services-config",
-			"iibOverwriteFromIndexCredential": "iib-overwrite-fromimage-credentials",
 			"requestUpdateTimeout":            "1500",
 			"buildTimeoutSeconds":             "1500",
 			"hotfix":                          hotfix,


### PR DESCRIPTION
this commit removes iibServiceConfigSecret  and iibOverwriteFromIndexCredential as both are paremeters pinned by the FBC pipeline and should not be rewritten.

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
