### PR TITLE
feat(STONEINTG-1114): reflect build PLR failure to intg status in git

### DIFF
--- a/pkg/clients/github/pull_request.go
+++ b/pkg/clients/github/pull_request.go
@@ -136,3 +136,69 @@ func (g *Github) GetCheckRunConclusion(checkRunName, repoName, prHeadSha string,
 	}
 	return checkRun.GetConclusion(), nil
 }
+
+// GetCheckRunStatus fetches a specific CheckRun within a given repo
+// by matching the CheckRun's name with the given checkRunName, and
+// then returns the CheckRun status
+func (g *Github) GetCheckRunStatus(checkRunName, repoName, prHeadSha string, prNumber int) (string, error) {
+	var errMsgSuffix = fmt.Sprintf("repository: %s, PR number: %d, PR head SHA: %s, checkRun name: %s\n", repoName, prNumber, prHeadSha, checkRunName)
+
+	var checkRun *github.CheckRun
+	var timeout time.Duration
+	var err error
+
+	timeout = time.Minute * 5
+
+	err = utils.WaitUntil(func() (done bool, err error) {
+		checkRuns, err := g.ListCheckRuns(repoName, prHeadSha)
+		if err != nil {
+			ginkgo.GinkgoWriter.Printf("got error when listing CheckRuns: %+v\n", err)
+			return false, nil
+		}
+		for _, cr := range checkRuns {
+			if strings.Contains(cr.GetName(), checkRunName) {
+				checkRun = cr
+				return true, nil
+			}
+		}
+		return false, nil
+	}, timeout)
+	if err != nil {
+		return "", fmt.Errorf("timed out when waiting for the PaC CheckRun to appear for %s", errMsgSuffix)
+	}
+
+	return checkRun.GetStatus(), nil
+}
+
+// GetCheckRunText fetches a specific CheckRun within a given repo
+// by matching the CheckRun's name with the given checkRunName, and
+// then returns the CheckRun text
+func (g *Github) GetCheckRunText(checkRunName, repoName, prHeadSha string, prNumber int) (string, error) {
+	var errMsgSuffix = fmt.Sprintf("repository: %s, PR number: %d, PR head SHA: %s, checkRun name: %s\n", repoName, prNumber, prHeadSha, checkRunName)
+
+	var checkRun *github.CheckRun
+	var timeout time.Duration
+	var err error
+
+	timeout = time.Minute * 5
+
+	err = utils.WaitUntil(func() (done bool, err error) {
+		checkRuns, err := g.ListCheckRuns(repoName, prHeadSha)
+		if err != nil {
+			ginkgo.GinkgoWriter.Printf("got error when listing CheckRuns: %+v\n", err)
+			return false, nil
+		}
+		for _, cr := range checkRuns {
+			if strings.Contains(cr.GetName(), checkRunName) {
+				checkRun = cr
+				return true, nil
+			}
+		}
+		return false, nil
+	}, timeout)
+	if err != nil {
+		return "", fmt.Errorf("timed out when waiting for the PaC CheckRun to appear for %s", errMsgSuffix)
+	}
+
+	return checkRun.GetOutput().GetText(), nil
+}

--- a/pkg/clients/has/components.go
+++ b/pkg/clients/has/components.go
@@ -68,7 +68,7 @@ func (h *HasController) GetComponentPipelineRun(componentName string, applicatio
 
 // GetComponentPipelineRunWithType returns first pipeline run for a given component labels with pipeline type within label "pipelines.appstudio.openshift.io/type" ("build", "test")
 func (h *HasController) GetComponentPipelineRunWithType(componentName string, applicationName string, namespace, pipelineType string, sha string) (*pipeline.PipelineRun, error) {
-	prs, err := h.GetComponentPipelineRunsWithType(componentName, applicationName, namespace, "", sha)
+	prs, err := h.GetComponentPipelineRunsWithType(componentName, applicationName, namespace, pipelineType, sha)
 	if err != nil {
 		return nil, err
 	} else {

--- a/tests/integration-service/const.go
+++ b/tests/integration-service/const.go
@@ -43,6 +43,7 @@ const (
 	testGroupSnapshotAnnotation              = "test.appstudio.openshift.io/group-test-info"
 	pipelinerunFinalizerByIntegrationService = "test.appstudio.openshift.io/pipelinerun"
 	snapshotRerunLabel                       = "test.appstudio.openshift.io/run"
+	snapshotCreationReport                   = "test.appstudio.openshift.io/snapshot-creation-report"
 
 	chainsSignedAnnotation = "chains.tekton.dev/signed"
 )

--- a/tests/integration-service/status-reporting-to-pullrequest.go
+++ b/tests/integration-service/status-reporting-to-pullrequest.go
@@ -4,17 +4,20 @@ import (
 	"fmt"
 	"os"
 	"time"
+	"strings"
 
 	"github.com/konflux-ci/e2e-tests/pkg/clients/has"
 	"github.com/konflux-ci/e2e-tests/pkg/constants"
 	"github.com/konflux-ci/e2e-tests/pkg/framework"
 	"github.com/konflux-ci/e2e-tests/pkg/utils"
+	"github.com/devfile/library/v2/pkg/util"
 
 	appstudioApi "github.com/konflux-ci/application-api/api/v1alpha1"
 	integrationv1beta2 "github.com/konflux-ci/integration-service/api/v1beta2"
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	pipeline "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ = framework.IntegrationServiceSuiteDescribe("Status Reporting of Integration tests", Label("integration-service", "github-status-reporting"), func() {
@@ -28,9 +31,10 @@ var _ = framework.IntegrationServiceSuiteDescribe("Status Reporting of Integrati
 	var prHeadSha string
 	var snapshot *appstudioApi.Snapshot
 	var component *appstudioApi.Component
-	var pipelineRun, testPipelinerun *pipeline.PipelineRun
+	var pipelineRun, testPipelinerun, failedPipelineRun *tektonv1.PipelineRun
 	var integrationTestScenarioPass, integrationTestScenarioFail *integrationv1beta2.IntegrationTestScenario
 	var applicationName, componentName, componentBaseBranchName, pacBranchName, testNamespace string
+	var labels, annotations map[string]string
 
 	AfterEach(framework.ReportFailure(&f))
 
@@ -55,6 +59,22 @@ var _ = framework.IntegrationServiceSuiteDescribe("Status Reporting of Integrati
 			Expect(err).ShouldNot(HaveOccurred())
 			integrationTestScenarioFail, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenario("", applicationName, testNamespace, gitURL, revision, pathInRepoFail, []string{})
 			Expect(err).ShouldNot(HaveOccurred())
+
+			timeout = time.Second * 600
+			interval = time.Second * 1
+			Eventually(func() error {
+				pipelineRun, err = f.AsKubeAdmin.HasController.GetComponentPipelineRunWithType(componentName, applicationName, testNamespace, "build", "")
+				if err != nil {
+					GinkgoWriter.Printf("Build PipelineRun has not been created yet for the component %s/%s\n", testNamespace, componentName)
+					return err
+				}
+				if !pipelineRun.HasStarted() {
+					return fmt.Errorf("build pipelinerun %s/%s hasn't started yet", pipelineRun.GetNamespace(), pipelineRun.GetName())
+				}
+				return nil
+			}, timeout, constants.PipelineRunPollingInterval).Should(Succeed(), fmt.Sprintf("timed out when waiting for the build PipelineRun to start for the component %s/%s", testNamespace, componentName))
+			labels = pipelineRun.GetLabels()
+			annotations = pipelineRun.GetAnnotations()
 		})
 
 		AfterAll(func() {
@@ -74,29 +94,8 @@ var _ = framework.IntegrationServiceSuiteDescribe("Status Reporting of Integrati
 		})
 
 		When("a new Component with specified custom branch is created", Label("custom-branch"), func() {
-			It("triggers a Build PipelineRun", func() {
-				timeout = time.Second * 600
-				interval = time.Second * 1
-				Eventually(func() error {
-					pipelineRun, err = f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, "")
-					if err != nil {
-						GinkgoWriter.Printf("Build PipelineRun has not been created yet for the component %s/%s\n", testNamespace, componentName)
-						return err
-					}
-					if !pipelineRun.HasStarted() {
-						return fmt.Errorf("build pipelinerun %s/%s hasn't started yet", pipelineRun.GetNamespace(), pipelineRun.GetName())
-					}
-					return nil
-				}, timeout, constants.PipelineRunPollingInterval).Should(Succeed(), fmt.Sprintf("timed out when waiting for the build PipelineRun to start for the component %s/%s", testNamespace, componentName))
-			})
-
 			It("does not contain an annotation with a Snapshot Name", func() {
 				Expect(pipelineRun.Annotations[snapshotAnnotation]).To(Equal(""))
-			})
-
-			It("should lead to build PipelineRun finishing successfully", func() {
-				Expect(f.AsKubeAdmin.HasController.WaitForComponentPipelineToBeFinished(component,
-					"", f.AsKubeAdmin.TektonController, &has.RetryOptions{Retries: 2, Always: true}, pipelineRun)).To(Succeed())
 			})
 
 			It("should have a related PaC init PR created", func() {
@@ -116,16 +115,29 @@ var _ = framework.IntegrationServiceSuiteDescribe("Status Reporting of Integrati
 					}
 					return false
 				}, timeout, interval).Should(BeTrue(), fmt.Sprintf("timed out when waiting for init PaC PR (branch name '%s') to be created in %s repository", pacBranchName, componentRepoNameForStatusReporting))
-
 				// in case the first pipelineRun attempt has failed and was retried, we need to update the value of pipelineRun variable
-				pipelineRun, err = f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, prHeadSha)
+				pipelineRun, err = f.AsKubeAdmin.HasController.GetComponentPipelineRunWithType(componentName, applicationName, testNamespace, "build", prHeadSha)
 				Expect(err).ShouldNot(HaveOccurred())
+			})
+
+			It("initialized integration test status is reported to github", func() {
+				Eventually(func() error {
+					status, err := f.AsKubeAdmin.CommonController.Github.GetCheckRunStatus(integrationTestScenarioPass.Name, componentRepoNameForStatusReporting, prHeadSha, prNumber)
+					if status != "queued" || err != nil {
+						return fmt.Errorf("error occurred when checking pending integration test checkRun %v", err)
+					}
+					return nil
+				}, timeout, constants.PipelineRunPollingInterval).Should(Succeed(), fmt.Sprintf("timed out when waiting for the pending checkrun for the component  %s/%s and integrationTestScenarioPass %s", testNamespace, componentName, integrationTestScenarioPass.Name))
+			})
+
+			It("should lead to build PipelineRun finishing successfully", func() {
+				Expect(f.AsKubeAdmin.HasController.WaitForComponentPipelineToBeFinished(component,
+					"", f.AsKubeAdmin.TektonController, &has.RetryOptions{Retries: 2, Always: true}, pipelineRun)).To(Succeed())
 			})
 
 			It("eventually leads to the build PipelineRun's status reported at Checks tab", func() {
 				expectedCheckRunName := fmt.Sprintf("%s-%s", componentName, "on-pull-request")
-				Expect(f.AsKubeAdmin.CommonController.Github.GetCheckRunConclusion(expectedCheckRunName, componentRepoNameForStatusReporting, prHeadSha, prNumber)).To(Equal(constants.CheckrunConclusionSuccess))
-			})
+				Expect(f.AsKubeAdmin.CommonController.Github.GetCheckRunConclusion(expectedCheckRunName, componentRepoNameForStatusReporting, prHeadSha, prNumber)).To(Equal(constants.CheckrunConclusionSuccess))		})
 		})
 
 		When("the PaC build pipelineRun run succeeded", func() {
@@ -167,7 +179,13 @@ var _ = framework.IntegrationServiceSuiteDescribe("Status Reporting of Integrati
 		When("Integration PipelineRuns completes successfully", func() {
 			It("should lead to Snapshot CR being marked as failed", FlakeAttempts(3), func() {
 				// Snapshot marked as Failed because one of its Integration test failed (as expected)
+				pipelineRun, err = f.AsKubeAdmin.HasController.GetComponentPipelineRunWithType(componentName, applicationName, testNamespace, "build", prHeadSha)
+				Expect(err).Should(Succeed())
 				Eventually(func() bool {
+					pipelineRun, err = f.AsKubeAdmin.HasController.GetComponentPipelineRunWithType(componentName, applicationName, testNamespace, "build", prHeadSha)
+					if err != nil {
+						return false
+					}
 					snapshot, err = f.AsKubeAdmin.IntegrationController.GetSnapshot("", pipelineRun.Name, "", testNamespace)
 					return err == nil && !f.AsKubeAdmin.CommonController.HaveTestsSucceeded(snapshot)
 				}, time.Minute*3, time.Second*5).Should(BeTrue(), fmt.Sprintf("Timed out waiting for Snapshot to be marked as failed %s/%s", snapshot.GetNamespace(), snapshot.GetName()))
@@ -179,6 +197,61 @@ var _ = framework.IntegrationServiceSuiteDescribe("Status Reporting of Integrati
 
 			It("eventually leads to the status reported at Checks tab for the failed Integration PipelineRun", func() {
 				Expect(f.AsKubeAdmin.CommonController.Github.GetCheckRunConclusion(integrationTestScenarioFail.Name, componentRepoNameForStatusReporting, prHeadSha, prNumber)).To(Equal(constants.CheckrunConclusionFailure))
+			})
+		})
+
+		When("build pipelinerun fails", func() {
+			It("build pipelinerun is created but fails", func() {
+				// delete snapshot creation report annotation to create a new build plr manually
+				delete(annotations, snapshotCreationReport)
+				failedPipelineRun = &tektonv1.PipelineRun{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:	"failing-build-plr-"+util.GenerateRandomString(4),
+						Namespace: testNamespace,
+						Labels: labels,
+						Annotations: annotations,
+					},
+					Spec: tektonv1.PipelineRunSpec{
+						PipelineRef: &tektonv1.PipelineRef{
+							ResolverRef: tektonv1.ResolverRef{
+								Resolver: "git",
+								Params: tektonv1.Params{
+									{
+										Name: "url",
+										Value: tektonv1.ParamValue{Type: "string", StringVal: "https://github.com/konflux-ci/integration-examples.git"},
+									},
+									{
+										Name: "revision",
+										Value: tektonv1.ParamValue{Type: "string", StringVal: "main"},
+									},
+									{
+										Name: "pathInRepo",
+										Value: tektonv1.ParamValue{Type: "string", StringVal: "pipelines/integration_resolver_pipeline_pass.yaml"},
+									},
+								},
+							},
+						},
+					},
+				}
+				failedPipelineRun.Labels = labels
+				failedPipelineRun.Annotations = annotations
+				failedPipelineRun, err = f.AsKubeAdmin.TektonController.CreatePipelineRun(failedPipelineRun, testNamespace)
+				Expect(err).Should(Succeed())
+
+				// check PipelineRun status
+				pipelineRunTimeout := int(time.Duration(20) * time.Minute)
+				Expect(f.AsKubeAdmin.TektonController.WatchPipelineRunSucceeded(failedPipelineRun.Name, testNamespace, pipelineRunTimeout)).Should(Succeed())
+			})
+
+			It("build pipelinerun failure is reported to integration test checkRun", func() {
+				Eventually(func() error {
+					text, err := f.AsKubeAdmin.CommonController.Github.GetCheckRunText(integrationTestScenarioPass.Name, componentRepoNameForStatusReporting, prHeadSha, prNumber)
+					if err != nil || !strings.Contains(text, "Failed to create snapshot") {
+						GinkgoWriter.Printf("failed to check expected checkRun text, actual text is %s: \n", err, text)
+						return fmt.Errorf("error occurred when checking failing integration test checkRun text")
+					}
+					return nil
+				}, time.Minute*3, time.Second*5).Should(Succeed(), fmt.Sprintf("timed out when waiting for the failing checkrun for the component  %s/%s and integrationTestScenarioPass %s", testNamespace, componentName, integrationTestScenarioPass.Name))
 			})
 		})
 	})


### PR DESCRIPTION
* reflect build PLR failure to integration test status in git
* Use GetComponentPipelineRunWithType instead of GetComponentPipelineRun to void getting integration test
* Fix GetComponentPipelineRunWithType in has controller

Signed-off-by: Hongwei Liu <hongliu@redhat.com>
# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
