### PR TITLE
fix: PR pairing

### DIFF
--- a/integration-tests/scripts/konflux-e2e-runner.sh
+++ b/integration-tests/scripts/konflux-e2e-runner.sh
@@ -2,10 +2,6 @@
 
 set -euo pipefail
 
-log() {
-    echo -e "[$(date +'%Y-%m-%d %H:%M:%S')] [$1] $2"
-}
-
 load_envs() {
     local konflux_ci_secrets_file="/usr/local/konflux-ci-secrets"
     local konflux_infra_secrets_file="/usr/local/konflux-test-infra"
@@ -14,9 +10,6 @@ load_envs() {
         [ENABLE_SCHEDULING_ON_MASTER_NODES]="false"
         [UNREGISTER_PAC]="true"
         [EC_DISABLE_DOWNLOAD_SERVICE]="true"
-        [ARTIFACT_DIR]="$(mktemp -d)"
-        [GITHUB_USER]=""
-        [GITHUB_TOKEN]=""
         [DEFAULT_QUAY_ORG]="redhat-appstudio-qe"
         [OCI_STORAGE_USERNAME]="$(jq -r '."quay-username"' ${konflux_infra_secrets_file}/oci-storage)"
         [OCI_STORAGE_TOKEN]="$(jq -r '."quay-token"' ${konflux_infra_secrets_file}/oci-storage)"
@@ -24,7 +17,6 @@ load_envs() {
 
     declare -A load_envs_from_file=(
         [DEFAULT_QUAY_ORG_TOKEN]="${konflux_ci_secrets_file}/default-quay-org-token"
-        [GITHUB_TOKENS_LIST]="${konflux_ci_secrets_file}/github_accounts"
         [QUAY_TOKEN]="${konflux_ci_secrets_file}/quay-token"
         [QUAY_OAUTH_USER]="${konflux_ci_secrets_file}/quay-oauth-user"
         [QUAY_OAUTH_TOKEN]="${konflux_ci_secrets_file}/quay-oauth-token"
@@ -71,7 +63,9 @@ load_envs() {
 
 post_actions() {
     local exit_code=$?
-    local temp_annotation_file="$(mktemp)"
+    local temp_annotation_file
+
+    temp_annotation_file="$(mktemp)"
 
     if [[ "${UNREGISTER_PAC}" == "true" ]]; then
         make ci/sprayproxy/unregister
@@ -81,7 +75,7 @@ post_actions() {
 
     # Fetch the manifest annotations for the container
     if ! MANIFESTS=$(oras manifest fetch "${ORAS_CONTAINER}" | jq .annotations); then
-        log "ERROR" "Failed to fetch manifest from ${OCI_STORAGE_CONTAINER}"
+        log "ERROR" "Failed to fetch manifest from ${ORAS_CONTAINER}"
         exit 1
     fi
 
@@ -110,26 +104,6 @@ load_envs
 oc config view --minify --raw > /workspace/kubeconfig
 export KUBECONFIG=/workspace/kubeconfig
 
-export PREVIOUS_RATE_REMAINING=0
-IFS=',' read -r -a GITHUB_ACCOUNTS_ARRAY <<< "$(cat /usr/local/konflux-ci-secrets/github_accounts)"
-for account in "${GITHUB_ACCOUNTS_ARRAY[@]}"; do
-    IFS=':' read -r -a GITHUB_USERNAME_ARRAY <<< "$account"
-
-    GH_RATE_REMAINING=$(curl -s \
-        -H "Accept: application/vnd.github+json" \
-        -H "Authorization: Bearer ${GITHUB_USERNAME_ARRAY[1]}" \
-        https://api.github.com/rate_limit | jq ".rate.remaining")
-
-    log "INFO" "user: ${GITHUB_USERNAME_ARRAY[0]} with rate limit remaining $GH_RATE_REMAINING"
-    if [[ "$GH_RATE_REMAINING" -ge "$PREVIOUS_RATE_REMAINING" ]]; then
-        GITHUB_USER="${GITHUB_USERNAME_ARRAY[0]}"
-        GITHUB_TOKEN="${GITHUB_USERNAME_ARRAY[1]}"
-    fi
-    PREVIOUS_RATE_REMAINING="$GH_RATE_REMAINING"
-done
-
-log "INFO" "running tests with github user: ${GITHUB_USER}"
-
 # ROSA HCP workaround for Docker limits
 # for namespaces 'minio-operator' and 'tekton-results'
 oc get secret/pull-secret -n openshift-config --template='{{index .data ".dockerconfigjson" | base64decode}}' > ./global-pull-secret.json
@@ -154,18 +128,4 @@ while IFS='|' read -r ns sa_name; do
     oc secrets link "$sa_name" pull-secret --for=pull -n "$ns"
 done <<< "$namespace_sa_names"
 
-
-# Prepare git, pair branch if necessary, Install Konflux and run e2e tests
-cd "$(mktemp -d)"
-
-git config --global user.name "redhat-appstudio-qe-bot"
-git config --global user.email redhat-appstudio-qe-bot@redhat.com
-
-mkdir -p "${HOME}/creds"
-git_creds_path="${HOME}/creds/file"
-git config --global credential.helper "store --file $git_creds_path"
-echo "https://${GITHUB_USER}:${GITHUB_TOKEN}@github.com" > "$git_creds_path"
-
-git clone --origin upstream --branch main "https://${GITHUB_TOKEN}@github.com/konflux-ci/e2e-tests.git" .
-make ci/prepare/e2e-branch 2>&1 | tee "${ARTIFACT_DIR}"/e2e-branch.log
 make ci/test/e2e 2>&1 | tee "${ARTIFACT_DIR}"/e2e-tests.log

--- a/integration-tests/tasks/konflux-e2e-tests-task.yaml
+++ b/integration-tests/tasks/konflux-e2e-tests-task.yaml
@@ -18,11 +18,11 @@ spec:
       description: "The name of the test being executed."
     - name: git-repo
       type: string
-      default: "rhtap-e2e"
+      default: "e2e-tests"
       description: "The name of the Git repository containing the E2E tests."
     - name: git-url
       type: string
-      default: "https://github.com/redhat-appstudio/rhtap-e2e.git"
+      default: "https://github.com/konflux-ci/e2e-tests.git"
       description: "The URL of the Git repository containing the E2E tests."
     - name: git-revision
       type: string
@@ -84,23 +84,68 @@ spec:
           value: $(params.job-spec)
         - name: COMPONENT_IMAGE
           value: $(params.component-image)
+        - name: GINKGO_PROCS
+          value: $(params.ginkgo-procs)
+        - name: ORAS_CONTAINER
+          value: $(params.oras-container)
       script: |
         #!/bin/bash
 
-        # Params related with tekton task
-        export GINKGO_PROCS=$(params.ginkgo-procs)
-        export ORAS_CONTAINER=$(params.oras-container)
+        set -euo pipefail
 
-        # Log into OpenShift
-        $(params.ocp-login-command)
+        log() {
+            echo -e "[$(date +'%Y-%m-%d %H:%M:%S')] [$1] $2"
+        }
+        export -f log
 
-        if [ "$GIT_REPO" = "e2e-tests" ]; then
-          export SOURCE_REPO_URL=$(echo "$JOB_SPEC" | jq -r '.git.source_repo_url' | sed 's#https://github.com/##')
-          export SOURCE_REPO_BRANCH=$(echo "$JOB_SPEC" | jq -r '.git.source_repo_branch')
+        # Log into OpenShift cluster (the connection is sometimes flaky - give it more time)
+        timeout --foreground "10m" bash -c "
+        until $(params.ocp-login-command)
+        do
+            echo \"Waiting for 'oc login' command to succeed... Trying again in 10 seconds\"
+            sleep 10
+        done
+        "
 
-          echo -e "[INFO] Running e2e tests from source: $SOURCE_REPO_URL and branch $SOURCE_REPO_BRANCH"
-          /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/$SOURCE_REPO_URL/$SOURCE_REPO_BRANCH/integration-tests/scripts/konflux-e2e-runner.sh)"
-        else
-          echo -e "[INFO] Running e2e tests from source: konflux-ci/e2e-tests and branch main"
-          /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/konflux-ci/e2e-tests/main/integration-tests/scripts/konflux-e2e-runner.sh)"
-        fi
+        export GITHUB_TOKEN
+
+        PREVIOUS_RATE_REMAINING=0
+
+        IFS=',' read -r -a GITHUB_ACCOUNTS_ARRAY <<< "$(cat /usr/local/konflux-ci-secrets/github_accounts)"
+        for account in "${GITHUB_ACCOUNTS_ARRAY[@]}"; do
+            IFS=':' read -r -a GITHUB_USERNAME_ARRAY <<< "$account"
+
+            GH_RATE_REMAINING=$(curl -s \
+                -H "Accept: application/vnd.github+json" \
+                -H "Authorization: Bearer ${GITHUB_USERNAME_ARRAY[1]}" \
+                https://api.github.com/rate_limit | jq ".rate.remaining")
+
+            log "INFO" "user: ${GITHUB_USERNAME_ARRAY[0]} with rate limit remaining $GH_RATE_REMAINING"
+            if [[ "$GH_RATE_REMAINING" -ge "$PREVIOUS_RATE_REMAINING" ]]; then
+                GITHUB_USER="${GITHUB_USERNAME_ARRAY[0]}"
+                GITHUB_TOKEN="${GITHUB_USERNAME_ARRAY[1]}"
+            fi
+            PREVIOUS_RATE_REMAINING="$GH_RATE_REMAINING"
+        done
+
+        log "INFO" "running tests with github user: ${GITHUB_USER}"
+
+        export ARTIFACT_DIR
+        ARTIFACT_DIR="$(mktemp -d)"
+
+        # Prepare git, pair branch if necessary, Install Konflux and run e2e tests
+        cd "$(mktemp -d)"
+
+        git config --global user.name "redhat-appstudio-qe-bot"
+        git config --global user.email redhat-appstudio-qe-bot@redhat.com
+
+        mkdir -p "${HOME}/creds"
+        git_creds_path="${HOME}/creds/file"
+        git config --global credential.helper "store --file $git_creds_path"
+        echo "https://${GITHUB_USER}:${GITHUB_TOKEN}@github.com" > "$git_creds_path"
+
+        git clone --origin upstream --branch main "https://github.com/konflux-ci/e2e-tests.git" .
+        make ci/prepare/e2e-branch 2>&1 | tee "${ARTIFACT_DIR}"/e2e-branch.log
+
+        /bin/bash -c "integration-tests/scripts/konflux-e2e-runner.sh"
+


### PR DESCRIPTION
# Description

* added `make ci/prepare/e2e-branch` to `integration-tests/tasks/konflux-e2e-tests-task.yaml` to determine the git reference for running `integration-tests/scripts/konflux-e2e-runner.sh`, which will solve the issue with PR pairing described in [KFLUXBUGS-1917](https://issues.redhat.com//browse/KFLUXBUGS-1917)
* the `integration-tests/tasks/konflux-e2e-tests-task.yaml` Task now contains only a code that's necessary for logging into OCP cluster and configuring PR pairing - most of the code that might change is then located in `integration-tests/scripts/konflux-e2e-runner.sh`, which will be possible to test from e2e-tests and konflux components' PRs
* CI in this PR is irrelevant, the functionality was tested in [this PR](https://github.com/konflux-ci/build-service/pull/377)
 
## Issue ticket number and link
[KFLUXBUGS-1917](https://issues.redhat.com//browse/KFLUXBUGS-1917)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

in CI 🤷 

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
