### PR TITLE
feat: Lower number of iterations when creating user

### DIFF
--- a/pkg/sandbox/sandbox.go
+++ b/pkg/sandbox/sandbox.go
@@ -324,7 +324,7 @@ func (s *SandboxController) CheckUserCreated(userName string) (compliantUsername
 }
 
 func (s *SandboxController) CheckUserCreatedWithSignUp(userName string, userSignup *toolchainApi.UserSignup) (compliantUsername string, err error) {
-	err = utils.WaitUntil(func() (done bool, err error) {
+	err = utils.WaitUntilWithInterval(func() (done bool, err error) {
 		err = s.KubeRest.Get(context.Background(), types.NamespacedName{
 			Namespace: DEFAULT_TOOLCHAIN_NAMESPACE,
 			Name:      userName,
@@ -346,7 +346,7 @@ func (s *SandboxController) CheckUserCreatedWithSignUp(userName string, userSign
 		}
 		GinkgoWriter.Printf("Waiting for UserSignup %s to have condition Complete:True\n", userSignup.GetName())
 		return false, nil
-	}, 4*time.Minute)
+	}, 4*time.Second, 4*time.Minute)
 
 	if err != nil {
 		return "", err


### PR DESCRIPTION
# Description

When we are creating 100 users in Load test in CI cluster it takes 30+ iterations to create first user. Adding 1 second delay will lower amount of output we are getting from this function given the price of about 0.5 seconds longer user creation.

## Issue ticket number and link

N/A

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I rely on CI, running some jobs with this change in https://github.com/konflux-ci/e2e-tests/pull/1382