### PR TITLE
feat(STONEINTG-1114): add case for report of snapshot creation faliure

### DIFF
--- a/pkg/clients/has/components.go
+++ b/pkg/clients/has/components.go
@@ -68,7 +68,7 @@ func (h *HasController) GetComponentPipelineRun(componentName string, applicatio
 
 // GetComponentPipelineRunWithType returns first pipeline run for a given component labels with pipeline type within label "pipelines.appstudio.openshift.io/type" ("build", "test")
 func (h *HasController) GetComponentPipelineRunWithType(componentName string, applicationName string, namespace, pipelineType string, sha string) (*pipeline.PipelineRun, error) {
-	prs, err := h.GetComponentPipelineRunsWithType(componentName, applicationName, namespace, "", sha)
+	prs, err := h.GetComponentPipelineRunsWithType(componentName, applicationName, namespace, pipelineType, sha)
 	if err != nil {
 		return nil, err
 	} else {

--- a/pkg/clients/tekton/pipelineruns.go
+++ b/pkg/clients/tekton/pipelineruns.go
@@ -292,3 +292,18 @@ func (t *TektonController) RemoveFinalizerFromPipelineRun(pipelineRun *pipeline.
 	}
 	return nil
 }
+
+func (t *TektonController) UpdatePipelineRunStatus(pipelineRun *pipeline.PipelineRun, status pipeline.PipelineRunStatus) (*pipeline.PipelineRun, error) {
+	ctx := context.Background()
+	pipelineRun, err := t.PipelineClient().TektonV1().PipelineRuns(pipelineRun.Namespace).Get(ctx, pipelineRun.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get PipelineRun: %v", err)
+	}
+	pipelineRun.Status = status
+
+	pipelineRun, err = t.PipelineClient().TektonV1().PipelineRuns(pipelineRun.Namespace).UpdateStatus(ctx, pipelineRun, metav1.UpdateOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("Failed to update PipelineRun status: %v", err)
+	}
+	return pipelineRun, nil
+}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -235,6 +235,9 @@ const (
 	CheckrunConclusionSuccess = "success"
 	CheckrunConclusionFailure = "failure"
 	CheckrunStatusCompleted   = "completed"
+
+	BuildPipelineRunSnapshotAnnotation = "appstudio.openshift.io/snapshot"
+	SnapshotCreationReportAnnotation = "test.appstudio.openshift.io/snapshot-creation-report"
 )
 
 var (


### PR DESCRIPTION
* add e2e case for report of snashot creation failure
* to achieve it, a e2e-test finalizer is added to build PLR after it is created, then after it pass the positive test, the test result with invalid image digest will be updated to build PLR and then we can get a snapshot creation failure, then finally e2e-test finalizer will be removed from build PLR after the negative case finishes. 

Signed-off-by: Hongwei Liu <hongliu@redhat.com>

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
