### PR TITLE
increase timeout and interval

### DIFF
--- a/tests/build/build.go
+++ b/tests/build/build.go
@@ -244,8 +244,8 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build-ser
 			})
 
 			It("a related PipelineRun should be deleted after deleting the component", func() {
-				timeout = time.Second * 60
-				interval = time.Second * 1
+				timeout = time.Second * 180
+				interval = time.Second * 5
 				Expect(f.AsKubeAdmin.HasController.DeleteComponent(customDefaultComponentName, testNamespace, true)).To(Succeed())
 				// Test removal of PipelineRun
 				Eventually(func() error {


### PR DESCRIPTION
# Description

Increasing the timeout and interval, observed that sometimes it is taking more time to delete the pipeline run after the component is deleted.

## Issue ticket number and link
N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
