### PR TITLE
feat: Support SPDX SBOMs

### DIFF
--- a/pkg/utils/build/sbom.go
+++ b/pkg/utils/build/sbom.go
@@ -49,6 +49,49 @@ func (c *CyclonedxComponent) GetPurl() string {
 	return c.Purl
 }
 
+type SbomSpdx struct {
+	SPDXID      string        `json:"SPDXID"`
+	SpdxVersion string        `json:"spdxVersion"`
+	Packages    []SpdxPackage `json:"packages"`
+}
+
+type SpdxPackage struct {
+	Name         string            `json:"name"`
+	VersionInfo  string            `json:"versionInfo"`
+	ExternalRefs []SpdxExternalRef `json:"externalRefs"`
+}
+
+type SpdxExternalRef struct {
+	ReferenceCategory string `json:"referenceCategory"`
+	ReferenceLocator  string `json:"referenceLocator"`
+	ReferenceType     string `json:"referenceType"`
+}
+
+func (s *SbomSpdx) GetPackages() []SbomPackage {
+	packages := []SbomPackage{}
+	for i := range s.Packages {
+		packages = append(packages, &s.Packages[i])
+	}
+	return packages
+}
+
+func (p *SpdxPackage) GetName() string {
+	return p.Name
+}
+
+func (p *SpdxPackage) GetVersion() string {
+	return p.VersionInfo
+}
+
+func (p *SpdxPackage) GetPurl() string {
+	for _, ref := range p.ExternalRefs {
+		if ref.ReferenceType == "purl" {
+			return ref.ReferenceLocator
+		}
+	}
+	return ""
+}
+
 func UnmarshalSbom(data []byte) (Sbom, error) {
 	cdx := SbomCyclonedx{}
 	if err := json.Unmarshal(data, &cdx); err != nil {
@@ -57,5 +100,14 @@ func UnmarshalSbom(data []byte) (Sbom, error) {
 	if cdx.BomFormat != "" {
 		return &cdx, nil
 	}
-	return nil, fmt.Errorf("unmarshalling SBOM: doesn't look like CycloneDX")
+
+	spdx := SbomSpdx{}
+	if err := json.Unmarshal(data, &spdx); err != nil {
+		return nil, fmt.Errorf("unmarshalling SBOM: %w", err)
+	}
+	if spdx.SPDXID != "" {
+		return &spdx, nil
+	}
+
+	return nil, fmt.Errorf("unmarshalling SBOM: doesn't look like either CycloneDX or SPDX")
 }

--- a/pkg/utils/build/sbom.go
+++ b/pkg/utils/build/sbom.go
@@ -1,15 +1,61 @@
 package build
 
+import (
+	"encoding/json"
+	"fmt"
+)
 
+type Sbom interface {
+	GetPackages() []SbomPackage
+}
+
+type SbomPackage interface {
+	GetName() string
+	GetVersion() string
+	GetPurl() string
+}
 
 type SbomCyclonedx struct {
 	BomFormat   string
 	SpecVersion string
 	Version     int
-	Components  []struct {
-		Name    string `json:"name"`
-		Purl    string `json:"purl"`
-		Type    string `json:"type"`
-		Version string `json:"version"`
-	} `json:"components"`
+	Components  []CyclonedxComponent `json:"components"`
+}
+
+type CyclonedxComponent struct {
+	Name    string `json:"name"`
+	Purl    string `json:"purl"`
+	Type    string `json:"type"`
+	Version string `json:"version"`
+}
+
+func (s *SbomCyclonedx) GetPackages() []SbomPackage {
+	packages := []SbomPackage{}
+	for i := range s.Components {
+		packages = append(packages, &s.Components[i])
+	}
+	return packages
+}
+
+func (c *CyclonedxComponent) GetName() string {
+	return c.Name
+}
+
+func (c *CyclonedxComponent) GetVersion() string {
+	return c.Version
+}
+
+func (c *CyclonedxComponent) GetPurl() string {
+	return c.Purl
+}
+
+func UnmarshalSbom(data []byte) (Sbom, error) {
+	cdx := SbomCyclonedx{}
+	if err := json.Unmarshal(data, &cdx); err != nil {
+		return nil, fmt.Errorf("unmarshalling SBOM: %w", err)
+	}
+	if cdx.BomFormat != "" {
+		return &cdx, nil
+	}
+	return nil, fmt.Errorf("unmarshalling SBOM: doesn't look like CycloneDX")
 }

--- a/tests/build/build_templates.go
+++ b/tests/build/build_templates.go
@@ -361,6 +361,9 @@ var _ = framework.BuildSuiteDescribe("Build templates E2E test", Label("build", 
 				case *build.SbomCyclonedx:
 					Expect(s.BomFormat).ToNot(BeEmpty())
 					Expect(s.SpecVersion).ToNot(BeEmpty())
+				case *build.SbomSpdx:
+					Expect(s.SPDXID).ToNot(BeEmpty())
+					Expect(s.SpdxVersion).ToNot(BeEmpty())
 				default:
 					Fail(fmt.Sprintf("unknown SBOM type: %T", s))
 				}


### PR DESCRIPTION
# Description

Support unmarshalling the show-sbom task output into either CycloneDX or SPDX models. Do similar assertions for both SBOM formats.

## Issue ticket number and link

https://issues.redhat.com/browse/STONEBLD-3051

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Temporary commit in https://github.com/konflux-ci/build-definitions/pull/1865

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
