### PR TITLE
fix: docker pull secret linking

### DIFF
--- a/integration-tests/scripts/konflux-e2e-runner.sh
+++ b/integration-tests/scripts/konflux-e2e-runner.sh
@@ -96,7 +96,7 @@ while IFS='|' read -r ns sa_name; do
     oc create namespace "$ns" --dry-run=client -o yaml | oc apply -f -
     oc create sa "$sa_name" -n "$ns" --dry-run=client -o yaml | oc apply -f -
     if ! oc get secret/pull-secret -n "$ns" &> /dev/null; then
-        oc create secret docker-registry pull-secret --from-file=.dockerconfigjson=./$DOCKER_CONFIG_JSON_FILE
+        oc create secret docker-registry pull-secret --from-file=.dockerconfigjson=./$DOCKER_CONFIG_JSON_FILE -n "$ns"
     fi
     oc secrets link "$sa_name" pull-secret --for=pull -n "$ns"
 done <<< "$namespace_sa_names"

--- a/integration-tests/scripts/konflux-e2e-runner.sh
+++ b/integration-tests/scripts/konflux-e2e-runner.sh
@@ -80,11 +80,8 @@ oc config view --minify --raw > /workspace/kubeconfig
 export KUBECONFIG=/workspace/kubeconfig
 
 # ROSA HCP workaround for Docker limits
-# for namespaces 'minio-operator' and 'tekton-results'
-oc get secret/pull-secret -n openshift-config --template='{{index .data ".dockerconfigjson" | base64decode}}' > ./global-pull-secret.json
-oc get secret -n openshift-config -o yaml pull-secret > global-pull-secret.yaml
-yq -i e 'del(.metadata.namespace)' global-pull-secret.yaml
-oc registry login --registry=docker.io --auth-basic="$DOCKER_IO_AUTH" --to=./global-pull-secret.json
+DOCKER_CONFIG_JSON_FILE=docker-config.json
+oc registry login --registry=docker.io --auth-basic="$DOCKER_IO_AUTH" --to=./$DOCKER_CONFIG_JSON_FILE
 
 namespace_sa_names=$(cat << 'EOF'
 minio-operator|console-sa
@@ -99,8 +96,7 @@ while IFS='|' read -r ns sa_name; do
     oc create namespace "$ns" --dry-run=client -o yaml | oc apply -f -
     oc create sa "$sa_name" -n "$ns" --dry-run=client -o yaml | oc apply -f -
     if ! oc get secret/pull-secret -n "$ns" &> /dev/null; then
-        oc apply -f global-pull-secret.yaml -n "$ns"
-        oc set data secret/pull-secret -n "$ns" --from-file=.dockerconfigjson=./global-pull-secret.json
+        oc create secret docker-registry pull-secret --from-file=.dockerconfigjson=./$DOCKER_CONFIG_JSON_FILE
     fi
     oc secrets link "$sa_name" pull-secret --for=pull -n "$ns"
 done <<< "$namespace_sa_names"


### PR DESCRIPTION
# Description
Setting the secret data (dockerconfigjson) immediately after creating the secret was causing error `the object has been modified; please apply your changes to the latest version and try again`. This commit reduces the secret content only to the docker.io registry, which should be sufficient

## Issue ticket number and link
N/A, the issue came from [the report on slack](https://redhat-internal.slack.com/archives/C02FANRBZQD/p1740492413809459)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

in CI 🤷 

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
