### PR TITLE
fix: add docker-build-multi-platform-oci-ta pipeline test

### DIFF
--- a/pkg/utils/build/source_image.go
+++ b/pkg/utils/build/source_image.go
@@ -347,26 +347,19 @@ func readDockerfile(pathContext, dockerfile, repoURL, repoRevision string) ([]by
 
 // ReadDockerfileUsedForBuild reads the Dockerfile and return its content.
 func ReadDockerfileUsedForBuild(c client.Client, tektonController *tekton.TektonController, pr *pipeline.PipelineRun) ([]byte, error) {
-	var paramDockerfileValue, paramPathContextValue string
-	var paramUrlValue, paramRevisionValue string
+	var paramDockerfileValue, paramPathContextValue, paramUrlValue, paramRevisionValue string
 	var err error
-	getParam := tektonController.GetTaskRunParam
 
-	if paramDockerfileValue, err = getParam(c, pr, "build-container", "DOCKERFILE"); err != nil {
-		return nil, err
-	}
-
-	if paramPathContextValue, err = getParam(c, pr, "build-container", "CONTEXT"); err != nil {
-		return nil, err
-	}
-
-	// get git-clone param url and revision
-	if paramUrlValue, err = getParam(c, pr, "clone-repository", "url"); err != nil {
-		return nil, err
-	}
-
-	if paramRevisionValue, err = getParam(c, pr, "clone-repository", "revision"); err != nil {
-		return nil, err
+	for _, param := range pr.Spec.Params {
+		if param.Name == "dockerfile" {
+			paramDockerfileValue = param.Value.StringVal
+		} else if param.Name == "path-context" {
+			paramPathContextValue = param.Value.StringVal
+		} else if param.Name == "git-url" {
+			paramUrlValue = param.Value.StringVal
+		} else if param.Name == "revision" {
+			paramRevisionValue = param.Value.StringVal
+		}
 	}
 
 	dockerfileContent, err := readDockerfile(paramPathContextValue, paramDockerfileValue, paramUrlValue, paramRevisionValue)

--- a/tests/build/build_templates_scenarios.go
+++ b/tests/build/build_templates_scenarios.go
@@ -35,12 +35,20 @@ func (s ComponentScenarioSpec) DeepCopy() ComponentScenarioSpec {
 
 var componentScenarios = []ComponentScenarioSpec{
 	{
-		GitURL:         "https://github.com/konflux-qe-bd/devfile-sample-python-basic",
-		Revision:       "47fc22092005aabebce233a9b6eab994a8152bbd",
-		ContextDir:     ".",
-		DockerFilePath: constants.DockerFilePath,
-		// "docker-build-multi-platform-oci-ta" needs to be enabled, when the issue https://issues.redhat.com/browse/KFLUXBUGS-1646 is fixed
+		GitURL:              "https://github.com/konflux-qe-bd/devfile-sample-python-basic",
+		Revision:            "47fc22092005aabebce233a9b6eab994a8152bbd",
+		ContextDir:          ".",
+		DockerFilePath:      constants.DockerFilePath,
 		PipelineBundleNames: []string{"docker-build", "docker-build-oci-ta"},
+		EnableHermetic:      false,
+		PrefetchInput:       "",
+	},
+	{
+		GitURL:              "https://github.com/konflux-qe-bd/multiarch-sample-repo",
+		Revision:            "bc0452861279eb59da685ba86918938c6c9d8310",
+		ContextDir:          ".",
+		DockerFilePath:      "Dockerfile",
+		PipelineBundleNames: []string{"docker-build-multi-platform-oci-ta"},
 		EnableHermetic:      false,
 		PrefetchInput:       "",
 	},


### PR DESCRIPTION
# Description

This PR adds the `docker-build-multi-platform-oci-ta` pipeline test back, fixes the rule to run build tests 

## Issue ticket number and link
https://issues.redhat.com/browse/KFLUXBUGS-1646

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested it [here](https://github.com/konflux-ci/build-definitions/pull/1465)

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
