### PR TITLE
feat(ISV-5130): add Atlas secrets to e2e tests

### DIFF
--- a/integration-tests/scripts/konflux-e2e-runner.sh
+++ b/integration-tests/scripts/konflux-e2e-runner.sh
@@ -30,6 +30,8 @@ load_envs() {
         [QUAY_OAUTH_TOKEN]="${konflux_ci_secrets_file}/quay-oauth-token"
         [PYXIS_STAGE_KEY]="${konflux_ci_secrets_file}/pyxis-stage-key"
         [PYXIS_STAGE_CERT]="${konflux_ci_secrets_file}/pyxis-stage-cert"
+        [ATLAS_STAGE_ACCOUNT]="${konflux_ci_secrets_file}/atlas-stage-account"
+        [ATLAS_STAGE_TOKEN]="${konflux_ci_secrets_file}/atlas-stage-token"
         [OFFLINE_TOKEN]="${konflux_ci_secrets_file}/stage_offline_token"
         [TOOLCHAIN_API_URL]="${konflux_ci_secrets_file}/stage_toolchain_api_url"
         [KEYLOAK_URL]="${konflux_ci_secrets_file}/stage_keyloak_url"

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -69,6 +69,12 @@ const (
 	// Cert auth for accessing Pyxis stage external registry
 	PYXIS_STAGE_CERT_ENV string = "PYXIS_STAGE_CERT"
 
+	// SSO user for accessing the Atlas stage release instance
+	ATLAS_STAGE_ACCOUNT_ENV string = "ATLAS_STAGE_ACCOUNT" // #nosec
+
+	// SSO token for accessing the Atlas stage release instance
+	ATLAS_STAGE_TOKEN_ENV string = "ATLAS_STAGE_TOKEN" // #nosec
+
 	// Offline/refresh token used for getting Keycloak token in order to authenticate against stage/prod cluster
 	// More details: https://access.redhat.com/articles/3626371
 	OFFLINE_TOKEN_ENV = "OFFLINE_TOKEN"

--- a/tests/release/pipelines/rh_advisories.go
+++ b/tests/release/pipelines/rh_advisories.go
@@ -1,10 +1,8 @@
 package pipelines
 
 import (
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"os"
 	"regexp"
 	"time"
 
@@ -15,15 +13,12 @@ import (
 	releaseapi "github.com/konflux-ci/release-service/api/v1alpha1"
 	tektonutils "github.com/konflux-ci/release-service/tekton/utils"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/devfile/library/v2/pkg/util"
 	"github.com/konflux-ci/e2e-tests/pkg/constants"
 	"github.com/konflux-ci/e2e-tests/pkg/framework"
 	"github.com/konflux-ci/e2e-tests/pkg/utils"
 	"github.com/konflux-ci/e2e-tests/pkg/utils/tekton"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"knative.dev/pkg/apis"
 
@@ -42,7 +37,6 @@ var advsComponentName = "advs-comp-" + util.GenerateRandomString(4)
 
 var _ = framework.ReleasePipelinesSuiteDescribe("e2e tests for rh-advisories pipeline", Label("release-pipelines", "rh-advisories"), func() {
 	defer GinkgoRecover()
-	var pyxisKeyDecoded, pyxisCertDecoded []byte
 
 	var devWorkspace = utils.GetEnv(constants.RELEASE_DEV_WORKSPACE_ENV, constants.DevReleaseTeam)
 	var managedWorkspace = utils.GetEnv(constants.RELEASE_MANAGED_WORKSPACE_ENV, constants.ManagedReleaseTeam)
@@ -70,36 +64,17 @@ var _ = framework.ReleasePipelinesSuiteDescribe("e2e tests for rh-advisories pip
 			managedFw = releasecommon.NewFramework(managedWorkspace)
 			managedNamespace = managedFw.UserNamespace
 
-			keyPyxisStage := os.Getenv(constants.PYXIS_STAGE_KEY_ENV)
-			Expect(keyPyxisStage).ToNot(BeEmpty())
-
-			certPyxisStage := os.Getenv(constants.PYXIS_STAGE_CERT_ENV)
-			Expect(certPyxisStage).ToNot(BeEmpty())
-
-			// Creating k8s secret to access Pyxis stage based on base64 decoded of key and cert
-			pyxisKeyDecoded, err = base64.StdEncoding.DecodeString(string(keyPyxisStage))
-			Expect(err).ToNot(HaveOccurred())
-
-			pyxisCertDecoded, err = base64.StdEncoding.DecodeString(string(certPyxisStage))
-			Expect(err).ToNot(HaveOccurred())
-
-			pyxisSecret, err := managedFw.AsKubeAdmin.CommonController.GetSecret(managedNamespace, "pyxis")
-			if pyxisSecret == nil || errors.IsNotFound(err) {
-				secret := &corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "pyxis",
-						Namespace: managedNamespace,
-					},
-					Type: corev1.SecretTypeOpaque,
-					Data: map[string][]byte{
-						"cert": pyxisCertDecoded,
-						"key":  pyxisKeyDecoded,
-					},
-				}
-
-				_, err = managedFw.AsKubeAdmin.CommonController.CreateSecret(managedNamespace, secret)
-				Expect(err).ToNot(HaveOccurred())
+			pyxisFieldEnvMap := map[string]string{
+				"key":  constants.PYXIS_STAGE_KEY_ENV,
+				"cert": constants.PYXIS_STAGE_CERT_ENV,
 			}
+			releasecommon.CreateOpaqueSecret(managedFw, managedNamespace, "pyxis", pyxisFieldEnvMap)
+
+			atlasFieldEnvMap := map[string]string{
+				"sso_account": constants.ATLAS_STAGE_ACCOUNT_ENV,
+				"sso_token":   constants.ATLAS_STAGE_TOKEN_ENV,
+			}
+			releasecommon.CreateOpaqueSecret(managedFw, managedNamespace, "atlas", atlasFieldEnvMap)
 
 			err = managedFw.AsKubeAdmin.CommonController.LinkSecretToServiceAccount(managedNamespace, releasecommon.RedhatAppstudioUserSecret, constants.DefaultPipelineServiceAccount, true)
 			Expect(err).ToNot(HaveOccurred())
@@ -253,6 +228,9 @@ func createADVSReleasePlanAdmission(advsRPAName string, managedFw framework.Fram
 		"pyxis": map[string]interface{}{
 			"server": "stage",
 			"secret": "pyxis",
+		},
+		"atlas": map[string]interface{}{
+			"server": "stage",
 		},
 		"releaseNotes": map[string]interface{}{
 			"cpe":             "cpe:/a:example.com",

--- a/tests/release/pipelines/rh_push_to_redhat_io.go
+++ b/tests/release/pipelines/rh_push_to_redhat_io.go
@@ -1,10 +1,8 @@
 package pipelines
 
 import (
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"os"
 	"regexp"
 	"time"
 
@@ -15,15 +13,12 @@ import (
 	releaseapi "github.com/konflux-ci/release-service/api/v1alpha1"
 	tektonutils "github.com/konflux-ci/release-service/tekton/utils"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/devfile/library/v2/pkg/util"
 	"github.com/konflux-ci/e2e-tests/pkg/constants"
 	"github.com/konflux-ci/e2e-tests/pkg/framework"
 	"github.com/konflux-ci/e2e-tests/pkg/utils"
 	"github.com/konflux-ci/e2e-tests/pkg/utils/tekton"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"knative.dev/pkg/apis"
 
@@ -42,7 +37,6 @@ var rhioComponentName = "rhio-comp-" + util.GenerateRandomString(4)
 
 var _ = framework.ReleasePipelinesSuiteDescribe("e2e tests for rh-push-to-redhat-io pipeline", Pending, Label("release-pipelines", "rh-push-to-redhat-io"), func() {
 	defer GinkgoRecover()
-	var pyxisKeyDecoded, pyxisCertDecoded []byte
 
 	var devWorkspace = utils.GetEnv(constants.RELEASE_DEV_WORKSPACE_ENV, constants.DevReleaseTeam)
 	var managedWorkspace = utils.GetEnv(constants.RELEASE_MANAGED_WORKSPACE_ENV, constants.ManagedReleaseTeam)
@@ -70,36 +64,11 @@ var _ = framework.ReleasePipelinesSuiteDescribe("e2e tests for rh-push-to-redhat
 			managedFw = releasecommon.NewFramework(managedWorkspace)
 			managedNamespace = managedFw.UserNamespace
 
-			keyPyxisStage := os.Getenv(constants.PYXIS_STAGE_KEY_ENV)
-			Expect(keyPyxisStage).ToNot(BeEmpty())
-
-			certPyxisStage := os.Getenv(constants.PYXIS_STAGE_CERT_ENV)
-			Expect(certPyxisStage).ToNot(BeEmpty())
-
-			// Creating k8s secret to access Pyxis stage based on base64 decoded of key and cert
-			pyxisKeyDecoded, err = base64.StdEncoding.DecodeString(string(keyPyxisStage))
-			Expect(err).ToNot(HaveOccurred())
-
-			pyxisCertDecoded, err = base64.StdEncoding.DecodeString(string(certPyxisStage))
-			Expect(err).ToNot(HaveOccurred())
-
-			pyxisSecret, err := managedFw.AsKubeAdmin.CommonController.GetSecret(managedNamespace, "pyxis")
-			if pyxisSecret == nil || errors.IsNotFound(err) {
-				secret := &corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "pyxis",
-						Namespace: managedNamespace,
-					},
-					Type: corev1.SecretTypeOpaque,
-					Data: map[string][]byte{
-						"cert": pyxisCertDecoded,
-						"key":  pyxisKeyDecoded,
-					},
-				}
-
-				_, err = managedFw.AsKubeAdmin.CommonController.CreateSecret(managedNamespace, secret)
-				Expect(err).ToNot(HaveOccurred())
+			pyxisFieldEnvMap := map[string]string{
+				"key":  constants.PYXIS_STAGE_KEY_ENV,
+				"cert": constants.PYXIS_STAGE_CERT_ENV,
 			}
+			releasecommon.CreateOpaqueSecret(managedFw, managedNamespace, "pyxis", pyxisFieldEnvMap)
 
 			err = managedFw.AsKubeAdmin.CommonController.LinkSecretToServiceAccount(managedNamespace, releasecommon.RedhatAppstudioUserSecret, constants.DefaultPipelineServiceAccount, true)
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
# Description 
In [ISV-5130](https://issues.redhat.com//browse/ISV-5130), the `rh-advisories` pipeline gained the ability to upload component and product-level SBOMs to the Atlas release instance.

The upload of SBOMs requires a new k8s Secret containing the SSO account and token for the stage [Atlas release instance](https://atlas.release.stage.devshift.net/). **The secrets have been added to the QE vault.**

This PR makes the e2e test use the new secrets and refactors secret creation to avoid duplicate code. I left the other tests use the old way of creating the secrets but I can refactor those as well if you wish.

## Issue ticket number and link
[ISV-5130](https://issues.redhat.com/browse/ISV-5130) - Add new pipeline steps in rh-advisories for sbom upload 
[ISV-5394](https://issues.redhat.com/browse/ISV-5394) - Update rh-advisories pipeline e2e tests
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [x] I have updated labels (if needed)
