### PR TITLE
feat(KFLUXDP-108): Allow to pass via COMPONENT_IMAGE env images with tag and sha

### DIFF
--- a/magefiles/rulesengine/repos/build_service.go
+++ b/magefiles/rulesengine/repos/build_service.go
@@ -1,7 +1,6 @@
 package repos
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/konflux-ci/e2e-tests/magefiles/rulesengine"
@@ -38,10 +37,8 @@ var BuildServiceRepoSetDefaultSettingsRule = rulesengine.Rule{Name: "General Req
 			return nil
 		}
 		rctx.ComponentEnvVarPrefix = "BUILD_SERVICE"
-		// TODO keep only "KONFLUX_CI" option once we migrate off openshift-ci
-		if os.Getenv("KONFLUX_CI") == "true" {
-			rctx.ComponentImageTag = fmt.Sprintf("on-pr-%s", rctx.PrCommitSha)
-		} else {
+		// Option to execute the tests in Openshift CI
+		if os.Getenv("KONFLUX_CI") != "true" {
 			rctx.ComponentImageTag = "redhat-appstudio-build-service-image"
 		}
 		return SetEnvVarsForComponentImageDeployment(rctx)

--- a/magefiles/rulesengine/repos/image_controller.go
+++ b/magefiles/rulesengine/repos/image_controller.go
@@ -1,7 +1,6 @@
 package repos
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/konflux-ci/e2e-tests/magefiles/rulesengine"
@@ -39,9 +38,7 @@ var ImageControllerRepoSetDefaultSettingsRule = rulesengine.Rule{Name: "General 
 		}
 		rctx.ComponentEnvVarPrefix = "IMAGE_CONTROLLER"
 		// TODO keep only "KONFLUX_CI" option once we migrate off openshift-ci
-		if os.Getenv("KONFLUX_CI") == "true" {
-			rctx.ComponentImageTag = fmt.Sprintf("on-pr-%s", rctx.PrCommitSha)
-		} else {
+		if os.Getenv("KONFLUX_CI") != "true" {
 			rctx.ComponentImageTag = "redhat-appstudio-image-controller-image"
 		}
 		return SetEnvVarsForComponentImageDeployment(rctx)

--- a/magefiles/rulesengine/repos/integration_service.go
+++ b/magefiles/rulesengine/repos/integration_service.go
@@ -1,7 +1,6 @@
 package repos
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/konflux-ci/e2e-tests/magefiles/rulesengine"
@@ -39,9 +38,7 @@ var IntegrationServiceRepoSetDefaultSettingsRule = rulesengine.Rule{Name: "Gener
 		}
 		rctx.ComponentEnvVarPrefix = "INTEGRATION_SERVICE"
 		// TODO keep only "KONFLUX_CI" option once we migrate off openshift-ci
-		if os.Getenv("KONFLUX_CI") == "true" {
-			rctx.ComponentImageTag = fmt.Sprintf("on-pr-%s", rctx.PrCommitSha)
-		} else {
+		if os.Getenv("KONFLUX_CI") != "true" {
 			rctx.ComponentImageTag = "redhat-appstudio-integration-service-image"
 		}
 		return SetEnvVarsForComponentImageDeployment(rctx)

--- a/magefiles/rulesengine/repos/release_service.go
+++ b/magefiles/rulesengine/repos/release_service.go
@@ -36,9 +36,8 @@ var ReleaseServiceRepoSetDefaultSettingsRule = rulesengine.Rule{Name: "General R
 		}
 		rctx.ComponentEnvVarPrefix = "RELEASE_SERVICE"
 		// TODO keep only "KONFLUX_CI" option once we migrate off openshift-ci
-		if os.Getenv("KONFLUX_CI") == "true" {
-			rctx.ComponentImageTag = fmt.Sprintf("on-pr-%s", rctx.PrCommitSha)
-		} else {
+
+		if os.Getenv("KONFLUX_CI") != "true" {
 			rctx.ComponentImageTag = "redhat-appstudio-release-service-image"
 		}
 		//This is env variable is specified for release service


### PR DESCRIPTION

# Description

Extend functinality to add via COMPONENT_IMAGE images like: quay.io/redhat-user-workloads/rhtap-build-tenant/build-service/build-service@sha256:20ca83111840a28c870750d576a4e2bdf0c8452f2ed3e1a21a64b9f2cbba580d

This images contain the tag name and the sha

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
