### PR TITLE
fix: always update secret

### DIFF
--- a/pkg/clients/common/secret.go
+++ b/pkg/clients/common/secret.go
@@ -25,6 +25,11 @@ func (s *SuiteController) GetSecret(ns string, name string) (*corev1.Secret, err
 	return s.KubeInterface().CoreV1().Secrets(ns).Get(context.Background(), name, metav1.GetOptions{})
 }
 
+// Update a secret in a specified namespace
+func (s *SuiteController) UpdateSecret(ns string, secret *corev1.Secret) (*corev1.Secret, error) {
+	return s.KubeInterface().CoreV1().Secrets(ns).Update(context.Background(), secret, metav1.UpdateOptions{})
+}
+
 // Deleted a secret in a specified namespace
 func (s *SuiteController) DeleteSecret(ns string, name string) error {
 	return s.KubeInterface().CoreV1().Secrets(ns).Delete(context.Background(), name, metav1.DeleteOptions{})


### PR DESCRIPTION
Creating the Secret only if it didn't exist caused updates in the vault values to be ignored. This bug was discovered in this slack discussion: https://redhat-internal.slack.com/archives/C02CTEB3MMF/p1742898268213099

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [x] I have updated labels (if needed)
