### PR TITLE
feat: use secure-push-oci for archiving artifacts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,8 @@ RUN curl -LO "https://github.com/oras-project/oras/releases/download/v${ORAS_VER
 
 FROM registry.access.redhat.com/ubi9/go-toolset:1.21.11-7
 
+USER root
+
 WORKDIR /konflux-e2e
 
 ENV GOBIN=$GOPATH/bin

--- a/integration-tests/pipelines/konflux-e2e-tests-pipeline.yaml
+++ b/integration-tests/pipelines/konflux-e2e-tests-pipeline.yaml
@@ -73,21 +73,6 @@ spec:
           value: $(params.SNAPSHOT)
         - name: test-name
           value: $(context.pipelineRun.name)
-    - name: create-oci-container
-      taskRef:
-        resolver: git
-        params:
-          - name: url
-            value: https://github.com/konflux-ci/konflux-qe-definitions.git
-          - name: revision
-            value: main
-          - name: pathInRepo
-            value: common/tasks/create-oci-artifact/0.1/create-oci-artifact.yaml
-      params:
-        - name: oci-container-repo
-          value: $(params.oci-container-repo)
-        - name: oci-container-tag
-          value: $(context.pipelineRun.name)
     - name: provision-rosa
       when:
         - input: "$(tasks.test-metadata.results.test-event-type)"
@@ -95,17 +80,16 @@ spec:
           values: ["pull_request"]
       runAfter:
         - rosa-hcp-metadata
-        - create-oci-container
         - test-metadata
       taskRef:
         resolver: git
         params:
           - name: url
-            value: https://github.com/konflux-ci/konflux-qe-definitions.git
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
           - name: revision
             value: main
           - name: pathInRepo
-            value: common/tasks/rosa/hosted-cp/rosa-hcp-provision/rosa-hcp-provision.yaml
+            value: tasks/rosa/hosted-cp/rosa-hcp-provision/0.2/rosa-hcp-provision.yaml
       params:
         - name: cluster-name
           value: "$(tasks.rosa-hcp-metadata.results.cluster-name)"
@@ -119,6 +103,8 @@ spec:
           value: "$(params.konflux-test-infra-secret)"
         - name: cloud-credential-key
           value: "$(params.cloud-credential-key)"
+        - name: oci-container
+          value: "$(params.oci-container-repo):$(context.pipelineRun.name)"
     - name: konflux-e2e-tests
       timeout: 3h
       when:
@@ -131,9 +117,9 @@ spec:
         resolver: git
         params:
           - name: url
-            value: https://github.com/konflux-ci/e2e-tests.git
+            value: https://github.com/psturc/e2e-tests.git
           - name: revision
-            value: main
+            value: KFLUXDP-6
           - name: pathInRepo
             value: integration-tests/tasks/konflux-e2e-tests-task.yaml
       params:
@@ -146,7 +132,7 @@ spec:
         - name: git-revision
           value: "$(tasks.test-metadata.results.git-revision)"
         - name: oras-container
-          value: "$(tasks.create-oci-container.results.oci-container)"
+          value: "$(params.oci-container-repo):$(context.pipelineRun.name)"
         - name: job-spec
           value: "$(tasks.test-metadata.results.job-spec)"
         - name: ocp-login-command
@@ -165,18 +151,18 @@ spec:
         resolver: git
         params:
           - name: url
-            value: https://github.com/konflux-ci/konflux-qe-definitions.git
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
           - name: revision
             value: main
           - name: pathInRepo
-            value: common/tasks/rosa/hosted-cp/rosa-hcp-deprovision/rosa-hcp-deprovision.yaml
+            value: tasks/rosa/hosted-cp/rosa-hcp-deprovision/0.2/rosa-hcp-deprovision.yaml
       params:
         - name: test-name
           value: "$(context.pipelineRun.name)"
         - name: ocp-login-command
           value: "$(tasks.provision-rosa.results.ocp-login-command)"
         - name: oci-container
-          value: "$(tasks.create-oci-container.results.oci-container)"
+          value: "$(params.oci-container-repo):$(context.pipelineRun.name)"
         - name: pull-request-author
           value: "$(tasks.test-metadata.results.pull-request-author)"
         - name: git-revision
@@ -213,7 +199,7 @@ spec:
         - name: test-name
           value: "$(context.pipelineRun.name)"
         - name: oci-container
-          value: "$(tasks.create-oci-container.results.oci-container)"
+          value: "$(params.oci-container-repo):$(context.pipelineRun.name)"
         - name: quality-dashboard-api
           value: $(params.quality-dashboard-api)
         - name: pipeline-aggregate-status
@@ -238,7 +224,7 @@ spec:
         - name: test-name
           value: "$(context.pipelineRun.name)"
         - name: oci-container
-          value: "$(tasks.create-oci-container.results.oci-container)"
+          value: "$(params.oci-container-repo):$(context.pipelineRun.name)"
         - name: pipeline-aggregate-status
           value: "$(tasks.status)"
         - name: pull-request-author

--- a/integration-tests/pipelines/konflux-e2e-tests-pipeline.yaml
+++ b/integration-tests/pipelines/konflux-e2e-tests-pipeline.yaml
@@ -117,9 +117,9 @@ spec:
         resolver: git
         params:
           - name: url
-            value: https://github.com/psturc/e2e-tests.git
+            value: https://github.com/konflux-ci/e2e-tests.git
           - name: revision
-            value: KFLUXDP-6
+            value: main
           - name: pathInRepo
             value: integration-tests/tasks/konflux-e2e-tests-task.yaml
       params:

--- a/integration-tests/tasks/konflux-e2e-tests-task.yaml
+++ b/integration-tests/tasks/konflux-e2e-tests-task.yaml
@@ -68,7 +68,7 @@ spec:
           mountPath: /usr/local/konflux-ci-secrets
         - name:  konflux-test-infra-volume
           mountPath: /usr/local/konflux-test-infra
-      workingDir: /workspace
+      workingDir: /workspace/e2e-tests
       env:
         - name: JOB_NAME
           value: $(params.test-name)
@@ -88,6 +88,9 @@ spec:
           value: $(params.ginkgo-procs)
         - name: ORAS_CONTAINER
           value: $(params.oras-container)
+        - name: ARTIFACT_DIR
+          value: /workspace/artifact-dir
+      onError: continue
       script: |
         #!/bin/bash
 
@@ -130,9 +133,6 @@ spec:
 
         log "INFO" "running tests with github user: ${GITHUB_USER}"
 
-        export ARTIFACT_DIR
-        ARTIFACT_DIR="$(mktemp -d)"
-
         # Prepare git, pair branch if necessary, Install Konflux and run e2e tests
         cd "$(mktemp -d)"
 
@@ -148,4 +148,30 @@ spec:
         make ci/prepare/e2e-branch 2>&1 | tee "${ARTIFACT_DIR}"/e2e-branch.log
 
         /bin/bash -c "integration-tests/scripts/konflux-e2e-runner.sh"
-
+    - name: secure-push-oci
+      ref:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: stepactions/secure-push-oci/0.1/secure-push-oci.yaml
+      params:
+        - name: workdir-path
+          value: /workspace/artifact-dir
+        - name: oci-ref
+          value: $(params.oras-container)
+        - name: credentials-volume-name
+          value: konflux-test-infra-volume
+    - name: fail-if-any-step-failed
+      ref:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: stepactions/fail-if-any-step-failed/0.1/fail-if-any-step-failed.yaml


### PR DESCRIPTION
# Description

* use new versions of tasks for (de)provisioning ROSA clusters and stepactions for pushing artifacts to OCI storage
* remove `create-oci-container` task, because it's not needed anymore, since [**secure-push-oci** stepaction detects whether it's needed to create a new OCI artifact](https://github.com/konflux-ci/tekton-integration-catalog/blob/168d270f154b72b42aff1973ca754939df6895d8/stepactions/secure-push-oci/0.1/secure-push-oci.yaml#L62) or use existing one
* the change was tested in a previous commit ([which was referencing the current PR git URL and branch](https://github.com/konflux-ci/e2e-tests/pull/1475/commits/af569d60b4c7ca82e7fce31d859c3a4de2859ba7#diff-b95cbbb0088e1a08e6e3983fd72cf84eeeb1b822379e1fa092fcc4c9dd0cddc4L120)) - the OCI artifact including the logs from this PR is [here](https://app-artifact-browser.apps.rosa.konflux-qe.zmr9.p3.openshiftapps.com/e2e-tests/2024-12-14_11-30-56+konflux-e2e-58mjt/)

## Issue ticket number and link
[KFLUXDP-6](https://issues.redhat.com//browse/KFLUXDP-6)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

in CI 🤷 

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
