### PR TITLE
fix: typo in restoreRelease

### DIFF
--- a/pkg/clients/release/releases.go
+++ b/pkg/clients/release/releases.go
@@ -118,7 +118,7 @@ func (r *ReleaseController) StoreRelease(release *releaseApi.Release) error {
 	if err != nil {
 		return err
 	}
-	artifacts["component-"+release.Name+".yaml"] = releaseYaml
+	artifacts["release-"+release.Name+".yaml"] = releaseYaml
 
 	if err := logs.StoreArtifacts(artifacts); err != nil {
 		return err


### PR DESCRIPTION
The name of the release file was  added a wrong prefix.  It's to change it to the correct one.

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
