### PR TITLE
fix: docker.io creds to tekton-results postgres SA

### DIFF
--- a/integration-tests/scripts/konflux-e2e-runner.sh
+++ b/integration-tests/scripts/konflux-e2e-runner.sh
@@ -88,7 +88,8 @@ oc registry login --registry=docker.io --auth-basic="$DOCKER_IO_AUTH" --to=./glo
 namespace_sa_names=$(cat << 'EOF'
 minio-operator|console-sa
 minio-operator|minio-operator
-tekton-logging|vectors-tekton-logs-collector
+product-kubearchive|default
+tekton-logging|vector-tekton-logs-collector
 tekton-results|storage-sa
 tekton-results|postgres-postgresql
 EOF

--- a/integration-tests/scripts/konflux-e2e-runner.sh
+++ b/integration-tests/scripts/konflux-e2e-runner.sh
@@ -90,6 +90,7 @@ minio-operator|console-sa
 minio-operator|minio-operator
 tekton-logging|vectors-tekton-logs-collector
 tekton-results|storage-sa
+tekton-results|postgres-postgresql
 EOF
 )
 while IFS='|' read -r ns sa_name; do


### PR DESCRIPTION
# Description

quick workaround for
```
Failed to pull image "docker.io/bitnami/os-shell:11-debian-11-r96": reading manifest 11-debian-11-r96 in docker.io/bitnami/os-shell: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit
```

long-term we need to get rid of docker.io dependency to prevent these issues - tracked [here](https://issues.redhat.com/browse/KFLUXDP-133)

## Update
* after initial fix for tekton-results namespace I found out 2 more updates were needed:
  * add pull secret to `default` SA in `product-kubearchive` namespace
  * update `vectors-tekton-logs-collector` SA name in tekton-logging to `vector-tekton-logs-collector`