### PR TITLE
fix: add --no-color to rules

### DIFF
--- a/magefiles/rulesengine/repos/common.go
+++ b/magefiles/rulesengine/repos/common.go
@@ -43,6 +43,7 @@ func ExecuteTestAction(rctx *rulesengine.RuleCtx) error {
 	} else {
 		// Set the number of parallel test processes
 		rctx.CLIConfig.Procs = 20
+		rctx.NoColor = true
 	}
 
 	var suiteConfig = rctx.SuiteConfig


### PR DESCRIPTION
# Description

we still see these escaped characters in the e2e tests output:
```
Will run [1m6[0m of [1m327[0m specs
Running in parallel across [1m20[0m processes
[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m
[38;5;243m------------------------------[0m
[38;5;11mP [PENDING][0m
```

setting the ReporterConfig's `NoColor` field to `true` should fix this

## Issue ticket number and link
N/A

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

in CI 🤷 

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
