### PR TITLE
chore: pending multiarch_advisories

### DIFF
--- a/tests/release/pipelines/multiarch_advisories.go
+++ b/tests/release/pipelines/multiarch_advisories.go
@@ -38,7 +38,7 @@ const (
 
 var multiarchComponentName = "e2e-multi-platform-test"
 
-var _ = framework.ReleasePipelinesSuiteDescribe("e2e tests for multi arch test for rh-advisories release pipeline", Label("release-pipelines", "multiarch-advisories"), func() {
+var _ = framework.ReleasePipelinesSuiteDescribe("e2e tests for multi arch test for rh-advisories release pipeline", Pending, Label("release-pipelines", "multiarch-advisories"), func() {
 	defer GinkgoRecover()
 	var pyxisKeyDecoded, pyxisCertDecoded []byte
 


### PR DESCRIPTION
Signed-off-by: Jing Qi <jinqi@redhat.com>

Because multiarch_advisories is using a fixed application, component, ReleasePlan and ReleasePlanAdmission, the RPA can't be updated to test the PR branch in CI. If the RPA can be updated in one test run, it will affect other test runs running in Parallel.

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
