### PR TITLE
feat: Initialize Test Session ID just before running Ginkgo tests

### DIFF
--- a/integration-tests/tasks/konflux-e2e-tests-task.yaml
+++ b/integration-tests/tasks/konflux-e2e-tests-task.yaml
@@ -66,6 +66,25 @@ spec:
       secret:
         secretName: konflux-test-infra
   steps:
+    - name: initialize-sealights-session
+      when:
+        - input: $(params.enable-sealights)
+          operator: in
+          values: ["true"]
+      ref:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: stepactions/sealights/initialize-session/0.1/initialize-sealights-session.yaml
+      params:
+        - name: sealights-bsid
+          value: $(params.sealights-bsid)
+        - name: test-stage
+          value: $(params.test-stage)
     - name: e2e-test
       computeResources:
         requests:
@@ -184,6 +203,8 @@ spec:
           value: $(params.test-stage)
         - name: sealights-bsid
           value: $(params.sealights-bsid)
+        - name: test-session-id
+          value: $(steps.initialize-sealights-session.results.test-session-id)
     - name: secure-push-oci
       ref:
         resolver: git


### PR DESCRIPTION
# Description

Sealights recommendations are to open the session before running the ginkgo tests.

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
