### PR TITLE
feat(KONFLUX-4272): Update latest PaC config in run-stage-max-concurrency.sh

### DIFF
--- a/tests/load-tests/run-stage-max-concurrency.sh
+++ b/tests/load-tests/run-stage-max-concurrency.sh
@@ -59,10 +59,8 @@ load_test() {
         --journey-repeats "${JOURNEY_REPEATS:-1}" \
         --log-trace \
         --stage \
-        --multiarch-workflow="${MULTIARCH_WORKFLOW:-false}" \
+        --pipeline-repo-templating="${PIPELINE_REPO_TEMPLATING:-false}" \
         --output-dir "${workdir:-/tmp}" \
-        --pipeline-request-configure-pac="${PIPELINE_REQUEST_CONFIGURE_PAC:-false}" \
-        --pipeline-skip-initial-checks="${PIPELINE_SKIP_INITIAL_CHECKS:-true}" \
         --purge="${PURGE:-true}" \
         --quay-repo "${QUAY_REPO:-stonesoup_perfscale}" \
         --test-scenario-git-url "${TEST_SCENARIO_GIT_URL:-https://github.com/konflux-ci/integration-examples.git}" \


### PR DESCRIPTION
# Description

Follow up change based on https://github.com/konflux-ci/e2e-tests/pull/1382

Remove non-PAC build configs from `run-stage-max-concurrency.sh` script and use the latest templating env variable.

## Issue ticket number and link
[KONFLUX-4272](https://issues.redhat.com//browse/KONFLUX-4272)

## Type of change
Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Locally tested the changes against stage cluster.

```
source user.env
export THRESHOLD=3500 MAX_THREADS=300 MAX_CONCURRENCY_STEPS=2 COMPONENT_REPO=https://github.com/rh-perf-test-org/devfile-sample RUN_ON_STAGE=true
./tests/load-tests/ci-scripts/max-concurrency/load-test.sh
./tests/load-tests/ci-scripts/max-concurrency/collect-results.sh
```


# Checklist:
I have performed a self-review of my code.
