### PR TITLE
feat(KONFLUX-4319): Capture Application & Component JSONs after load test

### DIFF
--- a/tests/load-tests/ci-scripts/collect-results.sh
+++ b/tests/load-tests/ci-scripts/collect-results.sh
@@ -76,14 +76,6 @@ application_stub=$ARTIFACT_DIR/collected-data/collected-applications.appstudio.r
 component_stub=$ARTIFACT_DIR/collected-data/collected-components.appstudio.redhat.com
 node_stub=$ARTIFACT_DIR/collected-data/collected-nodes
 
-## Application info
-echo "Collecting Application timestamps..."
-collect_application "-A" "$application_stub"
-
-## Component info
-echo "Collecting Component timestamps..."
-collect_component "-A" "$component_stub"
-
 ## Nodes info
 #echo "Collecting node specs"
 #collect_nodes "$node_stub"

--- a/tests/load-tests/ci-scripts/stage/collect-results.sh
+++ b/tests/load-tests/ci-scripts/stage/collect-results.sh
@@ -105,13 +105,6 @@ else
         fi
         tenant="${username}-tenant"
 
-        # Application info
-        echo "Collecting Application timestamps..."
-        collect_application "-n ${tenant}" "$application_stub-$tenant" || echo "ERROR: Failed collecting applications"
-
-        # Component info
-        echo "Collecting Component timestamps..."
-        collect_component "-n ${tenant}" "$component_stub-$tenant" || echo "ERROR: Failed collecting components"
     done
 fi
 

--- a/tests/load-tests/pkg/journey/handle_collections.go
+++ b/tests/load-tests/pkg/journey/handle_collections.go
@@ -1,13 +1,16 @@
 package journey
 
-import "fmt"
-import "os"
-import "path/filepath"
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
 
-import logging "github.com/konflux-ci/e2e-tests/tests/load-tests/pkg/logging"
+	logging "github.com/konflux-ci/e2e-tests/tests/load-tests/pkg/logging"
 
-import framework "github.com/konflux-ci/e2e-tests/pkg/framework"
+	framework "github.com/konflux-ci/e2e-tests/pkg/framework"
+)
 
 func getDirName(baseDir, namespace, iteration string) string {
 	return filepath.Join(baseDir, "collected-data", namespace, iteration) + "/"
@@ -131,6 +134,45 @@ func collectPipelineRunJSONs(f *framework.Framework, dirPath, namespace, applica
 	return nil
 }
 
+func collectApplicationComponentJSONs(f *framework.Framework, dirPath, namespace, application, component string) error {
+	// Only save Application JSON if it has not already been collected (as HandlePerComponentCollection method is called for each component)
+	if _, err := os.Stat(filepath.Join(dirPath, "collected-application-" + application + ".json")); errors.Is(err, os.ErrNotExist) {
+		// Get Application JSON
+		app, err := f.AsKubeDeveloper.HasController.GetApplication(application, namespace)
+		if err != nil {
+			return fmt.Errorf("Failed to get Application %s: %v", application, err)
+		}
+
+		appJSON, err := json.Marshal(app)
+		if err != nil {
+			return fmt.Errorf("Failed to dump Application JSON: %v", err)
+		}
+
+		err = writeToFile(dirPath, "collected-application-" + application + ".json", appJSON)
+		if err != nil {
+			return fmt.Errorf("Failed to write Application: %v", err)
+		}
+	}
+
+	// Collect Component JSON
+	comp, err := f.AsKubeDeveloper.HasController.GetComponent(component, namespace)
+	if err != nil {
+		return fmt.Errorf("Failed to get Component %s: %v", component, err)
+	}
+
+	compJSON, err := json.Marshal(comp)
+	if err != nil {
+		return fmt.Errorf("Failed to dump Component JSON: %v", err)
+	}
+
+	err = writeToFile(dirPath, "collected-component-" + component + ".json", compJSON)
+	if err != nil {
+		return fmt.Errorf("Failed to write Component: %v", err)
+	}
+
+	return nil
+}
+
 func HandlePerComponentCollection(ctx *PerComponentContext) error {
 	if ctx.ComponentName == "" {
 		logging.Logger.Debug("Component name not populated, so skipping per-component collections in %s", ctx.ParentContext.ParentContext.Namespace)
@@ -154,6 +196,11 @@ func HandlePerComponentCollection(ctx *PerComponentContext) error {
 	err = collectPipelineRunJSONs(ctx.Framework, dirPath, ctx.ParentContext.ParentContext.Namespace, ctx.ParentContext.ApplicationName, ctx.ComponentName)
 	if err != nil {
 		return logging.Logger.Fail(102, "Failed to collect pipeline run JSONs: %v", err)
+	}
+
+	err = collectApplicationComponentJSONs(ctx.Framework, dirPath, ctx.ParentContext.ParentContext.Namespace, ctx.ParentContext.ApplicationName, ctx.ComponentName)
+	if err != nil {
+		return logging.Logger.Fail(102, "Failed to collect Application and Component JSONs: %v", err)
 	}
 
 	return nil

--- a/tests/load-tests/pkg/journey/handle_collections.go
+++ b/tests/load-tests/pkg/journey/handle_collections.go
@@ -1,16 +1,14 @@
 package journey
 
-import (
-	"encoding/json"
-	"errors"
-	"fmt"
-	"os"
-	"path/filepath"
+import "fmt"
+import "os"
+import "errors"
+import "path/filepath"
+import "encoding/json"
 
-	logging "github.com/konflux-ci/e2e-tests/tests/load-tests/pkg/logging"
+import logging "github.com/konflux-ci/e2e-tests/tests/load-tests/pkg/logging"
 
-	framework "github.com/konflux-ci/e2e-tests/pkg/framework"
-)
+import framework "github.com/konflux-ci/e2e-tests/pkg/framework"
 
 func getDirName(baseDir, namespace, iteration string) string {
 	return filepath.Join(baseDir, "collected-data", namespace, iteration) + "/"
@@ -135,8 +133,9 @@ func collectPipelineRunJSONs(f *framework.Framework, dirPath, namespace, applica
 }
 
 func collectApplicationComponentJSONs(f *framework.Framework, dirPath, namespace, application, component string) error {
+	appJsonFileName := "collected-application-" + application + ".json"
 	// Only save Application JSON if it has not already been collected (as HandlePerComponentCollection method is called for each component)
-	if _, err := os.Stat(filepath.Join(dirPath, "collected-application-" + application + ".json")); errors.Is(err, os.ErrNotExist) {
+	if _, err := os.Stat(filepath.Join(dirPath, appJsonFileName)); errors.Is(err, os.ErrNotExist) {
 		// Get Application JSON
 		app, err := f.AsKubeDeveloper.HasController.GetApplication(application, namespace)
 		if err != nil {
@@ -148,7 +147,7 @@ func collectApplicationComponentJSONs(f *framework.Framework, dirPath, namespace
 			return fmt.Errorf("Failed to dump Application JSON: %v", err)
 		}
 
-		err = writeToFile(dirPath, "collected-application-" + application + ".json", appJSON)
+		err = writeToFile(dirPath, appJsonFileName, appJSON)
 		if err != nil {
 			return fmt.Errorf("Failed to write Application: %v", err)
 		}


### PR DESCRIPTION
# Description
Application and Component JSON definitions were not being captured during load test execution because the objects were cleared when the `--purge` flag was set. 

This PR addresses the issue by moving the collection of Application and Component JSON definitions to the component handler level.

## Issue ticket number and link
https://issues.redhat.com/browse/KONFLUX-4319

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

The changes have been tested successfully on Hive OpenShift cluster.

```
# On Hive cluster - setup & install Konflux
source user.env 
./tests/load-tests/ci-scripts/setup-cluster.sh

# Run Load test
export COMPONENT_REPO=https://github.com/rh-perf-test-org/devfile-sample CONCURRENCY=1 APPLICATIONS_COUNT=2 COMPONENTS_COUNT=2
./tests/load-tests/ci-scripts/load-test.sh
```

At end of the load test, we should be able to find `collected-application-*.json` and `collected-component-*.json` files with the object definition for Applications and Components created during the load test.

![app(2)   component (4)](https://github.com/user-attachments/assets/7e01d826-185c-46d6-928b-aa1c1327065c)

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)

