### PR TITLE
fix: update release multiarch data fields

### DIFF
--- a/tests/release/pipelines/multiarch_advisories.go
+++ b/tests/release/pipelines/multiarch_advisories.go
@@ -235,11 +235,6 @@ func createMultiArchReleasePlanAdmission(multiarchRPAName string, managedFw fram
 					"name":       multiarchComponentName,
 					"repository": "registry.stage.redhat.io/rhtap/konflux-release-e2e",
 					"tags":       []string{"latest", "latest-{{ timestamp }}"},
-					"source": map[string]interface{}{
-						"git": map[string]interface{}{
-							"url": multiarchGitSourceURL,
-						},
-					},
 				},
 			},
 		},
@@ -249,7 +244,7 @@ func createMultiArchReleasePlanAdmission(multiarchRPAName string, managedFw fram
 		},
 		"releaseNotes": map[string]interface{}{
 			"cpe":             "cpe:/a:example.com",
-			"product_id":      "555",
+			"product_id":      555,
 			"product_name":    "test product",
 			"product_stream":  "rhtas-tp1",
 			"product_version": "v1.0",

--- a/tests/release/pipelines/rh_advisories.go
+++ b/tests/release/pipelines/rh_advisories.go
@@ -249,7 +249,7 @@ func createADVSReleasePlanAdmission(advsRPAName string, managedFw framework.Fram
 		},
 		"releaseNotes": map[string]interface{}{
 			"cpe":             "cpe:/a:example.com",
-			"product_id":      "555",
+			"product_id":      555,
 			"product_name":    "test product",
 			"product_stream":  "rhtas-tp1",
 			"product_version": "v1.0",


### PR DESCRIPTION
This commit fixes two data fields in the multiarch advisories release pipeline test. The product_id field is changed from a string to an int, and the component source is removed from the data section of the ReleasePlanAdmission. The same component source information already appears to be present in the create snapshot function.

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
