### PR TITLE
fix(KONFLUX-4965): add prometheus metrics to max-concurrency collector

### DIFF
--- a/tests/load-tests/ci-scripts/max-concurrency/cluster_read_config.yaml
+++ b/tests/load-tests/ci-scripts/max-concurrency/cluster_read_config.yaml
@@ -1,3 +1,139 @@
+- name: measurements.tekton_pipelines_controller_running_pipelineruns_count
+  monitoring_query: sum(tekton_pipelines_controller_running_pipelineruns_count)
+  monitoring_step: 15
+
+- name: measurements.storage_count_attachable_volumes_in_use
+  monitoring_query: sum(storage_count_attachable_volumes_in_use)
+  monitoring_step: 15
+
+- name: measurements.cluster_cpu_usage_seconds_total_rate
+  monitoring_query: sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=""})
+  monitoring_step: 15
+
+- name: measurements.cluster_memory_usage_rss_total
+  monitoring_query: sum(container_memory_rss{job="kubelet", metrics_path="/metrics/cadvisor", cluster="", container!=""})
+  monitoring_step: 15
+
+- name: measurements.cluster_disk_throughput_total
+  monitoring_query: sum (rate(container_fs_reads_bytes_total{id!="", device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+", cluster=""}[5m]) + rate(container_fs_writes_bytes_total{id!="", device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+", cluster=""}[5m]))
+  monitoring_step: 15
+
+- name: measurements.token_pool_rate_primary
+  monitoring_query: sum(rate(token_pool_gauge{rateLimited="primary"}[5m]))
+  monitoring_step: 15
+
+- name: measurements.token_pool_rate_secondary
+  monitoring_query: sum(rate(token_pool_gauge{rateLimited="secondary"}[5m]))
+  monitoring_step: 15
+
+- name: measurements.cluster_nodes_worker_count
+  monitoring_query: count(kube_node_role{role="worker"})
+  monitoring_step: 15
+
+- name: measurements.cluster_pods_count
+  monitoring_query: count(kube_pod_info)
+  monitoring_step: 15
+
+- name: measurements.cluster_running_pods_on_workers_count
+  monitoring_query: count(kube_pod_info * on(node) group_left(role) kube_node_role{role="worker"} and on(pod, namespace) (kube_pod_status_phase{job="kube-state-metrics", phase="Running"} > 0))
+  monitoring_step: 15
+
+- name: measurements.scheduler_pending_pods_count
+  monitoring_query: sum(scheduler_pending_pods)
+  monitoring_step: 15
+
+- name: measurements.tekton_tekton_pipelines_controller_workqueue_depth
+  monitoring_query: sum(tekton_pipelines_controller_workqueue_depth)
+  monitoring_step: 15
+
+- name: measurements.pipelinerun_duration_scheduled_seconds
+  monitoring_query: sum(pipelinerun_duration_scheduled_seconds_sum / pipelinerun_duration_scheduled_seconds_count)
+  monitoring_step: 15
+
+- name: measurements.tekton_pipelines_controller_running_taskruns_throttled_by_node
+  monitoring_query: sum(tekton_pipelines_controller_running_taskruns_throttled_by_node_count)
+  monitoring_step: 15
+
+- name: measurements.tekton_pipelines_controller_running_taskruns_throttled_by_quota
+  monitoring_query: sum(tekton_pipelines_controller_running_taskruns_throttled_by_quota_count)
+  monitoring_step: 15
+
+- name: measurements.etcd_request_duration_seconds_average
+  monitoring_query: sum(rate(etcd_request_duration_seconds_sum{}[5m])) / sum(rate(etcd_request_duration_seconds_count[5m]))
+  monitoring_step: 15
+
+- name: measurements.cluster_network_bytes_total
+  monitoring_query: sum(irate(container_network_receive_bytes_total{cluster="",namespace=~".*"}[5m])) + sum(irate(container_network_transmit_bytes_total{cluster="",namespace=~".*"}[5m]))
+  monitoring_step: 15
+
+- name: measurements.cluster_network_receive_bytes_total
+  monitoring_query: sum(irate(container_network_receive_bytes_total{cluster="",namespace=~".*"}[5m]))
+  monitoring_step: 15
+
+- name: measurements.cluster_network_transmit_bytes_total
+  monitoring_query: sum(irate(container_network_transmit_bytes_total{cluster="",namespace=~".*"}[5m]))
+  monitoring_step: 15
+
+- name: measurements.node_disk_io_time_seconds_total
+  monitoring_query: sum(irate(node_disk_io_time_seconds_total{cluster="",namespace=~".*"}[5m]))
+  monitoring_step: 15
+
+# redhat-appstudio metrics
+# Availability of GitHub app
+- name: measurements.redhat_appstudio_buildservice_global_github_app_available
+  monitoring_query: sum(redhat_appstudio_buildservice_global_github_app_available)
+  monitoring_step: 15
+
+# Component creation til simple build pipeline submision or PaC provision in seconds
+- name: measurements.redhat_appstudio_buildservice_component_onboarding_time_sum
+  monitoring_query: sum(redhat_appstudio_buildservice_component_onboarding_time_sum)
+  monitoring_step: 15
+
+# Image repository provision to ready to use in seconds
+- name: measurements.redhat_appstudio_imagecontroller_image_repository_provision_time_sum
+  monitoring_query: sum(redhat_appstudio_imagecontroller_image_repository_provision_time_sum)
+  monitoring_step: 15
+
+# Interesting CI environment variables
+{% for var in [
+  'BUILD_ID',
+  'HOSTNAME',
+  'JOB_NAME',
+  'OPENSHIFT_API',
+  'PROW_JOB_ID',
+  'PULL_BASE_REF',
+  'PULL_BASE_SHA',
+  'PULL_HEAD_REF',
+  'PULL_NUMBER',
+  'PULL_PULL_SHA',
+  'PULL_REFS',
+  'REPO_NAME',
+  'REPO_OWNER',
+  'SCENARIO',
+] %}
+- name: metadata.env.{{ var }}
+  env_variable: {{ var }}
+{% endfor %}
+
+# Git info
+{% macro git_info(dir, path) -%}
+- name: metadata.git.{{ path }}.commit.hash
+  command: cd "{{ dir }}" && git log -1 --pretty=format:"%H"
+- name: metadata.git.{{ path }}.commit.abbreviated_hash
+  command: cd "{{ dir }}" && git log -1 --pretty=format:"%h"
+- name: metadata.git.{{ path }}.commit.author_date
+  command: cd "{{ dir }}" && git log -1 --pretty=format:"%aI"
+- name: metadata.git.{{ path }}.commit.committer_date
+  command: cd "{{ dir }}" && git log -1 --pretty=format:"%cI"
+- name: metadata.git.{{ path }}.commit.subject
+  command: cd "{{ dir }}" && git log -1 --pretty=format:"%s"
+- name: metadata.git.{{ path }}.commit.author_name
+  command: cd "{{ dir }}" && git log -1 --pretty=format:"%aN"
+- name: metadata.git.{{ path }}.commit.author_email
+  command: cd "{{ dir }}" && git log -1 --pretty=format:"%aE"
+{%- endmacro %}
+{{ git_info('.', 'redhat_appstudio.e2e_tests') }}
+
 {% macro monitor_pod(namespace, pod, step=15, pod_suffix_regex='-[0-9a-f]+-.*') -%}
 # Gather monitoring data about the pod
 - name: measurements.{{ pod }}.cpu


### PR DESCRIPTION
# Description
The PR adds additional PromQL to max-concurrency metric collector config. 

## Issue ticket number and link
https://issues.redhat.com/browse/KONFLUX-4965

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Successfully tested the changes by running max-concurrency builds on Hive cluster.
```
export THRESHOLD=1500 MAX_THREADS=200 MAX_CONCURRENCY_STEPS=1 COMPONENT_REPO=https://github.com/rh-perf-test-org/devfile-sample PIPELINE_REQUEST_CONFIGURE_PAC=true
./tests/load-tests/ci-scripts/max-concurrency/load-test.sh
./tests/load-tests/ci-scripts/max-concurrency/collect-results.sh
```

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
