### PR TITLE
feat: add no-color flag to e2e tests

### DIFF
--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -1293,7 +1293,7 @@ func CleanWorkload() error {
 
 func runTests(labelsToRun string, junitReportFile string) error {
 
-	ginkgoArgs := []string{"-p", "--output-interceptor-mode=none",
+	ginkgoArgs := []string{"-p", "--output-interceptor-mode=none", "--no-color",
 		"--timeout=90m", fmt.Sprintf("--output-dir=%s", artifactDir),
 		"--junit-report=" + junitReportFile, "--label-filter=" + labelsToRun}
 


### PR DESCRIPTION
# Description

By default ginkgo use colors in the output and that uglify that logs and make them confused
## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
