### PR TITLE
fix: git repo url should have .git suffix

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -134,7 +134,7 @@ const (
 	GITLAB_PROJECT_ID_ENV string = "GITLAB_PROJECT_ID"
 
 	// Release service catalog default URL and revision for e2e tests
-	RELEASE_CATALOG_DEFAULT_URL      = "https://github.com/konflux-ci/release-service-catalog"
+	RELEASE_CATALOG_DEFAULT_URL      = "https://github.com/konflux-ci/release-service-catalog.git"
 	RELEASE_CATALOG_DEFAULT_REVISION = "staging"
 
 	// Test namespace's required labels


### PR DESCRIPTION
This url is used in the RPA and it's used for Tekton git resolver. All the RPAs in konflux-release-data repo use the .git suffix and it's also what's used
as an example in Tekton docs.

For context, a user recently hit an issue:
https://github.com/konflux-ci/release-service-catalog/pull/759

We had a bug that caused an issue with the .git suffix. But e2e didn't expose the problem because the .git suffix was not there.

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [x] I have updated labels (if needed)
