### PR TITLE
fix: exit status of timeout command

### DIFF
--- a/integration-tests/scripts/konflux-e2e-runner.sh
+++ b/integration-tests/scripts/konflux-e2e-runner.sh
@@ -109,4 +109,4 @@ while IFS='|' read -r ns sa_name; do
     oc secrets link "$sa_name" pull-secret --for=pull -n "$ns"
 done <<< "$namespace_sa_names"
 
-timeout "$E2E_TIMEOUT" bash -c "make ci/test/e2e 2>&1 | tee ${ARTIFACT_DIR}/e2e-tests.log"
+timeout "$E2E_TIMEOUT" make ci/test/e2e 2>&1 | tee "${ARTIFACT_DIR}/e2e-tests.log"


### PR DESCRIPTION
# Description

a follow-up on the bug introduced in https://github.com/konflux-ci/e2e-tests/pull/1532

see [this thread](https://redhat-internal.slack.com/archives/C07PZ0U12MA/p1741970053027719?thread_ts=1741963509.543829&cid=C07PZ0U12MA) for more details

# Verification
```bash
bash-5.1# set -o pipefail
bash-5.1# E2E_TIMEOUT=1s
bash-5.1# ARTIFACT_DIR=/tmp
# old code
bash-5.1# timeout "$E2E_TIMEOUT" bash -c "make ci/test/e2e 2>&1 | tee ${ARTIFACT_DIR}/e2e-tests.log"
make: *** No rule to make target 'ci/test/e2e'.  Stop.
bash-5.1# echo $?
0
# new code
bash-5.1# timeout "$E2E_TIMEOUT" make ci/test/e2e 2>&1 | tee "${ARTIFACT_DIR}/e2e-tests.log"
make: *** No rule to make target 'ci/test/e2e'.  Stop.
bash-5.1# echo $?
2
```