### PR TITLE
fix: update release rh advisories data fields

### DIFF
--- a/tests/release/pipelines/rh_advisories.go
+++ b/tests/release/pipelines/rh_advisories.go
@@ -249,7 +249,7 @@ func createADVSReleasePlanAdmission(advsRPAName string, managedFw framework.Fram
 		},
 		"releaseNotes": map[string]interface{}{
 			"cpe":             "cpe:/a:example.com",
-			"product_id":      "555",
+			"product_id":      555,
 			"product_name":    "test product",
 			"product_stream":  "rhtas-tp1",
 			"product_version": "v1.0",


### PR DESCRIPTION


# Description
This fixes one data field in the `rh_advisories` pipeline, which is the `product_id` field is now changed from a string to an int.
## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
