### PR TITLE
refactor: use generic client in gitlab build tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/moby/buildkit v0.12.5
 	github.com/onsi/ginkgo/v2 v2.17.3
 	github.com/onsi/gomega v1.33.1
+	github.com/opencontainers/image-spec v1.1.0
 	github.com/openshift-pipelines/pipelines-as-code v0.18.0
 	github.com/openshift/api v0.0.0-20230213134911-7ba313770556
 	github.com/openshift/client-go v0.0.0-20221019143426-16aed247da5c
@@ -171,7 +172,6 @@ require (
 	github.com/go-kit/log v0.2.1 // indirect
 	github.com/go-logfmt/logfmt v0.6.0 // indirect
 	github.com/go-logr/logr v1.4.1 // indirect
-	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/errors v0.21.0 // indirect
 	github.com/go-openapi/jsonpointer v0.20.2 // indirect
 	github.com/go-openapi/jsonreference v0.20.4 // indirect
@@ -241,7 +241,6 @@ require (
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
-	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/opencontainers/runc v1.1.14 // indirect
 	github.com/opencontainers/runtime-spec v1.1.0 // indirect
 	github.com/operator-framework/operator-lib v0.13.0 // indirect
@@ -255,10 +254,7 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/prometheus/statsd_exporter v0.23.1 // indirect
-	github.com/redhat-appstudio/application-api v0.0.0-20240106104232-18f545e48a03 // indirect
 	github.com/redhat-appstudio/image-controller v0.0.0-20231003082540-48893226ba8b // indirect
-	github.com/redhat-appstudio/integration-service v0.0.0-20231025084434-b3f521c408d1 // indirect
-	github.com/redhat-appstudio/operator-toolkit v0.0.0-20231201124606-2087182322ae // indirect
 	github.com/redis/go-redis/v9 v9.0.5 // indirect
 	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1501,8 +1501,6 @@ github.com/konflux-ci/integration-service v0.0.0-20240513113947-6c76e6e0eb83 h1:
 github.com/konflux-ci/integration-service v0.0.0-20240513113947-6c76e6e0eb83/go.mod h1:g/8KTH8JJLFw+F/GE5OXC7CnL3SLAY3w7tfBM4ZM/ng=
 github.com/konflux-ci/operator-toolkit v0.0.0-20240402130556-ef6dcbeca69d h1:z7j3mglNoXvIrw5Vz/Ul+izoITRaqYURPIWrFoEyHgI=
 github.com/konflux-ci/operator-toolkit v0.0.0-20240402130556-ef6dcbeca69d/go.mod h1:AcChx7FjpYSIkDvQgaUKyauuF0PXm3ivB5MqZSC9Eis=
-github.com/konflux-ci/release-service v0.0.0-20240624130704-c6133cc0b908 h1:fVFlyCIB4eniA708isOgzCKYOeAXAsg8WFEZp1QQ3A4=
-github.com/konflux-ci/release-service v0.0.0-20240624130704-c6133cc0b908/go.mod h1:p+6Ua4y2VUJRW2BrwSXtVoV7b4PwL8PwbjJb2LaPu44=
 github.com/konflux-ci/release-service v0.0.0-20241016090118-bd730698b9c5 h1:eBQ2yFy/TRGhCGCbZC2KCM9rD/ADWorLxzpSmZ4JyKM=
 github.com/konflux-ci/release-service v0.0.0-20241016090118-bd730698b9c5/go.mod h1:KLuLvi1boDfnFsQL0cXytBLc+TWsRo80YQFTygElRvI=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
@@ -1790,16 +1788,10 @@ github.com/prometheus/statsd_exporter v0.22.7/go.mod h1:N/TevpjkIh9ccs6nuzY3jQn9
 github.com/prometheus/statsd_exporter v0.23.1 h1:TiNAE1XevlZZrpSbmf51l/Ryl2Eek9rYh//KlvcNvKw=
 github.com/prometheus/statsd_exporter v0.23.1/go.mod h1:FFmnBRWf+HxX+PR+2fnc0ciBIONVAPJ6k4lqIbdqVxo=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/redhat-appstudio/application-api v0.0.0-20240106104232-18f545e48a03 h1:UUgrEyvQJhEnvghkEaY9YlxeAk+D4cop+Bd3+8jh0eQ=
-github.com/redhat-appstudio/application-api v0.0.0-20240106104232-18f545e48a03/go.mod h1:YvckuKHe82eWloGk0/BpSw4YYG2owrGZAanztbOj3pQ=
 github.com/redhat-appstudio/image-controller v0.0.0-20231003082540-48893226ba8b h1:kM+t/FZSMVUydXIbii+bduAJov7pcADCybP9u1WSBcw=
 github.com/redhat-appstudio/image-controller v0.0.0-20231003082540-48893226ba8b/go.mod h1:fNP2oUEejlHZUkAz2f0ViKNl0D8w4cD8QVoGy1pri9c=
-github.com/redhat-appstudio/integration-service v0.0.0-20231025084434-b3f521c408d1 h1:Qo5VBBhi8ihz3mPaCQq0lGZAiCRAqhbv1XZkzyBTfGA=
-github.com/redhat-appstudio/integration-service v0.0.0-20231025084434-b3f521c408d1/go.mod h1:bh8uJ4whJ92ef5PXH6Rfm4F8tRXkDAlSYR7Pqp1LLT4=
 github.com/redhat-appstudio/jvm-build-service v0.0.0-20240126122210-0e2ee7e2e5b0 h1:wqP4/99Lg68zRpzt9zSc5OGf3zigaBlvflDuDLmDLdM=
 github.com/redhat-appstudio/jvm-build-service v0.0.0-20240126122210-0e2ee7e2e5b0/go.mod h1:awZP3qi/GpBhQ50N3rRjFPsGbFperwWYSTN+OVG1Gb8=
-github.com/redhat-appstudio/operator-toolkit v0.0.0-20231201124606-2087182322ae h1:98thWrMrr9YUNCVNGqkZxKfZkaWUmMC5dmkgAI7p3uY=
-github.com/redhat-appstudio/operator-toolkit v0.0.0-20231201124606-2087182322ae/go.mod h1:7cX2+4KGZLJ4Yoj+1v0iV5hkCGBzbSd9wkNJQjCdDJs=
 github.com/redhat-cop/operator-utils v1.3.3-0.20220121120056-862ef22b8cdf/go.mod h1:FfTyeSCu+e2VLgeMh/1RFG8TSkVjKRPEyR6EmDt0RIw=
 github.com/redis/go-redis/v9 v9.0.0-rc.4/go.mod h1:Vo3EsyWnicKnSKCA7HhgnvnyA74wOA69Cd2Meli5mmA=
 github.com/redis/go-redis/v9 v9.0.5 h1:CuQcn5HIEeK7BgElubPP8CGtE0KakrnbBSTLjathl5o=

--- a/pkg/clients/git/git.go
+++ b/pkg/clients/git/git.go
@@ -21,14 +21,23 @@ type PullRequest struct {
 	HeadSHA string
 }
 
+// RepositoryFile represents a generic provider-agnostic file in a repository
+type RepositoryFile struct {
+	// CommitSHA is the SHA of the commit in which the file was created
+	CommitSHA string
+	// Content is a string representation of the content of the file
+	Content string
+}
+
 type Client interface {
 	CreateBranch(repository, baseBranchName, revision, branchName string) error
 	DeleteBranch(repository, branchName string) error
 	BranchExists(repository, branchName string) (bool, error)
 	ListPullRequests(repository string) ([]*PullRequest, error)
-	CreateFile(repository, pathToFile, content, branchName string) error
-	GetFileContent(repository, pathToFile, branchName string) (string, error)
+	CreateFile(repository, pathToFile, content, branchName string) (*RepositoryFile, error)
+	GetFile(repository, pathToFile, branchName string) (*RepositoryFile, error)
 	CreatePullRequest(repository, title, body, head, base string) (*PullRequest, error)
 	MergePullRequest(repository string, prNumber int) (*PullRequest, error)
+	DeleteBranchAndClosePullRequest(repository string, prNumber int) error
 	CleanupWebhooks(repository, clusterAppDomain string) error
 }

--- a/tests/build/build.go
+++ b/tests/build/build.go
@@ -16,7 +16,6 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/openshift/library-go/pkg/image/reference"
 	pipeline "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
-	gitlab "github.com/xanzy/go-gitlab"
 	v1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -38,8 +37,12 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build-ser
 	var err error
 	defer GinkgoRecover()
 
-	DescribeTableSubtree("test PaC component build", Ordered, Label("github-webhook", "pac-build", "pipeline", "image-controller"), func(gitProvider, gitPrefix string) {
-		var applicationName, customDefaultComponentName, customBranchComponentName, componentBaseBranchName, pacBranchName, testNamespace, imageRepoName, pullRobotAccountName, pushRobotAccountName, helloWorldComponentGitSourceURL string
+	var gitClient git.Client
+
+	DescribeTableSubtree("test PaC component build", Ordered, Label("github-webhook", "pac-build", "pipeline", "image-controller"), func(gitProvider git.GitProvider, gitPrefix string) {
+		var applicationName, customDefaultComponentName, customBranchComponentName, componentBaseBranchName string
+		var pacBranchName, testNamespace, imageRepoName, pullRobotAccountName, pushRobotAccountName string
+		var helloWorldComponentGitSourceURL, customDefaultComponentBranch string
 		var component *appservice.Component
 		var plr *pipeline.PipelineRun
 
@@ -48,6 +51,8 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build-ser
 		var prNumber int
 		var prHeadSha string
 		var buildPipelineAnnotation map[string]string
+
+		var helloWorldRepository string
 
 		BeforeAll(func() {
 			if os.Getenv(constants.SKIP_PAC_TESTS_ENV) == "true" {
@@ -81,31 +86,15 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build-ser
 			customDefaultComponentName = fmt.Sprintf("%s-%s-%s", gitPrefix, "test-custom-default", util.GenerateRandomString(6))
 			customBranchComponentName = fmt.Sprintf("%s-%s-%s", gitPrefix, "test-custom-branch", util.GenerateRandomString(6))
 			pacBranchName = constants.PaCPullRequestBranchPrefix + customBranchComponentName
+			customDefaultComponentBranch = constants.PaCPullRequestBranchPrefix + customDefaultComponentName
 			componentBaseBranchName = fmt.Sprintf("base-%s", util.GenerateRandomString(6))
 
-			switch gitProvider {
-			case "github":
-				err = f.AsKubeAdmin.CommonController.Github.CreateRef(helloWorldComponentGitSourceRepoName, helloWorldComponentDefaultBranch, helloWorldComponentRevision, componentBaseBranchName)
-				Expect(err).ShouldNot(HaveOccurred())
-
-				helloWorldComponentGitSourceURL = helloWorldComponentGitHubURL
-			case "gitlab":
-				gitlabToken := utils.GetEnv(constants.GITLAB_BOT_TOKEN_ENV, "")
-				Expect(gitlabToken).ShouldNot(BeEmpty())
-
-				secretAnnotations := map[string]string{}
-
-				err = build.CreateGitlabBuildSecret(f, "pipelines-as-code-secret", secretAnnotations, gitlabToken)
-				Expect(err).ShouldNot(HaveOccurred())
-
-				err = f.AsKubeAdmin.CommonController.Gitlab.CreateBranch(helloWorldComponentGitLabProjectID, componentBaseBranchName, helloWorldComponentDefaultBranch)
-				Expect(err).ShouldNot(HaveOccurred())
-
-				helloWorldComponentGitSourceURL = helloWorldComponentGitLabURL
-			}
+			gitClient, helloWorldComponentGitSourceURL, helloWorldRepository = setupGitProvider(f, gitProvider)
 			// get the build pipeline bundle annotation
 			buildPipelineAnnotation = build.GetDockerBuildPipelineBundle()
 
+			err = gitClient.CreateBranch(helloWorldRepository, helloWorldComponentDefaultBranch, helloWorldComponentRevision, componentBaseBranchName)
+			Expect(err).ShouldNot(HaveOccurred())
 		})
 
 		AfterAll(func() {
@@ -114,32 +103,21 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build-ser
 				Expect(f.SandboxController.DeleteUserSignup(f.UserName)).To(BeTrue())
 			}
 
-			switch gitProvider {
-			case "github":
-				// Delete new branches created by PaC and a testing branch used as a component's base branch
-				err = f.AsKubeAdmin.CommonController.Github.DeleteRef(helloWorldComponentGitSourceRepoName, pacBranchName)
-				if err != nil {
-					Expect(err.Error()).To(ContainSubstring("Reference does not exist"))
-				}
-				err = f.AsKubeAdmin.CommonController.Github.DeleteRef(helloWorldComponentGitSourceRepoName, componentBaseBranchName)
-				if err != nil {
-					Expect(err.Error()).To(ContainSubstring("Reference does not exist"))
-				}
-				err = f.AsKubeAdmin.CommonController.Github.DeleteRef(helloWorldComponentGitSourceRepoName, constants.PaCPullRequestBranchPrefix+customBranchComponentName)
-				if err != nil {
-					Expect(err.Error()).To(ContainSubstring("Reference does not exist"))
-				}
-				// Delete created webhook from GitHub
-				Expect(build.CleanupWebhooks(f, helloWorldComponentGitSourceRepoName)).ShouldNot(HaveOccurred())
-			case "gitlab":
-				err = f.AsKubeAdmin.CommonController.Gitlab.CloseMergeRequest(helloWorldComponentGitLabProjectID, prNumber)
-				if err != nil {
-					Expect(err).To(MatchError(ContainSubstring("404")))
-				}
-
-				Expect(f.AsKubeAdmin.CommonController.Gitlab.DeleteBranch(helloWorldComponentGitLabProjectID, componentBaseBranchName)).To(Succeed())
-				Expect(f.AsKubeAdmin.CommonController.Gitlab.DeleteWebhooks(helloWorldComponentGitLabProjectID, f.ClusterAppDomain)).To(Succeed())
+			err = gitClient.DeleteBranch(helloWorldRepository, pacBranchName)
+			if err != nil {
+				Expect(err.Error()).To(Or(ContainSubstring("Reference does not exist"), ContainSubstring("404")))
 			}
+			err = gitClient.DeleteBranch(helloWorldRepository, componentBaseBranchName)
+			if err != nil {
+				Expect(err.Error()).To(Or(ContainSubstring("Reference does not exist"), ContainSubstring("404")))
+			}
+
+			err := gitClient.DeleteBranchAndClosePullRequest(helloWorldRepository, prNumber)
+			if err != nil {
+				Expect(err.Error()).To(Or(ContainSubstring("Reference does not exist"), ContainSubstring("404")))
+			}
+
+			Expect(gitClient.CleanupWebhooks(helloWorldRepository, f.ClusterAppDomain)).To(Succeed())
 		})
 
 		When("a new component without specified branch is created and with visibility private", Label("pac-custom-default-branch"), func() {
@@ -168,29 +146,14 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build-ser
 				timeout = time.Second * 300
 				interval = time.Second * 1
 				Eventually(func() bool {
-					switch gitProvider {
-					case "github":
-						prs, err := f.AsKubeAdmin.CommonController.Github.ListPullRequests(helloWorldComponentGitSourceRepoName)
-						Expect(err).ShouldNot(HaveOccurred())
+					prs, err := gitClient.ListPullRequests(helloWorldRepository)
+					Expect(err).ShouldNot(HaveOccurred())
 
-						for _, pr := range prs {
-							if pr.Head.GetRef() == constants.PaCPullRequestBranchPrefix+customDefaultComponentName {
-								Expect(pr.GetBase().GetRef()).To(Equal(helloWorldComponentDefaultBranch))
-								return true
-							}
+					for _, pr := range prs {
+						if pr.SourceBranch == customDefaultComponentBranch {
+							Expect(pr.TargetBranch).To(Equal(helloWorldComponentDefaultBranch))
+							return true
 						}
-						return false
-					case "gitlab":
-						mrs, err := f.AsKubeAdmin.CommonController.Gitlab.GetMergeRequests()
-						Expect(err).ShouldNot(HaveOccurred())
-
-						for _, mr := range mrs {
-							if mr.SourceBranch == constants.PaCPullRequestBranchPrefix+customDefaultComponentName {
-								Expect(mr.TargetBranch).To(Equal(helloWorldComponentDefaultBranch))
-								return true
-							}
-						}
-						return false
 					}
 					return false
 				}, timeout, interval).Should(BeTrue(), fmt.Sprintf("timed out when waiting for init PaC PR to be created against %s branch in %s repository", helloWorldComponentDefaultBranch, helloWorldComponentGitSourceRepoName))
@@ -291,24 +254,17 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build-ser
 						return fmt.Errorf("pipelinerun %s/%s is not removed yet", plr.GetNamespace(), plr.GetName())
 					}
 					return err
-				}, timeout, constants.PipelineRunPollingInterval).Should(MatchError(ContainSubstring("no pipelinerun found")), fmt.Sprintf("timed out when waiting for the PipelineRun to be removed for Component %s/%s", testNamespace, customBranchComponentName))
+				}, timeout, interval).Should(MatchError(ContainSubstring("no pipelinerun found")), fmt.Sprintf("timed out when waiting for the PipelineRun to be removed for Component %s/%s", testNamespace, customBranchComponentName))
 			})
 
 			It("PR branch should not exist in the repo", func() {
 				timeout = time.Second * 60
 				interval = time.Second * 1
-				branchName := constants.PaCPullRequestBranchPrefix + customDefaultComponentName
 				Eventually(func() bool {
-					var exists bool
-					switch gitProvider {
-					case "github":
-						exists, err = f.AsKubeAdmin.CommonController.Github.ExistsRef(helloWorldComponentGitSourceRepoName, constants.PaCPullRequestBranchPrefix+customDefaultComponentName)
-					case "gitlab":
-						exists, err = f.AsKubeAdmin.CommonController.Gitlab.ExistsBranch(helloWorldComponentGitLabProjectID, constants.PaCPullRequestBranchPrefix+customDefaultComponentName)
-					}
+					exists, err := gitClient.BranchExists(helloWorldRepository, customDefaultComponentBranch)
 					Expect(err).ShouldNot(HaveOccurred())
 					return exists
-				}, timeout, interval).Should(BeFalse(), fmt.Sprintf("timed out when waiting for the branch %s to be deleted from %s repository", branchName, helloWorldComponentGitSourceRepoName))
+				}, timeout, interval).Should(BeFalse(), fmt.Sprintf("timed out when waiting for the branch %s to be deleted from %s repository", customDefaultComponentBranch, helloWorldComponentGitSourceRepoName))
 			})
 
 			It("related image repo and the robot account should be deleted after deleting the component", func() {
@@ -378,31 +334,15 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build-ser
 				interval = time.Second * 1
 
 				Eventually(func() bool {
-					switch gitProvider {
-					case "github":
-						prs, err := f.AsKubeAdmin.CommonController.Github.ListPullRequests(helloWorldComponentGitSourceRepoName)
-						Expect(err).ShouldNot(HaveOccurred())
+					prs, err := gitClient.ListPullRequests(helloWorldRepository)
+					Expect(err).ShouldNot(HaveOccurred())
 
-						for _, pr := range prs {
-							if pr.Head.GetRef() == pacBranchName {
-								prNumber = pr.GetNumber()
-								prHeadSha = pr.Head.GetSHA()
-								return true
-							}
+					for _, pr := range prs {
+						if pr.SourceBranch == pacBranchName {
+							prNumber = pr.Number
+							prHeadSha = pr.HeadSHA
+							return true
 						}
-						return false
-					case "gitlab":
-						mrs, err := f.AsKubeAdmin.CommonController.Gitlab.GetMergeRequests()
-						Expect(err).ShouldNot(HaveOccurred())
-
-						for _, mr := range mrs {
-							if mr.SourceBranch == pacBranchName {
-								prNumber = mr.IID
-								prHeadSha = mr.DiffRefs.HeadSha
-								return true
-							}
-						}
-						return false
 					}
 					return false
 				}, timeout, interval).Should(BeTrue(), fmt.Sprintf("timed out when waiting for init PaC PR (branch name '%s') to be created in %s repository", pacBranchName, helloWorldComponentGitSourceRepoName))
@@ -482,10 +422,10 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build-ser
 			})
 			It("eventually leads to the PipelineRun status report at Checks tab", func() {
 				switch gitProvider {
-				case "github":
+				case git.GitHubProvider:
 					expectedCheckRunName := fmt.Sprintf("%s-%s", customBranchComponentName, "on-pull-request")
 					Expect(f.AsKubeAdmin.CommonController.Github.GetCheckRunConclusion(expectedCheckRunName, helloWorldComponentGitSourceRepoName, prHeadSha, prNumber)).To(Equal(constants.CheckrunConclusionSuccess))
-				case "gitlab":
+				case git.GitLabProvider:
 					expectedNote := fmt.Sprintf("**Pipelines as Code CI/%s-on-pull-request** has successfully validated your commit", customBranchComponentName)
 					f.AsKubeAdmin.HasController.GitLab.ValidateNoteInMergeRequestComment(helloWorldComponentGitLabProjectID, expectedNote, prNumber)
 				}
@@ -497,23 +437,12 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build-ser
 
 			BeforeAll(func() {
 				fileToCreatePath := fmt.Sprintf(".tekton/%s-readme.md", customBranchComponentName)
-				switch gitProvider {
-				case "github":
-					createdFile, err := f.AsKubeAdmin.CommonController.Github.CreateFile(helloWorldComponentGitSourceRepoName, fileToCreatePath, fmt.Sprintf("test PaC branch %s update", pacBranchName), pacBranchName)
-					Expect(err).NotTo(HaveOccurred())
 
-					createdFileSHA = createdFile.GetSHA()
-					GinkgoWriter.Println("created file sha:", createdFileSHA)
-				case "gitlab":
-					_, err = f.AsKubeAdmin.CommonController.Gitlab.CreateFile(helloWorldComponentGitLabProjectID, fileToCreatePath, fmt.Sprintf("test PaC branch %s update", pacBranchName), pacBranchName)
-					Expect(err).NotTo(HaveOccurred())
+				createdFile, err := gitClient.CreateFile(helloWorldRepository, fileToCreatePath, fmt.Sprintf("test PaC branch %s update", pacBranchName), pacBranchName)
+				Expect(err).ShouldNot(HaveOccurred())
 
-					metadata, err := f.AsKubeAdmin.CommonController.Gitlab.GetFileMetaData(helloWorldComponentGitLabProjectID, fileToCreatePath, pacBranchName)
-					Expect(err).NotTo(HaveOccurred())
-
-					createdFileSHA = metadata.CommitID
-					GinkgoWriter.Println("created file sha:", createdFileSHA)
-				}
+				createdFileSHA = createdFile.CommitSHA
+				GinkgoWriter.Println("created file sha:", createdFileSHA)
 			})
 
 			It("eventually leads to triggering another PipelineRun", func() {
@@ -536,33 +465,16 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build-ser
 				interval = time.Second * 1
 
 				Eventually(func() bool {
-					switch gitProvider {
-					case "github":
-						prs, err := f.AsKubeAdmin.CommonController.Github.ListPullRequests(helloWorldComponentGitSourceRepoName)
-						Expect(err).ShouldNot(HaveOccurred())
+					prs, err := gitClient.ListPullRequests(helloWorldRepository)
+					Expect(err).ShouldNot(HaveOccurred())
 
-						for _, pr := range prs {
-							if pr.Head.GetRef() == pacBranchName {
-								Expect(prHeadSha).NotTo(Equal(pr.Head.GetSHA()))
-								prNumber = pr.GetNumber()
-								prHeadSha = pr.Head.GetSHA()
-								return true
-							}
+					for _, pr := range prs {
+						if pr.SourceBranch == pacBranchName {
+							Expect(prHeadSha).NotTo(Equal(pr.HeadSHA))
+							prNumber = pr.Number
+							prHeadSha = pr.HeadSHA
+							return true
 						}
-						return false
-					case "gitlab":
-						mrs, err := f.AsKubeAdmin.CommonController.Gitlab.GetMergeRequests()
-						Expect(err).ShouldNot(HaveOccurred())
-
-						for _, mr := range mrs {
-							if mr.SourceBranch == pacBranchName {
-								Expect(prHeadSha).NotTo(Equal(mr.DiffRefs.HeadSha))
-								prNumber = mr.IID
-								prHeadSha = mr.DiffRefs.HeadSha
-								return true
-							}
-						}
-						return false
 					}
 					return false
 				}, timeout, interval).Should(BeTrue(), fmt.Sprintf("timed out when waiting for init PaC PR (branch name '%s') to be created in %s repository", pacBranchName, helloWorldComponentGitSourceRepoName))
@@ -575,10 +487,10 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build-ser
 			})
 			It("eventually leads to another update of a PR about the PipelineRun status report at Checks tab", func() {
 				switch gitProvider {
-				case "github":
+				case git.GitHubProvider:
 					expectedCheckRunName := fmt.Sprintf("%s-%s", customBranchComponentName, "on-pull-request")
 					Expect(f.AsKubeAdmin.CommonController.Github.GetCheckRunConclusion(expectedCheckRunName, helloWorldComponentGitSourceRepoName, createdFileSHA, prNumber)).To(Equal(constants.CheckrunConclusionSuccess))
-				case "gitlab":
+				case git.GitLabProvider:
 					expectedNote := fmt.Sprintf("**Pipelines as Code CI/%s-on-pull-request** has successfully validated your commit", customBranchComponentName)
 					f.AsKubeAdmin.HasController.GitLab.ValidateNoteInMergeRequestComment(helloWorldComponentGitLabProjectID, expectedNote, prNumber)
 				}
@@ -586,35 +498,16 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build-ser
 		})
 
 		When("the PaC init branch is merged", Label("build-custom-branch"), func() {
-			var mergeResult *github.PullRequestMergeResult
-			var mergeRequest *gitlab.MergeRequest
+			var mergeResult *git.PullRequest
 			var mergeResultSha string
 
 			BeforeAll(func() {
-				if gitProvider != "github" {
-					return
-				}
-
 				Eventually(func() error {
-					mergeResult, err = f.AsKubeAdmin.CommonController.Github.MergePullRequest(helloWorldComponentGitSourceRepoName, prNumber)
+					mergeResult, err = gitClient.MergePullRequest(helloWorldRepository, prNumber)
 					return err
 				}, time.Minute).Should(BeNil(), fmt.Sprintf("error when merging PaC pull request #%d in repo %s", prNumber, helloWorldComponentGitSourceRepoName))
 
-				mergeResultSha = mergeResult.GetSHA()
-				GinkgoWriter.Println("merged result sha:", mergeResultSha)
-			})
-
-			BeforeAll(func() {
-				if gitProvider != "gitlab" {
-					return
-				}
-
-				Eventually(func() error {
-					mergeRequest, err = f.AsKubeAdmin.CommonController.Gitlab.AcceptMergeRequest(helloWorldComponentGitLabProjectID, prNumber)
-					return err
-				}, time.Minute).Should(BeNil(), fmt.Sprintf("error when merging PaC pull request #%d in repo %s", prNumber, helloWorldComponentGitSourceRepoName))
-
-				mergeResultSha = mergeRequest.MergeCommitSHA
+				mergeResultSha = mergeResult.MergeCommitSHA
 				GinkgoWriter.Println("merged result sha:", mergeResultSha)
 			})
 
@@ -663,6 +556,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build-ser
 					return nil
 				}, time.Second*20, time.Second*1).Should(Succeed(), fmt.Sprintf("timed out when trying to change visibility of the image repos to private in %s/%s", testNamespace, customBranchComponentName))
 
+				GinkgoWriter.Printf("waiting for one minute and expecting to not trigger a PipelineRun")
 				Consistently(func() bool {
 					componentPipelineRun, _ := f.AsKubeAdmin.HasController.GetComponentPipelineRun(customBranchComponentName, applicationName, testNamespace, "")
 					return componentPipelineRun == nil
@@ -727,35 +621,21 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build-ser
 				timeout = time.Second * 10
 				interval = time.Second * 2
 				Consistently(func() error {
-					switch gitProvider {
-					case "github":
-						prs, err := f.AsKubeAdmin.CommonController.Github.ListPullRequests(helloWorldComponentGitSourceRepoName)
-						Expect(err).ShouldNot(HaveOccurred())
+					prs, err := gitClient.ListPullRequests(helloWorldRepository)
+					Expect(err).ShouldNot(HaveOccurred())
 
-						for _, pr := range prs {
-							if pr.Head.GetRef() == pacBranchName {
-								return fmt.Errorf("did not expect a new PR created in %s repository after initial PaC configuration was already merged for the same component name and a namespace", helloWorldComponentGitSourceRepoName)
-							}
+					for _, pr := range prs {
+						if pr.SourceBranch == pacBranchName {
+							return fmt.Errorf("did not expect a new PR created in %s repository after initial PaC configuration was already merged for the same component name and a namespace", helloWorldRepository)
 						}
-						return nil
-					case "gitlab":
-						mrs, err := f.AsKubeAdmin.CommonController.Gitlab.GetMergeRequests()
-						Expect(err).ShouldNot(HaveOccurred())
-
-						for _, mr := range mrs {
-							if mr.SourceBranch == pacBranchName {
-								return fmt.Errorf("did not expect a new PR created in %s repository after initial PaC configuration was already merged for the same component name and a namespace", helloWorldComponentGitSourceRepoName)
-							}
-						}
-						return nil
 					}
 					return nil
 				}, timeout, interval).Should(BeNil())
 			})
 		})
 	},
-		Entry("github", "github", "gh"),
-		Entry("gitlab", "gitlab", "gl"),
+		Entry("github", git.GitHubProvider, "gh"),
+		Entry("gitlab", git.GitLabProvider, "gl"),
 	)
 
 	Describe("test pac with multiple components using same repository", Ordered, Label("pac-build", "multi-component"), func() {
@@ -1687,10 +1567,10 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build-ser
 				Expect(imageRepoName).ShouldNot(BeEmpty(), "image repo name is empty")
 
 				parentImageNameWithNoDigest = "quay.io/" + quayOrg + "/" + imageRepoName
-				err = gitClient.CreateFile(childRepository, "Dockerfile.tmp", "FROM "+parentImageNameWithNoDigest+"@"+parentFirstDigest+"\nRUN echo hello\n", ChildComponentDef.pacBranchName)
+				_, err = gitClient.CreateFile(childRepository, "Dockerfile.tmp", "FROM "+parentImageNameWithNoDigest+"@"+parentFirstDigest+"\nRUN echo hello\n", ChildComponentDef.pacBranchName)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				err = gitClient.CreateFile(childRepository, "manifest.yaml", "image: "+distributionRepository+"@"+parentFirstDigest, ChildComponentDef.pacBranchName)
+				_, err = gitClient.CreateFile(childRepository, "manifest.yaml", "image: "+distributionRepository+"@"+parentFirstDigest, ChildComponentDef.pacBranchName)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				_, err = gitClient.CreatePullRequest(childRepository, "updated to build repo image", "update to build repo image", ChildComponentDef.pacBranchName, ChildComponentDef.componentBranch)
@@ -1800,14 +1680,14 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build-ser
 			It("Verify the nudge updated the contents", func() {
 
 				GinkgoWriter.Printf("Verifying Dockerfile.tmp updated to sha %s", parentPostPacMergeDigest)
-				content, err := gitClient.GetFileContent(childRepository, "Dockerfile.tmp", ChildComponentDef.componentBranch)
+				file, err := gitClient.GetFile(childRepository, "Dockerfile.tmp", ChildComponentDef.componentBranch)
 				Expect(err).ShouldNot(HaveOccurred())
-				GinkgoWriter.Printf("content: %s\n", content)
-				Expect(content).Should(Equal("FROM quay.io/" + quayOrg + "/" + imageRepoName + "@" + parentPostPacMergeDigest + "\nRUN echo hello\n"))
+				GinkgoWriter.Printf("content: %s\n", file.Content)
+				Expect(file.Content).Should(Equal("FROM quay.io/" + quayOrg + "/" + imageRepoName + "@" + parentPostPacMergeDigest + "\nRUN echo hello\n"))
 
-				content, err = gitClient.GetFileContent(childRepository, "manifest.yaml", ChildComponentDef.componentBranch)
+				file, err = gitClient.GetFile(childRepository, "manifest.yaml", ChildComponentDef.componentBranch)
 				Expect(err).ShouldNot(HaveOccurred())
-				Expect(content).Should(Equal("image: " + distributionRepository + "@" + parentPostPacMergeDigest))
+				Expect(file.Content).Should(Equal("image: " + distributionRepository + "@" + parentPostPacMergeDigest))
 
 			})
 		})
@@ -1816,6 +1696,27 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build-ser
 		Entry("gitlab", git.GitLabProvider, "gl"),
 	)
 })
+
+func setupGitProvider(f *framework.Framework, gitProvider git.GitProvider) (git.Client, string, string) {
+	switch gitProvider {
+	case git.GitHubProvider:
+		gitClient := git.NewGitHubClient(f.AsKubeAdmin.CommonController.Github)
+		return gitClient, helloWorldComponentGitHubURL, helloWorldComponentGitSourceRepoName
+	case git.GitLabProvider:
+		gitClient := git.NewGitlabClient(f.AsKubeAdmin.CommonController.Gitlab)
+
+		gitlabToken := utils.GetEnv(constants.GITLAB_BOT_TOKEN_ENV, "")
+		Expect(gitlabToken).ShouldNot(BeEmpty())
+
+		secretAnnotations := map[string]string{}
+
+		err := build.CreateGitlabBuildSecret(f, "pipelines-as-code-secret", secretAnnotations, gitlabToken)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		return gitClient, helloWorldComponentGitLabURL, helloWorldComponentGitLabProjectID
+	}
+	return nil, "", ""
+}
 
 func createBuildSecret(f *framework.Framework, secretName string, annotations map[string]string, token string) error {
 	buildSecret := v1.Secret{}


### PR DESCRIPTION
It is currently not possible to merge a PR with multiple commits without squashing them. Created https://github.com/konflux-ci/e2e-tests/pull/1418 that should be merged before this, so we can avoid squashing

# Description
Use generic, provider-agnostic, Git client functions leading to a nicer, more readable and maintainable code

## Issue ticket number and link
N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

`./bin/e2e-appstudio --ginkgo.v --ginkgo.label-filter=build-service`

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
