### PR TITLE
fix: add timeout for bootstrap & e2e

### DIFF
--- a/integration-tests/pipelines/konflux-e2e-tests-pipeline.yaml
+++ b/integration-tests/pipelines/konflux-e2e-tests-pipeline.yaml
@@ -141,6 +141,8 @@ spec:
           value: "$(tasks.test-metadata.results.container-image)"
         - name: container-image
           value: "$(params.container-image)"
+        - name: e2e-timeout
+          value: "90m"
   finally:
     - name: deprovision-rosa-collect-artifacts
       when:

--- a/integration-tests/tasks/konflux-e2e-tests-task.yaml
+++ b/integration-tests/tasks/konflux-e2e-tests-task.yaml
@@ -55,6 +55,9 @@ spec:
     - name: enable-sealights
       description: "A flag to enable or disable the Sealights integration feature. When set to 'true', test results are sent to Sealights for analysis; otherwise, this feature is skipped."
       default: "false"
+    - name: e2e-timeout
+      description: "Timeout value for running E2E script (cluster bootstrap + E2E tests)"
+      default: "90m"
   volumes:
     - name: konflux-secret-volume
       secret:
@@ -99,6 +102,8 @@ spec:
           value: $(params.oras-container)
         - name: ARTIFACT_DIR
           value: /workspace/artifact-dir
+        - name: E2E_TIMEOUT
+          value: $(params.e2e-timeout)
       onError: continue
       script: |
         #!/bin/bash


### PR DESCRIPTION
# Description

when e2e-tests Task times out, the artifact archiving is skipped. we need to configure a reasonable timeout for the make command for running tests to prevent this issue

## Issue ticket number and link
https://issues.redhat.com/browse/KFLUXDP-199

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I previously tested it by purposely [configuring 5 minute timeout](https://github.com/konflux-ci/e2e-tests/commit/c9776ae7861c20b238f95d80c1895cecf84e6db3)
* see the [test results analyzer message from that test run](https://github.com/konflux-ci/e2e-tests/pull/1532#issuecomment-2723760537)
* see the [archived e2e-tests.log in the artifact browser](https://app-artifact-browser.apps.rosa.konflux-qe.zmr9.p3.openshiftapps.com/e2e-tests/2025-03-14_06-25-13+konflux-e2e-kfps6/e2e-tests.log)


# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
