### PR TITLE
feat(KONFLUX-6576): Collect ETCD metrics for loadtest

### DIFF
--- a/tests/load-tests/ci-scripts/max-concurrency/cluster_read_config.yaml
+++ b/tests/load-tests/ci-scripts/max-concurrency/cluster_read_config.yaml
@@ -62,6 +62,18 @@
   monitoring_query: sum(rate(etcd_request_duration_seconds_sum{}[5m])) / sum(rate(etcd_request_duration_seconds_count[5m]))
   monitoring_step: 15
 
+- name: measurements.etcd_mvcc_db_total_size_in_bytes_average
+  monitoring_query: avg(etcd_mvcc_db_total_size_in_bytes)
+  monitoring_step: 15
+
+- name: measurements.etcd_mvcc_db_total_size_in_use_in_bytes_average
+  monitoring_query: avg(etcd_mvcc_db_total_size_in_use_in_bytes)
+  monitoring_step: 15
+
+- name: measurements.etcd_server_quota_backend_bytes_average
+  monitoring_query: avg(etcd_server_quota_backend_bytes)
+  monitoring_step: 15
+
 - name: measurements.cluster_network_bytes_total
   monitoring_query: sum(irate(container_network_receive_bytes_total{cluster="",namespace=~".*"}[5m])) + sum(irate(container_network_transmit_bytes_total{cluster="",namespace=~".*"}[5m]))
   monitoring_step: 15
@@ -181,4 +193,5 @@
 
 {{ monitor_pod('tekton-results', 'tekton-results-watcher', 20, '-.*') }}
 {{ monitor_pod_container('tekton-results', 'tekton-results-watcher', 'watcher', 20, '-.*') }}
+{{ monitor_pod('openshift-etcd', 'etcd', 15, pod_suffix_regex='-ip-.+') }}
 {{ pv_stats('tekton-results', 'data-postgres-postgresql-0', 20) }}

--- a/tests/load-tests/cluster_read_config.yaml
+++ b/tests/load-tests/cluster_read_config.yaml
@@ -62,6 +62,18 @@
   monitoring_query: sum(rate(etcd_request_duration_seconds_sum{}[5m])) / sum(rate(etcd_request_duration_seconds_count[5m]))
   monitoring_step: 15
 
+- name: measurements.etcd_mvcc_db_total_size_in_bytes_average
+  monitoring_query: avg(etcd_mvcc_db_total_size_in_bytes)
+  monitoring_step: 15
+
+- name: measurements.etcd_mvcc_db_total_size_in_use_in_bytes_average
+  monitoring_query: avg(etcd_mvcc_db_total_size_in_use_in_bytes)
+  monitoring_step: 15
+
+- name: measurements.etcd_server_quota_backend_bytes_average
+  monitoring_query: avg(etcd_server_quota_backend_bytes)
+  monitoring_step: 15
+
 - name: measurements.cluster_network_bytes_total
   monitoring_query: sum(irate(container_network_receive_bytes_total{cluster="",namespace=~".*"}[5m])) + sum(irate(container_network_transmit_bytes_total{cluster="",namespace=~".*"}[5m]))
   monitoring_step: 15
@@ -199,4 +211,5 @@
 
 {{ monitor_pod('openshift-pipelines', 'tekton-pipelines-controller', 15, '-[0-9]+') }}
 {{ monitor_pod('tekton-results', 'tekton-results-watcher', 1, '-.*') }}
+{{ monitor_pod('openshift-etcd', 'etcd', 15, pod_suffix_regex='-ip-.+') }}
 {{ monitor_pod_container('tekton-results', 'tekton-results-watcher', 'watcher', 1, '-.*') }}


### PR DESCRIPTION
# Description

Collect additional ETCD metrics for loadtest. 

This is a follow up on PR https://github.com/konflux-ci/e2e-tests/pull/1502, this changes adds the metrics to the default load test and max-concurrenct scenarios.

## Issue ticket number and link

https://issues.redhat.com/browse/KONFLUX-6576

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested the changes through GitHub Actions in Konflux Staging and confirmed that below metrics are being collected.

# Checklist:

- [x] I have performed a self-review of my code