### PR TITLE
fix: release advisory pipelines should use RHBA

### DIFF
--- a/tests/release/pipelines/multiarch_advisories.go
+++ b/tests/release/pipelines/multiarch_advisories.go
@@ -264,7 +264,7 @@ func createMultiArchReleasePlanAdmission(multiarchRPAName string, managedFw fram
 			"product_name":    "test product",
 			"product_stream":  "rhtas-tp1",
 			"product_version": "v1.0",
-			"type":            "RHSA",
+			"type":            "RHBA",
 		},
 		"sign": map[string]interface{}{
 			"configMapName": "hacbs-signing-pipeline-config-redhatbeta2",

--- a/tests/release/pipelines/rh_advisories.go
+++ b/tests/release/pipelines/rh_advisories.go
@@ -260,7 +260,7 @@ func createADVSReleasePlanAdmission(advsRPAName string, managedFw framework.Fram
 			"product_name":    "test product",
 			"product_stream":  "rhtas-tp1",
 			"product_version": "v1.0",
-			"type":            "RHSA",
+			"type":            "RHBA",
 		},
 		"sign": map[string]interface{}{
 			"configMapName":    "hacbs-signing-pipeline-config-redhatbeta2",


### PR DESCRIPTION
The release service pipeline suite tests that use advisories do not attach CVEs. Thus, they should not use RHSA type.

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
