### PR TITLE
fix: rm RP and RPA before creating in multiarch-advisories

### DIFF
--- a/tests/release/pipelines/multiarch_advisories.go
+++ b/tests/release/pipelines/multiarch_advisories.go
@@ -114,19 +114,23 @@ var _ = framework.ReleasePipelinesSuiteDescribe("e2e tests for multi arch test f
 			Expect(err).NotTo(HaveOccurred())
 
 			_, err = devFw.AsKubeDeveloper.ReleaseController.GetReleasePlan(multiarchReleasePlanName, devNamespace)
-			if errors.IsNotFound(err) {
-				createMultiArchReleasePlan(multiarchReleasePlanName, *devFw, devNamespace, multiarchApplicationName, managedNamespace, "true")
+			if err == nil {
+				Expect(devFw.AsKubeDeveloper.ReleaseController.DeleteReleasePlan(multiarchReleasePlanName, devNamespace, false)).NotTo(HaveOccurred())
 			}
+			createMultiArchReleasePlan(multiarchReleasePlanName, *devFw, devNamespace, multiarchApplicationName, managedNamespace, "true")
 
 			_, err = managedFw.AsKubeAdmin.ReleaseController.GetReleasePlanAdmission(multiarchReleasePlanAdmissionName, managedNamespace)
-			if errors.IsNotFound(err) {
-				createMultiArchReleasePlanAdmission(multiarchReleasePlanAdmissionName, *managedFw, devNamespace, managedNamespace, multiarchApplicationName, multiarchEnterpriseContractPolicyName, multiarchCatalogPathInRepo)
+			if err == nil {
+				Expect(managedFw.AsKubeDeveloper.ReleaseController.DeleteReleasePlanAdmission(multiarchReleasePlanAdmissionName, managedNamespace, false)).NotTo(HaveOccurred())
 			}
+			createMultiArchReleasePlanAdmission(multiarchReleasePlanAdmissionName, *managedFw, devNamespace, managedNamespace, multiarchApplicationName, multiarchEnterpriseContractPolicyName, multiarchCatalogPathInRepo)
 
 			_, err = managedFw.AsKubeDeveloper.TektonController.GetEnterpriseContractPolicy(multiarchEnterpriseContractPolicyName, managedNamespace)
-			if errors.IsNotFound(err) {
-				createMultiArchEnterpriseContractPolicy(multiarchEnterpriseContractPolicyName, *managedFw, devNamespace, managedNamespace)
+			if err == nil {
+				err = managedFw.AsKubeDeveloper.TektonController.DeleteEnterpriseContractPolicy(multiarchEnterpriseContractPolicyName, managedNamespace, false)
+				Expect(err).ShouldNot(HaveOccurred())
 			}
+			createMultiArchEnterpriseContractPolicy(multiarchEnterpriseContractPolicyName, *managedFw, devNamespace, managedNamespace)
 
 			snapshotPush, err = releasecommon.CreateSnapshotWithImageSource(*devFw, multiarchComponentName, multiarchApplicationName, devNamespace, sampleImage, multiarchGitSourceURL, multiarchGitSrcSHA, "", "", "", "")
 			Expect(err).ShouldNot(HaveOccurred())


### PR DESCRIPTION
# Description

Because multiarch-advisories is using an existing application(not created in the test) for testing, all the test runs are use one application.  We can't clean the RP/RPA/ECPolicy in the end in case affecting others.  This PR is to clean up them before creating new ones.

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
