### PR TITLE
fix: Match new tekton-pipelines-controller pod name as it is handled by StatefulSet now

### DIFF
--- a/tests/load-tests/cluster_read_config.yaml
+++ b/tests/load-tests/cluster_read_config.yaml
@@ -197,6 +197,6 @@
   monitoring_step: {{ step }}
 {%- endmacro %}
 
-{{ monitor_pod('openshift-pipelines', 'tekton-pipelines-controller', 15) }}
+{{ monitor_pod('openshift-pipelines', 'tekton-pipelines-controller', 15, '-[0-9]+') }}
 {{ monitor_pod('tekton-results', 'tekton-results-watcher', 1, '-.*') }}
 {{ monitor_pod_container('tekton-results', 'tekton-results-watcher', 'watcher', 1, '-.*') }}


### PR DESCRIPTION
# Description

tekton-pipelines-controller pods are now owned by StatefulSet now, so their name is not like `tekton-pipelines-controller-[0-9a-f]+-.*` (e.g. `tekton-pipelines-controller-679f858ccf-w5p9s`), but `tekton-pipelines-controller-[0-9]+` (e.g. `tekton-pipelines-controller-0`).

## Issue ticket number and link

None

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Not tested, will use CI job here.