### PR TITLE
chore: Revert "skip multicomponent test with same git url"

### DIFF
--- a/tests/build/build.go
+++ b/tests/build/build.go
@@ -938,8 +938,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build-ser
 				}, time.Minute*5, constants.PipelineRunPollingInterval).Should(Succeed(), "timeout while waiting for PR pipeline to start")
 			})
 		})
-		// Skipping this scenario due to the issue: https://issues.redhat.com/browse/KFLUXBUGS-1820 , reenable this test once issue is fixed
-		When("a components is created with same git url in different namespace", Pending, func() {
+		When("a components is created with same git url in different namespace", func() {
 			var namespace, appName, compName string
 			var fw *framework.Framework
 


### PR DESCRIPTION
Reverts konflux-ci/e2e-tests#1445 since the issue was fixed in https://github.com/konflux-ci/build-service/pull/363