### PR TITLE
fix: add docker.io creds to tekton-logging ns

### DIFF
--- a/integration-tests/scripts/konflux-e2e-runner.sh
+++ b/integration-tests/scripts/konflux-e2e-runner.sh
@@ -138,6 +138,7 @@ oc registry login --registry=docker.io --auth-basic="$DOCKER_IO_AUTH" --to=./glo
 namespace_sa_names=$(cat << 'EOF'
 minio-operator|console-sa
 minio-operator|minio-operator
+tekton-logging|vectors-tekton-logs-collector
 tekton-results|storage-sa
 EOF
 )


### PR DESCRIPTION
# Description

this should fix the konflux bootstrap issue recently seen on ROSA HCP cluster:

```
Failed to pull image "timberio/vector:0.42.0-distroless-libc": fetching target platform image selected from image index: reading manifest sha256:872e4daa04a347d61841cc387f0b56ea7e3031f9b2eb2ca2e0a936696d7def3c in docker.io/timberio/vector: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit
```