### PR TITLE
fix: update github org needed for the test

### DIFF
--- a/pkg/clients/github/git.go
+++ b/pkg/clients/github/git.go
@@ -66,55 +66,6 @@ func (g *Github) ExistsRef(repository, branchName string) (bool, error) {
 	return true, nil
 }
 
-func (g *Github) DeleteRefFromOrg(githubOrg, repository, branchName string) error {
-	_, err := g.client.Git.DeleteRef(context.Background(), githubOrg, repository, fmt.Sprintf(HEADS, branchName))
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func (g *Github) ExistsRefInOrg(githubOrg, repository, branchName string) (bool, error) {
-	_, _, err := g.client.Git.GetRef(context.Background(), githubOrg, repository, fmt.Sprintf(HEADS, branchName))
-	if err != nil {
-		if strings.Contains(err.Error(), "404 Not Found") {
-			return false, nil
-		} else {
-			return false, fmt.Errorf("error when getting the branch '%s' for the repo '%s': %+v", branchName, repository, err)
-		}
-	}
-	return true, nil
-}
-
-func (g *Github) CreateRefInOrg(githubOrg, repository, baseBranchName, sha, newBranchName string) error {
-	ctx := context.Background()
-	ref, _, err := g.client.Git.GetRef(ctx, githubOrg, repository, fmt.Sprintf(HEADS, baseBranchName))
-	if err != nil {
-		return fmt.Errorf("error when getting the base branch name '%s' for the repo '%s': %+v", baseBranchName, repository, err)
-	}
-
-	ref.Ref = github.String(fmt.Sprintf(HEADS, newBranchName))
-
-	if sha != "" {
-		ref.Object.SHA = &sha
-	}
-
-	_, _, err = g.client.Git.CreateRef(ctx, githubOrg, repository, ref)
-	if err != nil {
-		return fmt.Errorf("error when creating a new branch '%s' for the repo '%s': %+v", newBranchName, repository, err)
-	}
-	err = utils.WaitUntilWithInterval(func() (done bool, err error) {
-		exist, err := g.ExistsRefInOrg(githubOrg, repository, newBranchName)
-		if err != nil {
-			return false, err
-		}
-		if exist && err == nil {
-			return exist, err
-		}
-		return false, nil
-	}, 2*time.Second, 2*time.Minute) //Wait for the branch to actually exist
-	if err != nil {
-		return fmt.Errorf("error when waiting for ref: %+v", err)
-	}
-	return nil
+func (g *Github) UpdateGithubOrg(githubOrg string) {
+	g.organization = githubOrg
 }

--- a/tests/build/build.go
+++ b/tests/build/build.go
@@ -907,12 +907,15 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build-ser
 			_, err = f.AsKubeAdmin.HasController.CreateApplication(applicationName, testNamespace)
 			Expect(err).NotTo(HaveOccurred())
 
+			// Update the default github org
+			f.AsKubeAdmin.CommonController.Github.UpdateGithubOrg(noAppOrgName)
+
 			firstComponentBaseBranchName = fmt.Sprintf("component-one-base-%s", util.GenerateRandomString(6))
-			err = f.AsKubeAdmin.CommonController.Github.CreateRefInOrg(noAppOrgName, secretLookupGitSourceRepoOneName, secretLookupDefaultBranchOne, secretLookupGitRevisionOne, firstComponentBaseBranchName)
+			err = f.AsKubeAdmin.CommonController.Github.CreateRef(secretLookupGitSourceRepoOneName, secretLookupDefaultBranchOne, secretLookupGitRevisionOne, firstComponentBaseBranchName)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			secondComponentBaseBranchName = fmt.Sprintf("component-two-base-%s", util.GenerateRandomString(6))
-			err = f.AsKubeAdmin.CommonController.Github.CreateRefInOrg(noAppOrgName, secretLookupGitSourceRepoTwoName, secretLookupDefaultBranchTwo, secretLookupGitRevisionTwo, secondComponentBaseBranchName)
+			err = f.AsKubeAdmin.CommonController.Github.CreateRef(secretLookupGitSourceRepoTwoName, secretLookupDefaultBranchTwo, secretLookupGitRevisionTwo, secondComponentBaseBranchName)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// use custom bundle if env defined
@@ -928,22 +931,22 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build-ser
 			}
 
 			// Delete new branches created by PaC
-			err = f.AsKubeAdmin.CommonController.Github.DeleteRefFromOrg(noAppOrgName, secretLookupGitSourceRepoOneName, firstPacBranchName)
+			err = f.AsKubeAdmin.CommonController.Github.DeleteRef(secretLookupGitSourceRepoOneName, firstPacBranchName)
 			if err != nil {
 				Expect(err.Error()).To(ContainSubstring("Reference does not exist"))
 			}
-			err = f.AsKubeAdmin.CommonController.Github.DeleteRefFromOrg(noAppOrgName, secretLookupGitSourceRepoTwoName, secondPacBranchName)
+			err = f.AsKubeAdmin.CommonController.Github.DeleteRef(secretLookupGitSourceRepoTwoName, secondPacBranchName)
 			if err != nil {
 				Expect(err.Error()).To(ContainSubstring("Reference does not exist"))
 			}
 
 			// Delete the created first component base branch
-			err = f.AsKubeAdmin.CommonController.Github.DeleteRefFromOrg(noAppOrgName, secretLookupGitSourceRepoOneName, firstComponentBaseBranchName)
+			err = f.AsKubeAdmin.CommonController.Github.DeleteRef(secretLookupGitSourceRepoOneName, firstComponentBaseBranchName)
 			if err != nil {
 				Expect(err.Error()).To(ContainSubstring("Reference does not exist"))
 			}
 			// Delete the created second component base branch
-			err = f.AsKubeAdmin.CommonController.Github.DeleteRefFromOrg(noAppOrgName, secretLookupGitSourceRepoTwoName, secondComponentBaseBranchName)
+			err = f.AsKubeAdmin.CommonController.Github.DeleteRef(secretLookupGitSourceRepoTwoName, secondComponentBaseBranchName)
 			if err != nil {
 				Expect(err.Error()).To(ContainSubstring("Reference does not exist"))
 			}


### PR DESCRIPTION
# Description

CleanupWebhook call [here](https://github.com/konflux-ci/e2e-tests/blob/f042c509583ad36ff31cb2b5f90df25e1858e0e3/tests/build/build.go#L952) not working properly, updated github org needed for the test, so that it works correctly. Also removed few deprecated functions.

## Issue ticket number and link
N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Locally.

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
