### PR TITLE
feat: add option to use oci-ta-bundle

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -2,6 +2,8 @@ package constants
 
 import "time"
 
+type BuildPipelineType string
+
 // Global constants
 const (
 	// A github token is required to run the tests. The token need to have permissions to the given github organization. By default the e2e use redhat-appstudio-qe github organization.
@@ -236,6 +238,11 @@ const (
 	CheckrunConclusionSuccess = "success"
 	CheckrunConclusionFailure = "failure"
 	CheckrunStatusCompleted   = "completed"
+
+	DockerBuild                   BuildPipelineType = "docker-build"
+	DockerBuildOciTA              BuildPipelineType = "docker-build-oci-ta"
+	DockerBuildMultiPlatformOciTa BuildPipelineType = "docker-build-multi-platform-oci-ta"
+	FbcBuilder                    BuildPipelineType = "fbc-builder"
 )
 
 var (
@@ -244,7 +251,7 @@ var (
 	ImageControllerAnnotationRequestPublicRepo  = map[string]string{"image.redhat.com/generate": `{"visibility": "public"}`}
 	ImageControllerAnnotationRequestPrivateRepo = map[string]string{"image.redhat.com/generate": `{"visibility": "private"}`}
 	IntegrationTestScenarioDefaultLabels        = map[string]string{"test.appstudio.openshift.io/optional": "false"}
-	DefaultDockerBuildPipelineBundle            = map[string]string{"build.appstudio.openshift.io/pipeline": `{"name": "docker-build", "bundle": "latest"}`}
+	DefaultDockerBuildPipelineBundleAnnotation  = map[string]string{"build.appstudio.openshift.io/pipeline": `{"name": "docker-build", "bundle": "latest"}`}
 	DefaultFbcBuilderPipelineBundle             = map[string]string{"build.appstudio.openshift.io/pipeline": `{"name": "fbc-builder", "bundle": "latest"}`}
 	ComponentMintmakerDisabledAnnotation        = map[string]string{"mintmaker.appstudio.redhat.com/disabled": "true"}
 )

--- a/pkg/utils/build/custom_bundle.go
+++ b/pkg/utils/build/custom_bundle.go
@@ -24,7 +24,7 @@ const (
 	testBundle   = "quay.io/konflux-ci/tekton-catalog/task-buildah-min:0.4"
 )
 
-func GetDockerBuildPipelineBundleAnnotation(buildPipelineName constants.BuildPipelineType) map[string]string {
+func GetBuildPipelineBundleAnnotation(buildPipelineName constants.BuildPipelineType) map[string]string {
 	var bundleVersion string
 
 	switch buildPipelineName {

--- a/pkg/utils/tekton/bundle.go
+++ b/pkg/utils/tekton/bundle.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	remoteimg "github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/konflux-ci/e2e-tests/pkg/constants"
 	"github.com/tektoncd/cli/pkg/bundle"
 	pipeline "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/remote/oci"
@@ -31,12 +32,12 @@ type PipelineRef struct {
 }
 
 // ExtractTektonObjectFromBundle extracts specified Tekton object from specified bundle reference
-func ExtractTektonObjectFromBundle(bundleRef, kind, name string) (runtime.Object, error) {
+func ExtractTektonObjectFromBundle(bundleRef, kind string, name constants.BuildPipelineType) (runtime.Object, error) {
 	var obj runtime.Object
 	var err error
 
 	resolver := oci.NewResolver(bundleRef, authn.DefaultKeychain)
-	if obj, _, err = resolver.Get(context.Background(), kind, name); err != nil {
+	if obj, _, err = resolver.Get(context.Background(), kind, string(name)); err != nil {
 		return nil, fmt.Errorf("failed to fetch the tekton object %s with name %s: %v", kind, name, err)
 	}
 	return obj, nil
@@ -66,7 +67,7 @@ func GetBundleRef(pipelineRef *pipeline.PipelineRef) string {
 
 // GetDefaultPipelineBundleRef gets the specific Tekton pipeline bundle reference from a Build pipeline config
 // ConfigMap (in a YAML format) from a URL specified in the parameter
-func GetDefaultPipelineBundleRef(buildPipelineConfigConfigMapYamlURL, name string) (string, error) {
+func GetDefaultPipelineBundleRef(buildPipelineConfigConfigMapYamlURL string, name constants.BuildPipelineType) (string, error) {
 	request, err := http.NewRequest("GET", buildPipelineConfigConfigMapYamlURL, nil)
 	if err != nil {
 		return "", fmt.Errorf("error creating GET request: %s", err)
@@ -95,7 +96,7 @@ func GetDefaultPipelineBundleRef(buildPipelineConfigConfigMapYamlURL, name strin
 
 	for i := range bpc.Pipelines {
 		pipeline := bpc.Pipelines[i]
-		if pipeline.Name == name {
+		if pipeline.Name == string(name) {
 			return pipeline.Bundle, nil
 		}
 	}

--- a/tests/build/build.go
+++ b/tests/build/build.go
@@ -91,7 +91,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build-ser
 
 			gitClient, helloWorldComponentGitSourceURL, helloWorldRepository = setupGitProvider(f, gitProvider)
 			// get the build pipeline bundle annotation
-			buildPipelineAnnotation = build.GetDockerBuildPipelineBundle()
+			buildPipelineAnnotation = build.GetDockerBuildPipelineBundleAnnotation(constants.DockerBuild)
 
 			err = gitClient.CreateBranch(helloWorldRepository, helloWorldComponentDefaultBranch, helloWorldComponentRevision, componentBaseBranchName)
 			Expect(err).ShouldNot(HaveOccurred())
@@ -673,7 +673,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build-ser
 			multiComponentPRBranchName = fmt.Sprintf("%s-%s", "pr-branch", util.GenerateRandomString(6))
 
 			// get the build pipeline bundle annotation
-			buildPipelineAnnotation = build.GetDockerBuildPipelineBundle()
+			buildPipelineAnnotation = build.GetDockerBuildPipelineBundleAnnotation(constants.DockerBuild)
 
 		})
 
@@ -920,7 +920,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build-ser
 
 			// use custom bundle if env defined
 			// get the build pipeline bundle annotation
-			buildPipelineAnnotation = build.GetDockerBuildPipelineBundle()
+			buildPipelineAnnotation = build.GetDockerBuildPipelineBundleAnnotation(constants.DockerBuild)
 
 		})
 
@@ -1093,7 +1093,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build-ser
 			componentName = fmt.Sprintf("%s-%s", "test-annotations", util.GenerateRandomString(6))
 
 			// get the build pipeline bundle annotation
-			buildPipelineAnnotation = build.GetDockerBuildPipelineBundle()
+			buildPipelineAnnotation = build.GetDockerBuildPipelineBundleAnnotation(constants.DockerBuild)
 
 		})
 
@@ -1192,7 +1192,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build-ser
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// get the build pipeline bundle annotation
-			buildPipelineAnnotation = build.GetDockerBuildPipelineBundle()
+			buildPipelineAnnotation = build.GetDockerBuildPipelineBundleAnnotation(constants.DockerBuild)
 		})
 
 		AfterAll(func() {
@@ -1268,7 +1268,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build-ser
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// get the build pipeline bundle annotation
-			buildPipelineAnnotation = build.GetDockerBuildPipelineBundle()
+			buildPipelineAnnotation = build.GetDockerBuildPipelineBundleAnnotation(constants.DockerBuild)
 
 			componentObj := appservice.ComponentSpec{
 				ComponentName: componentName,
@@ -1445,7 +1445,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build-ser
 			Expect(err).NotTo(HaveOccurred())
 
 			// get the build pipeline bundle annotation
-			buildPipelineAnnotation = build.GetDockerBuildPipelineBundle()
+			buildPipelineAnnotation = build.GetDockerBuildPipelineBundleAnnotation(constants.DockerBuild)
 
 			if gitProvider == git.GitLabProvider {
 				gitlabToken := utils.GetEnv(constants.GITLAB_BOT_TOKEN_ENV, "")

--- a/tests/build/build.go
+++ b/tests/build/build.go
@@ -91,7 +91,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build-ser
 
 			gitClient, helloWorldComponentGitSourceURL, helloWorldRepository = setupGitProvider(f, gitProvider)
 			// get the build pipeline bundle annotation
-			buildPipelineAnnotation = build.GetDockerBuildPipelineBundleAnnotation(constants.DockerBuild)
+			buildPipelineAnnotation = build.GetBuildPipelineBundleAnnotation(constants.DockerBuild)
 
 			err = gitClient.CreateBranch(helloWorldRepository, helloWorldComponentDefaultBranch, helloWorldComponentRevision, componentBaseBranchName)
 			Expect(err).ShouldNot(HaveOccurred())
@@ -673,7 +673,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build-ser
 			multiComponentPRBranchName = fmt.Sprintf("%s-%s", "pr-branch", util.GenerateRandomString(6))
 
 			// get the build pipeline bundle annotation
-			buildPipelineAnnotation = build.GetDockerBuildPipelineBundleAnnotation(constants.DockerBuild)
+			buildPipelineAnnotation = build.GetBuildPipelineBundleAnnotation(constants.DockerBuild)
 
 		})
 
@@ -920,7 +920,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build-ser
 
 			// use custom bundle if env defined
 			// get the build pipeline bundle annotation
-			buildPipelineAnnotation = build.GetDockerBuildPipelineBundleAnnotation(constants.DockerBuild)
+			buildPipelineAnnotation = build.GetBuildPipelineBundleAnnotation(constants.DockerBuild)
 
 		})
 
@@ -1093,7 +1093,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build-ser
 			componentName = fmt.Sprintf("%s-%s", "test-annotations", util.GenerateRandomString(6))
 
 			// get the build pipeline bundle annotation
-			buildPipelineAnnotation = build.GetDockerBuildPipelineBundleAnnotation(constants.DockerBuild)
+			buildPipelineAnnotation = build.GetBuildPipelineBundleAnnotation(constants.DockerBuild)
 
 		})
 
@@ -1192,7 +1192,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build-ser
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// get the build pipeline bundle annotation
-			buildPipelineAnnotation = build.GetDockerBuildPipelineBundleAnnotation(constants.DockerBuild)
+			buildPipelineAnnotation = build.GetBuildPipelineBundleAnnotation(constants.DockerBuild)
 		})
 
 		AfterAll(func() {
@@ -1268,7 +1268,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build-ser
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// get the build pipeline bundle annotation
-			buildPipelineAnnotation = build.GetDockerBuildPipelineBundleAnnotation(constants.DockerBuild)
+			buildPipelineAnnotation = build.GetBuildPipelineBundleAnnotation(constants.DockerBuild)
 
 			componentObj := appservice.ComponentSpec{
 				ComponentName: componentName,
@@ -1445,7 +1445,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build-ser
 			Expect(err).NotTo(HaveOccurred())
 
 			// get the build pipeline bundle annotation
-			buildPipelineAnnotation = build.GetDockerBuildPipelineBundleAnnotation(constants.DockerBuild)
+			buildPipelineAnnotation = build.GetBuildPipelineBundleAnnotation(constants.DockerBuild)
 
 			if gitProvider == git.GitLabProvider {
 				gitlabToken := utils.GetEnv(constants.GITLAB_BOT_TOKEN_ENV, "")

--- a/tests/build/build_templates.go
+++ b/tests/build/build_templates.go
@@ -139,7 +139,7 @@ func CreateComponent(commonCtrl *common.SuiteController, ctrl *has.HasController
 	Expect(c.Name).Should(Equal(componentName))
 }
 
-func getDefaultPipeline(pipelineBundleName string) string {
+func getDefaultPipeline(pipelineBundleName constants.BuildPipelineType) string {
 	switch pipelineBundleName {
 	case "docker-build":
 		return os.Getenv(constants.CUSTOM_DOCKER_BUILD_PIPELINE_BUNDLE_ENV)
@@ -199,7 +199,7 @@ var _ = framework.BuildSuiteDescribe("Build templates E2E test", Label("build", 
 				componentName := fmt.Sprintf("test-comp-%s", util.GenerateRandomString(4))
 
 				s := scenario.DeepCopy()
-				s.PipelineBundleNames = []string{pipelineBundleName}
+				s.PipelineBundleNames = []constants.BuildPipelineType{pipelineBundleName}
 
 				components[componentName] = s
 			}
@@ -210,7 +210,7 @@ var _ = framework.BuildSuiteDescribe("Build templates E2E test", Label("build", 
 		symlinkComponentName := fmt.Sprintf("test-symlink-comp-%s", util.GenerateRandomString(4))
 		// Use the other value defined in componentScenarios in build_templates_scenario.go except revision and pipelineBundle
 		symlinkScenario.Revision = gitRepoContainsSymlinkBranchName
-		symlinkScenario.PipelineBundleNames = []string{"docker-build"}
+		symlinkScenario.PipelineBundleNames = []constants.BuildPipelineType{constants.DockerBuild}
 
 		BeforeAll(func() {
 			if os.Getenv("APP_SUFFIX") != "" {
@@ -379,7 +379,7 @@ var _ = framework.BuildSuiteDescribe("Build templates E2E test", Label("build", 
 			})
 
 			It("should push Dockerfile to registry", Label(buildTemplatesTestLabel), func() {
-				if !IsFBCBuildPipeline(pipelineBundleName) {
+				if pipelineBundleName != constants.FbcBuilder {
 					ensureOriginalDockerfileIsPushed(kubeadminClient, pr)
 				}
 			})
@@ -406,7 +406,7 @@ var _ = framework.BuildSuiteDescribe("Build templates E2E test", Label("build", 
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(pr).ToNot(BeNil(), fmt.Sprintf("PipelineRun for the component %s/%s not found", testNamespace, componentName))
 
-				if IsFBCBuildPipeline(pipelineBundleName) {
+				if pipelineBundleName == constants.FbcBuilder {
 					GinkgoWriter.Println("This is FBC build, which does not require source container build.")
 					Skip(fmt.Sprintf("Skiping FBC build %s", pr.GetName()))
 					return
@@ -513,7 +513,7 @@ var _ = framework.BuildSuiteDescribe("Build templates E2E test", Label("build", 
 			It(fmt.Sprintf("should validate tekton taskrun test results for component with Git source URL %s and Pipeline %s", scenario.GitURL, pipelineBundleName), Label(buildTemplatesTestLabel), func() {
 				pr, err := kubeadminClient.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, "")
 				Expect(err).ShouldNot(HaveOccurred())
-				Expect(build.ValidateBuildPipelineTestResults(pr, kubeadminClient.CommonController.KubeRest(), IsFBCBuildPipeline(pipelineBundleName))).To(Succeed())
+				Expect(build.ValidateBuildPipelineTestResults(pr, kubeadminClient.CommonController.KubeRest(), pipelineBundleName == constants.FbcBuilder)).To(Succeed())
 			})
 
 			When(fmt.Sprintf("the container image for component with Git source URL %s is created and pushed to container registry", scenario.GitURL), Label("sbom", "slow"), func() {
@@ -750,7 +750,7 @@ func getImageWithDigest(c *framework.ControllerHub, componentName, applicationNa
 
 // this function takes a bundle and prefetchInput value as inputs and creates a bundle with param hermetic=true
 // and then push the bundle to quay using format: quay.io/<QUAY_E2E_ORGANIZATION>/test-images:<generated_tag>
-func enableHermeticBuildInPipelineBundle(customDockerBuildBundle, pipelineBundleName, prefetchInput string) (string, error) {
+func enableHermeticBuildInPipelineBundle(customDockerBuildBundle string, pipelineBundleName constants.BuildPipelineType, prefetchInput string) (string, error) {
 	var tektonObj runtime.Object
 	var err error
 	var newPipelineYaml []byte
@@ -787,7 +787,7 @@ func enableHermeticBuildInPipelineBundle(customDockerBuildBundle, pipelineBundle
 // this function takes a bundle and additonalTags string slice as inputs
 // and creates a bundle with adding ADDITIONAL_TAGS params in the apply-tags task
 // and then push the bundle to quay using format: quay.io/<QUAY_E2E_ORGANIZATION>/test-images:<generated_tag>
-func applyAdditionalTagsInPipelineBundle(customDockerBuildBundle string, pipelineBundleName string, additionalTags []string) (string, error) {
+func applyAdditionalTagsInPipelineBundle(customDockerBuildBundle string, pipelineBundleName constants.BuildPipelineType, additionalTags []string) (string, error) {
 	var tektonObj runtime.Object
 	var err error
 	var newPipelineYaml []byte

--- a/tests/build/build_templates_scenarios.go
+++ b/tests/build/build_templates_scenarios.go
@@ -12,14 +12,14 @@ type ComponentScenarioSpec struct {
 	Revision            string
 	ContextDir          string
 	DockerFilePath      string
-	PipelineBundleNames []string
+	PipelineBundleNames []constants.BuildPipelineType
 	EnableHermetic      bool
 	PrefetchInput       string
 	CheckAdditionalTags bool
 }
 
 func (s ComponentScenarioSpec) DeepCopy() ComponentScenarioSpec {
-	pipelineBundleNames := make([]string, len(s.PipelineBundleNames))
+	pipelineBundleNames := make([]constants.BuildPipelineType, len(s.PipelineBundleNames))
 	copy(pipelineBundleNames, s.PipelineBundleNames)
 	return ComponentScenarioSpec{
 		GitURL:              s.GitURL,
@@ -39,7 +39,7 @@ var componentScenarios = []ComponentScenarioSpec{
 		Revision:            "47fc22092005aabebce233a9b6eab994a8152bbd",
 		ContextDir:          ".",
 		DockerFilePath:      constants.DockerFilePath,
-		PipelineBundleNames: []string{"docker-build", "docker-build-oci-ta"},
+		PipelineBundleNames: []constants.BuildPipelineType{constants.DockerBuild, constants.DockerBuildOciTA},
 		EnableHermetic:      false,
 		PrefetchInput:       "",
 	},
@@ -48,7 +48,7 @@ var componentScenarios = []ComponentScenarioSpec{
 		Revision:            "bc0452861279eb59da685ba86918938c6c9d8310",
 		ContextDir:          ".",
 		DockerFilePath:      "Dockerfile",
-		PipelineBundleNames: []string{"docker-build-multi-platform-oci-ta"},
+		PipelineBundleNames: []constants.BuildPipelineType{constants.DockerBuildMultiPlatformOciTa},
 		EnableHermetic:      false,
 		PrefetchInput:       "",
 	},
@@ -57,7 +57,7 @@ var componentScenarios = []ComponentScenarioSpec{
 		Revision:            "d8e3195d1ab9dbee1f621e3b0625a589114ac80f",
 		ContextDir:          ".",
 		DockerFilePath:      "Dockerfile",
-		PipelineBundleNames: []string{"docker-build"},
+		PipelineBundleNames: []constants.BuildPipelineType{constants.DockerBuild},
 		EnableHermetic:      true,
 		PrefetchInput:       "gomod",
 	},
@@ -66,7 +66,7 @@ var componentScenarios = []ComponentScenarioSpec{
 		Revision:            "1ecda839ba9ca55070d75c86c26a1bb07d777bba",
 		ContextDir:          ".",
 		DockerFilePath:      "Dockerfile",
-		PipelineBundleNames: []string{"docker-build"},
+		PipelineBundleNames: []constants.BuildPipelineType{constants.DockerBuild},
 		EnableHermetic:      true,
 		PrefetchInput:       "pip",
 		CheckAdditionalTags: true,
@@ -76,7 +76,7 @@ var componentScenarios = []ComponentScenarioSpec{
 		Revision:            "8e374e107fecf03f3c64c528bb53798039661414",
 		ContextDir:          "4.13",
 		DockerFilePath:      "catalog.Dockerfile",
-		PipelineBundleNames: []string{"fbc-builder"},
+		PipelineBundleNames: []constants.BuildPipelineType{constants.FbcBuilder},
 		EnableHermetic:      false,
 		PrefetchInput:       "",
 	},
@@ -85,7 +85,7 @@ var componentScenarios = []ComponentScenarioSpec{
 		Revision:            "34de8caa4952b6214700699e6df4bb53d6f799e6",
 		ContextDir:          ".",
 		DockerFilePath:      "Dockerfile",
-		PipelineBundleNames: []string{"docker-build"},
+		PipelineBundleNames: []constants.BuildPipelineType{constants.DockerBuild},
 		EnableHermetic:      false,
 		PrefetchInput:       "",
 	},
@@ -94,7 +94,7 @@ var componentScenarios = []ComponentScenarioSpec{
 		Revision:            "a4f744581c0768eb84a4345f11d04090bb14bdff",
 		ContextDir:          ".",
 		DockerFilePath:      "Dockerfile",
-		PipelineBundleNames: []string{"docker-build"},
+		PipelineBundleNames: []constants.BuildPipelineType{constants.DockerBuild},
 		EnableHermetic:      false,
 		PrefetchInput:       "",
 	},
@@ -103,7 +103,7 @@ var componentScenarios = []ComponentScenarioSpec{
 		Revision:            "b4584ac47e1df84114a10debf262b6d40f6a95f8",
 		ContextDir:          ".",
 		DockerFilePath:      "Dockerfile",
-		PipelineBundleNames: []string{"docker-build"},
+		PipelineBundleNames: []constants.BuildPipelineType{constants.DockerBuild},
 		EnableHermetic:      false,
 		PrefetchInput:       "",
 	},
@@ -112,7 +112,7 @@ var componentScenarios = []ComponentScenarioSpec{
 		Revision:            "3f5dcac703a35dcb7b29312be72f86221d0f10ee",
 		ContextDir:          ".",
 		DockerFilePath:      "Dockerfile",
-		PipelineBundleNames: []string{"docker-build"},
+		PipelineBundleNames: []constants.BuildPipelineType{constants.DockerBuild},
 		EnableHermetic:      false,
 		PrefetchInput:       "",
 	},
@@ -121,7 +121,7 @@ var componentScenarios = []ComponentScenarioSpec{
 		Revision:            "b6960c7602f21c531e3ead4df1dd1827e6f208f6",
 		ContextDir:          ".",
 		DockerFilePath:      "Dockerfile",
-		PipelineBundleNames: []string{"docker-build"},
+		PipelineBundleNames: []constants.BuildPipelineType{constants.DockerBuild},
 		EnableHermetic:      false,
 		PrefetchInput:       "",
 	},
@@ -132,7 +132,7 @@ func IsDockerBuildGitURL(gitURL string) bool {
 		//check repo name for both the giturls is same
 		if utils.GetRepoName(componentScenario.GitURL) == utils.GetRepoName(gitURL) {
 			for _, pipeline := range componentScenario.PipelineBundleNames {
-				if !strings.HasPrefix(pipeline, "docker-build") {
+				if !strings.HasPrefix(string(pipeline), string(constants.DockerBuild)) {
 					return false
 				}
 			}
@@ -143,7 +143,7 @@ func IsDockerBuildGitURL(gitURL string) bool {
 }
 
 func IsDockerBuildPipeline(pipelineName string) bool {
-	return strings.HasPrefix(pipelineName, "docker-build")
+	return strings.HasPrefix(pipelineName, string(constants.DockerBuild))
 }
 
 func IsFBCBuildPipeline(pipelineName string) bool {

--- a/tests/integration-service/gitlab-integration-reporting.go
+++ b/tests/integration-service/gitlab-integration-reporting.go
@@ -110,7 +110,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Gitlab Status Reporting of In
 					},
 				}
 				// get the build pipeline bundle annotation
-				buildPipelineAnnotation := build.GetDockerBuildPipelineBundle()
+				buildPipelineAnnotation := build.GetDockerBuildPipelineBundleAnnotation(constants.DockerBuild)
 				// Create a component with Git Source URL, a specified git branch
 				component, err = f.AsKubeAdmin.HasController.CreateComponent(componentObj, testNamespace, "", "", applicationName, false, utils.MergeMaps(utils.MergeMaps(constants.ComponentPaCRequestAnnotation, constants.ImageControllerAnnotationRequestPublicRepo), buildPipelineAnnotation))
 				Expect(err).ShouldNot(HaveOccurred())

--- a/tests/integration-service/gitlab-integration-reporting.go
+++ b/tests/integration-service/gitlab-integration-reporting.go
@@ -110,7 +110,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Gitlab Status Reporting of In
 					},
 				}
 				// get the build pipeline bundle annotation
-				buildPipelineAnnotation := build.GetDockerBuildPipelineBundleAnnotation(constants.DockerBuild)
+				buildPipelineAnnotation := build.GetBuildPipelineBundleAnnotation(constants.DockerBuild)
 				// Create a component with Git Source URL, a specified git branch
 				component, err = f.AsKubeAdmin.HasController.CreateComponent(componentObj, testNamespace, "", "", applicationName, false, utils.MergeMaps(utils.MergeMaps(constants.ComponentPaCRequestAnnotation, constants.ImageControllerAnnotationRequestPublicRepo), buildPipelineAnnotation))
 				Expect(err).ShouldNot(HaveOccurred())

--- a/tests/integration-service/integration.go
+++ b/tests/integration-service/integration.go
@@ -442,7 +442,7 @@ func createComponent(f framework.Framework, testNamespace, applicationName, comp
 	Expect(err).ShouldNot(HaveOccurred())
 
 	// get the build pipeline bundle annotation
-	buildPipelineAnnotation := build.GetDockerBuildPipelineBundleAnnotation(constants.DockerBuild)
+	buildPipelineAnnotation := build.GetBuildPipelineBundleAnnotation(constants.DockerBuild)
 
 	componentObj := appstudioApi.ComponentSpec{
 		ComponentName: componentName,
@@ -465,7 +465,7 @@ func createComponent(f framework.Framework, testNamespace, applicationName, comp
 
 func createComponentWithCustomBranch(f framework.Framework, testNamespace, applicationName, componentName, componentRepoURL string, toBranchName string, contextDir string) *appstudioApi.Component {
 	// get the build pipeline bundle annotation
-	buildPipelineAnnotation := build.GetDockerBuildPipelineBundleAnnotation(constants.DockerBuild)
+	buildPipelineAnnotation := build.GetBuildPipelineBundleAnnotation(constants.DockerBuild)
 	dockerFileURL := constants.DockerFilePath
 	if contextDir == "" {
 		dockerFileURL = "Dockerfile"

--- a/tests/integration-service/integration.go
+++ b/tests/integration-service/integration.go
@@ -442,7 +442,7 @@ func createComponent(f framework.Framework, testNamespace, applicationName, comp
 	Expect(err).ShouldNot(HaveOccurred())
 
 	// get the build pipeline bundle annotation
-	buildPipelineAnnotation := build.GetDockerBuildPipelineBundle()
+	buildPipelineAnnotation := build.GetDockerBuildPipelineBundleAnnotation(constants.DockerBuild)
 
 	componentObj := appstudioApi.ComponentSpec{
 		ComponentName: componentName,
@@ -465,7 +465,7 @@ func createComponent(f framework.Framework, testNamespace, applicationName, comp
 
 func createComponentWithCustomBranch(f framework.Framework, testNamespace, applicationName, componentName, componentRepoURL string, toBranchName string, contextDir string) *appstudioApi.Component {
 	// get the build pipeline bundle annotation
-	buildPipelineAnnotation := build.GetDockerBuildPipelineBundle()
+	buildPipelineAnnotation := build.GetDockerBuildPipelineBundleAnnotation(constants.DockerBuild)
 	dockerFileURL := constants.DockerFilePath
 	if contextDir == "" {
 		dockerFileURL = "Dockerfile"

--- a/tests/konflux-demo/config/scenarios.go
+++ b/tests/konflux-demo/config/scenarios.go
@@ -20,7 +20,7 @@ var ApplicationSpecs = []ApplicationSpec{
 			GitSourceContext:           "",
 			GitSourceDefaultBranchName: "main",
 			DockerFilePath:             "Dockerfile",
-
+			BuildPipelineType:          constants.DockerBuildOciTA,
 			IntegrationTestScenario: IntegrationTestScenarioSpec{
 				GitURL:      "https://github.com/konflux-ci/integration-examples.git",
 				GitRevision: "843f455fe87a6d7f68c238f95a8f3eb304e65ac5",
@@ -31,18 +31,19 @@ var ApplicationSpecs = []ApplicationSpec{
 }
 var UpstreamAppSpecs = []ApplicationSpec{
 	{
-		Name:            "Test local instance of konflux-ci",
-		ApplicationName: "konflux-ci-upstream",
+		Name:            "Test local instance of konflux-ci - docker-build-oci-ta pipeline",
+		ApplicationName: "konflux-ci-upstream-docker-build-oci-ta",
 		Skip:            false,
 		ComponentSpec: ComponentSpec{
 			Name:                       "konflux-ci-upstream",
 			GitSourceUrl:               fmt.Sprintf("https://github.com/%s/%s", utils.GetEnv(constants.GITHUB_E2E_ORGANIZATION_ENV, "redhat-appstudio-qe"), "testrepo"),
-			GitSourceRevision:          "ba3f8828d061a539ef774229d2f5c8651d854d7e",
+			GitSourceRevision:          "d451fb5563c40be05e299f74f4ea7dc9221a0280",
 			GitSourceDefaultBranchName: "main",
 			DockerFilePath:             "Dockerfile",
+			BuildPipelineType:          constants.DockerBuildOciTA,
 			IntegrationTestScenario: IntegrationTestScenarioSpec{
 				GitURL:      fmt.Sprintf("https://github.com/%s/%s", utils.GetEnv(constants.GITHUB_E2E_ORGANIZATION_ENV, "redhat-appstudio-qe"), "testrepo"),
-				GitRevision: "ba3f8828d061a539ef774229d2f5c8651d854d7e",
+				GitRevision: "d451fb5563c40be05e299f74f4ea7dc9221a0280",
 				TestPath:    "integration-tests/testrepo-integration.yaml",
 			},
 		},

--- a/tests/konflux-demo/config/types.go
+++ b/tests/konflux-demo/config/types.go
@@ -1,5 +1,7 @@
 package config
 
+import "github.com/konflux-ci/e2e-tests/pkg/constants"
+
 // Set of Applications to create and test in Konflux
 type ApplicationSpec struct {
 	// The test name corresponding to an application
@@ -52,6 +54,9 @@ type ComponentSpec struct {
 
 	// Relative path of the docker file in the repository
 	DockerFilePath string `yaml:"dockerFilePath,omitempty"`
+
+	// Type of build pipeline used for building the component (e.g. docker-build, docker-build-oci-ta etc.)
+	BuildPipelineType constants.BuildPipelineType
 
 	// Set k8s resource specific properties
 	K8sSpec *K8sSpec `yaml:"spec,omitempty"`

--- a/tests/konflux-demo/konflux-demo.go
+++ b/tests/konflux-demo/konflux-demo.go
@@ -123,7 +123,7 @@ var _ = framework.KonfluxDemoSuiteDescribe(Label(devEnvTestLabel), func() {
 				createReleaseConfig(kubeadminClient, managedNamespace, userNamespace, appSpec.ComponentSpec.Name, appSpec.ApplicationName, sharedSecret.Data[".dockerconfigjson"])
 
 				// get the build pipeline bundle annotation
-				buildPipelineAnnotation = build.GetDockerBuildPipelineBundleAnnotation(appSpec.ComponentSpec.BuildPipelineType)
+				buildPipelineAnnotation = build.GetBuildPipelineBundleAnnotation(appSpec.ComponentSpec.BuildPipelineType)
 
 			})
 

--- a/tests/konflux-demo/konflux-demo.go
+++ b/tests/konflux-demo/konflux-demo.go
@@ -123,7 +123,7 @@ var _ = framework.KonfluxDemoSuiteDescribe(Label(devEnvTestLabel), func() {
 				createReleaseConfig(kubeadminClient, managedNamespace, userNamespace, appSpec.ComponentSpec.Name, appSpec.ApplicationName, sharedSecret.Data[".dockerconfigjson"])
 
 				// get the build pipeline bundle annotation
-				buildPipelineAnnotation = build.GetDockerBuildPipelineBundle()
+				buildPipelineAnnotation = build.GetDockerBuildPipelineBundleAnnotation(appSpec.ComponentSpec.BuildPipelineType)
 
 			})
 

--- a/tests/load-tests/pkg/journey/handle_component.go
+++ b/tests/load-tests/pkg/journey/handle_component.go
@@ -1,19 +1,25 @@
 package journey
 
-import "encoding/json"
-import "fmt"
-import "regexp"
-import "strconv"
-import "strings"
-import "time"
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
 
-import logging "github.com/konflux-ci/e2e-tests/tests/load-tests/pkg/logging"
+	logging "github.com/konflux-ci/e2e-tests/tests/load-tests/pkg/logging"
 
-import constants "github.com/konflux-ci/e2e-tests/pkg/constants"
-import framework "github.com/konflux-ci/e2e-tests/pkg/framework"
-import utils "github.com/konflux-ci/e2e-tests/pkg/utils"
-import appstudioApi "github.com/konflux-ci/application-api/api/v1alpha1"
-import pipeline "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	constants "github.com/konflux-ci/e2e-tests/pkg/constants"
+
+	framework "github.com/konflux-ci/e2e-tests/pkg/framework"
+
+	utils "github.com/konflux-ci/e2e-tests/pkg/utils"
+
+	appstudioApi "github.com/konflux-ci/application-api/api/v1alpha1"
+
+	pipeline "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+)
 
 // Parse PR number out of PR url
 func getPRNumberFromPRUrl(prUrl string) (int, error) {
@@ -78,7 +84,7 @@ func getPaCPull(annotations map[string]string) (string, error) {
 
 func createComponent(f *framework.Framework, namespace, name, repoUrl, repoRevision, containerContext, containerFile, buildPipelineSelector, appName string, mintmakerDisabled bool) error {
 	// Prepare annotations to add to component
-	annotationsMap := constants.DefaultDockerBuildPipelineBundle
+	annotationsMap := constants.DefaultDockerBuildPipelineBundleAnnotation
 	if buildPipelineSelector != "" {
 		// Custom build pipeline selector
 		annotationsMap["build.appstudio.openshift.io/pipeline"] = fmt.Sprintf(`{"name": "docker-build", "bundle": "%s"}`, buildPipelineSelector)
@@ -236,7 +242,7 @@ func utilityRepoTemplatingComponentCleanup(f *framework.Framework, namespace, ap
 
 	// Delete pipeline run we do not care about
 	for file, sha := range *shaMap {
-		if ! strings.HasSuffix(file, "-push.yaml") {
+		if !strings.HasSuffix(file, "-push.yaml") {
 			err = listAndDeletePipelineRunsWithTimeout(f, namespace, appName, compName, sha, 1)
 			if err != nil {
 				return fmt.Errorf("Error deleting on-push merged PipelineRun in namespace %s: %v", namespace, err)
@@ -293,11 +299,11 @@ func HandleComponent(ctx *PerComponentContext) error {
 	if ctx.ParentContext.ParentContext.Opts.PipelineRepoTemplating {
 		// Placeholders for template multi-arch PaC pipeline files
 		placeholders := &map[string]string{
-			"NAMESPACE": ctx.ParentContext.ParentContext.Namespace,
-			"QUAY_REPO": ctx.ParentContext.ParentContext.Opts.QuayRepo,
+			"NAMESPACE":   ctx.ParentContext.ParentContext.Namespace,
+			"QUAY_REPO":   ctx.ParentContext.ParentContext.Opts.QuayRepo,
 			"APPLICATION": ctx.ParentContext.ApplicationName,
-			"COMPONENT": ctx.ComponentName,
-			"BRANCH": ctx.ParentContext.ParentContext.Opts.ComponentRepoRevision,
+			"COMPONENT":   ctx.ComponentName,
+			"BRANCH":      ctx.ParentContext.ParentContext.Opts.ComponentRepoRevision,
 		}
 
 		// Skip what we do not care about

--- a/tests/release/releaseLib.go
+++ b/tests/release/releaseLib.go
@@ -96,7 +96,7 @@ func CreateComponentWithNewBranch(f framework.Framework, testNamespace, applicat
 
 	if buildPipelineBundle["build.appstudio.openshift.io/pipeline"] != string(`{"name": "fbc-builder", "bundle": "latest"}`) {
 		// deal with some custom pipeline bundle there
-		buildPipelineAnnotation = build.GetDockerBuildPipelineBundleAnnotation(constants.DockerBuild)
+		buildPipelineAnnotation = build.GetBuildPipelineBundleAnnotation(constants.DockerBuild)
 	} else {
 		buildPipelineAnnotation = constants.DefaultFbcBuilderPipelineBundle
 	}


### PR DESCRIPTION
# Description

* add option to use oci-ta bundle in e2e tests
* update konflux-demo test to test `docker-build-oci-ta` pipeline

## Issue ticket number and link
https://issues.redhat.com/browse/KONFLUX-5837

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
in CI 🤷 

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
