### PR TITLE
fix: ec golden-image check and delete OldTektonTaskTestOutputName

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -180,11 +180,6 @@ const (
 	StrategyConfigsDefaultBranch = "main"
 	StrategyConfigsRevision      = "caeaaae63a816ab42dad6c7be1e4b352ea8aabf4"
 
-	// TODO
-	// delete this constant and all its occurrences in the code base
-	// once https://issues.redhat.com/browse/RHTAP-810 is completed
-	OldTektonTaskTestOutputName = "HACBS_TEST_OUTPUT"
-
 	TektonTaskTestOutputName = "TEST_OUTPUT"
 
 	DefaultPipelineServiceAccount            = "appstudio-pipeline"

--- a/tests/enterprise-contract/contract.go
+++ b/tests/enterprise-contract/contract.go
@@ -219,8 +219,6 @@ var _ = framework.EnterpriseContractSuiteDescribe("Enterprise Contract E2E tests
 				Expect(tekton.DidTaskRunSucceed(tr)).To(BeTrue())
 				GinkgoWriter.Printf("Make sure result for TaskRun %q succeeded\n", tr.PipelineTaskName)
 				Expect(tr.Status.TaskRunStatusFields.Results).Should(Or(
-					// TODO: delete the first option after https://issues.redhat.com/browse/RHTAP-810 is completed
-					ContainElements(tekton.MatchTaskRunResultWithJSONPathValue(constants.OldTektonTaskTestOutputName, "{$.result}", `["SUCCESS"]`)),
 					ContainElements(tekton.MatchTaskRunResultWithJSONPathValue(constants.TektonTaskTestOutputName, "{$.result}", `["SUCCESS"]`)),
 				))
 			})
@@ -249,8 +247,6 @@ var _ = framework.EnterpriseContractSuiteDescribe("Enterprise Contract E2E tests
 				Expect(tekton.DidTaskRunSucceed(tr)).To(BeTrue())
 				GinkgoWriter.Printf("Make sure result for TaskRun %q succeeded\n", tr.PipelineTaskName)
 				Expect(tr.Status.TaskRunStatusFields.Results).Should(Or(
-					// TODO: delete the first option after https://issues.redhat.com/browse/RHTAP-810 is completed
-					ContainElements(tekton.MatchTaskRunResultWithJSONPathValue(constants.OldTektonTaskTestOutputName, "{$.result}", `["FAILURE"]`)),
 					ContainElements(tekton.MatchTaskRunResultWithJSONPathValue(constants.TektonTaskTestOutputName, "{$.result}", `["FAILURE"]`)),
 				))
 			})
@@ -322,8 +318,6 @@ var _ = framework.EnterpriseContractSuiteDescribe("Enterprise Contract E2E tests
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(tr.Status.TaskRunStatusFields.Results).Should(Or(
-						// TODO: delete the first option after https://issues.redhat.com/browse/RHTAP-810 is completed
-						ContainElements(tekton.MatchTaskRunResultWithJSONPathValue(constants.OldTektonTaskTestOutputName, "{$.result}", `["FAILURE"]`)),
 						ContainElements(tekton.MatchTaskRunResultWithJSONPathValue(constants.TektonTaskTestOutputName, "{$.result}", `["FAILURE"]`)),
 					))
 					//Get container step-report-json log details from pod
@@ -367,8 +361,6 @@ var _ = framework.EnterpriseContractSuiteDescribe("Enterprise Contract E2E tests
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(tr.Status.TaskRunStatusFields.Results).Should(Or(
-						// TODO: delete the first option after https://issues.redhat.com/browse/RHTAP-810 is completed
-						ContainElements(tekton.MatchTaskRunResultWithJSONPathValue(constants.OldTektonTaskTestOutputName, "{$.result}", `["SUCCESS"]`)),
 						ContainElements(tekton.MatchTaskRunResultWithJSONPathValue(constants.TektonTaskTestOutputName, "{$.result}", `["SUCCESS"]`)),
 					))
 					//Get container step-report-json log details from pod
@@ -397,7 +389,7 @@ var _ = framework.EnterpriseContractSuiteDescribe("Enterprise Contract E2E tests
 							// This test validates an image via a floating tag (as designed). This makes
 							// it hard to provide the expected git commit. Here we just ignore that
 							// particular check.
-							Exclude: []string{"slsa_source_correlated.source_code_reference_provided"},
+							Exclude: []string{"slsa_source_correlated.source_code_reference_provided", "cve.cve_results_found"},
 						})
 					Expect(fwk.AsKubeAdmin.TektonController.CreateOrUpdatePolicyConfiguration(namespace, policy)).To(Succeed())
 
@@ -413,8 +405,6 @@ var _ = framework.EnterpriseContractSuiteDescribe("Enterprise Contract E2E tests
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(tr.Status.TaskRunStatusFields.Results).ShouldNot(Or(
-						// TODO: delete the first option after https://issues.redhat.com/browse/RHTAP-810 is completed
-						ContainElements(tekton.MatchTaskRunResultWithJSONPathValue(constants.OldTektonTaskTestOutputName, "{$.result}", `["FAILURE"]`)),
 						ContainElements(tekton.MatchTaskRunResultWithJSONPathValue(constants.TektonTaskTestOutputName, "{$.result}", `["FAILURE"]`)),
 					))
 				})
@@ -449,8 +439,6 @@ var _ = framework.EnterpriseContractSuiteDescribe("Enterprise Contract E2E tests
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(tr.Status.TaskRunStatusFields.Results).Should(Or(
-						// TODO: delete the first option after https://issues.redhat.com/browse/RHTAP-810 is completed
-						ContainElements(tekton.MatchTaskRunResultWithJSONPathValue(constants.OldTektonTaskTestOutputName, "{$.result}", `["FAILURE"]`)),
 						ContainElements(tekton.MatchTaskRunResultWithJSONPathValue(constants.TektonTaskTestOutputName, "{$.result}", `["FAILURE"]`)),
 					))
 
@@ -489,8 +477,6 @@ var _ = framework.EnterpriseContractSuiteDescribe("Enterprise Contract E2E tests
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(tr.Status.TaskRunStatusFields.Results).Should(Or(
-						// TODO: delete the first option after https://issues.redhat.com/browse/RHTAP-810 is completed
-						ContainElements(tekton.MatchTaskRunResultWithJSONPathValue(constants.OldTektonTaskTestOutputName, "{$.result}", `["WARNING"]`)),
 						ContainElements(tekton.MatchTaskRunResultWithJSONPathValue(constants.TektonTaskTestOutputName, "{$.result}", `["WARNING"]`)),
 					))
 


### PR DESCRIPTION
# Description

fix the failed test in [enterprise-contract-suite Enterprise Contract E2E tests] test creating and signing an image and task verify-enterprise-contract task Release Policy [It] verifies redhat products pass the redhat policy rule collection before release  [ec, pipeline]

delete var OldTektonTaskTestOutputName as https://issues.redhat.com/browse/RHTAP-810 is completed 

## Issue ticket number and link

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
