### PR TITLE
fix: increase the wait time for no new pipelines gets triggered check

### DIFF
--- a/tests/build/build.go
+++ b/tests/build/build.go
@@ -559,8 +559,11 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build-ser
 				GinkgoWriter.Printf("waiting for one minute and expecting to not trigger a PipelineRun")
 				Consistently(func() bool {
 					componentPipelineRun, _ := f.AsKubeAdmin.HasController.GetComponentPipelineRun(customBranchComponentName, applicationName, testNamespace, "")
+					if componentPipelineRun != nil {
+						GinkgoWriter.Printf("While waiting for no pipeline to be triggered, found Pipelinerun: %s\n", componentPipelineRun.GetName())
+					}
 					return componentPipelineRun == nil
-				}, time.Minute, constants.PipelineRunPollingInterval).Should(BeTrue(), fmt.Sprintf("expected no PipelineRun to be triggered for the component %s in %s namespace", customBranchComponentName, testNamespace))
+				}, 2*time.Minute, constants.PipelineRunPollingInterval).Should(BeTrue(), fmt.Sprintf("expected no PipelineRun to be triggered for the component %s in %s namespace", customBranchComponentName, testNamespace))
 			})
 			It("image repo is updated to private", func() {
 				isPublic, err := build.IsImageRepoPublic(imageRepoName)


### PR DESCRIPTION
# Description

Recently in the periodic executions of the e2e-tests, below test started to fail frequently
` [FAIL] [build-service-suite Build service E2E tests] test PaC component build gitlab when the PaC init branch is merged [It] After updating image visibility to private, it should not trigger another PipelineRun [build-service, github-webhook, pac-build, pipeline, image-controller, build-custom-branch]`

one such example is [here](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-redhat-appstudio-infra-deployments-main-appstudio-e2e-tests-periodic/1884693173121323008).

It might be due the deletion of pipelineruns [here ](https://github.com/konflux-ci/e2e-tests/blob/6aa3c66ddd2e0fda956f898f7828c13ca8400f12/tests/build/build.go#L549) is taking longer time, increasing the timeout will help here.

## Issue ticket number and link
N/A
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
