### PR TITLE
fix: make target setup-source-build

### DIFF
--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -766,8 +766,13 @@ func createNewTaskBundleAndPush(currentSourceTaskBundle, sourceImage string) str
 		return ""
 	}
 	sourceTaskObject := tektonObj.(*tektonapi.Task)
-	klog.Infof("current source build task image: %v", sourceTaskObject.Spec.Steps[0].Image)
-	sourceTaskObject.Spec.Steps[0].Image = sourceImage
+	for i := range sourceTaskObject.Spec.Steps {
+		if sourceTaskObject.Spec.Steps[i].Name == "build" {
+			klog.Infof("current source build task image: %v", sourceTaskObject.Spec.Steps[i].Image)
+			sourceTaskObject.Spec.Steps[i].Image = sourceImage
+		}
+	}
+
 	if newTaskYaml, err = yaml.Marshal(sourceTaskObject); err != nil {
 		klog.Errorf("error when marshalling a new pipeline to YAML: %v", err)
 		return ""

--- a/tests/build/build_templates_scenarios.go
+++ b/tests/build/build_templates_scenarios.go
@@ -118,7 +118,7 @@ var componentScenarios = []ComponentScenarioSpec{
 	},
 	{
 		GitURL:              "https://github.com/konflux-qe-bd/source-build-base-on-konflux-image",
-		Revision:            "86c4d160cfafb8976a23030d4bbc1216bfe8e14f",
+		Revision:            "b6960c7602f21c531e3ead4df1dd1827e6f208f6",
 		ContextDir:          ".",
 		DockerFilePath:      "Dockerfile",
 		PipelineBundleNames: []string{"docker-build"},


### PR DESCRIPTION
# Description

Source build task got changed and broken into two steps, leading to wrong behavior when running `make setup-source-build` , this PR will fix the issue

## Issue ticket number and link
Part of https://issues.redhat.com/browse/STONEBLD-2991

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Locally

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
