### PR TITLE
feat(KONFLUX-7535): New variable for GH action & PaC templating

### DIFF
--- a/.github/workflows/loadtest.yaml
+++ b/.github/workflows/loadtest.yaml
@@ -41,6 +41,17 @@ jobs:
         STAGING_USERS_8: ${{ secrets.STAGING_USERS_8 }}
       run: ./ci-scripts/merge-json.sh $STAGING_USERS_1 $STAGING_USERS_2 $STAGING_USERS_3 $STAGING_USERS_4 $STAGING_USERS_5 $STAGING_USERS_6 $STAGING_USERS_7 $STAGING_USERS_8
 
+    - name: Select specific users from users.json
+      working-directory: ./tests/load-tests
+      env:
+        SCENARIO: ${{ github.event.inputs.scenario }}
+      run: |
+        export $SCENARIO
+        export USER_START_INDEX=${USER_START_INDEX:-0}
+        export CONCURRENCY=${CONCURRENCY:-1}
+        export USER_END_INDEX=$((USER_START_INDEX + CONCURRENCY))
+        jq --argjson start "$USER_START_INDEX" --argjson end "$USER_END_INDEX" '.[$start:$end]' users.json > tmp_users.json && mv tmp_users.json users.json
+
     - name: Run Load Test
       working-directory: ./tests/load-tests
       env:

--- a/tests/load-tests/pkg/journey/handle_component.go
+++ b/tests/load-tests/pkg/journey/handle_component.go
@@ -304,7 +304,7 @@ func HandleComponent(ctx *PerComponentContext) error {
 			"APPLICATION": ctx.ParentContext.ApplicationName,
 			"COMPONENT":   ctx.ComponentName,
 			"BRANCH":      ctx.ParentContext.ParentContext.Opts.ComponentRepoRevision,
-			"REPOURL":	   ctx.ParentContext.ParentContext.ComponentRepoUrl,
+			"REPOURL":     ctx.ParentContext.ParentContext.ComponentRepoUrl,
 		}
 
 		// Skip what we do not care about

--- a/tests/load-tests/pkg/journey/handle_component.go
+++ b/tests/load-tests/pkg/journey/handle_component.go
@@ -304,6 +304,7 @@ func HandleComponent(ctx *PerComponentContext) error {
 			"APPLICATION": ctx.ParentContext.ApplicationName,
 			"COMPONENT":   ctx.ComponentName,
 			"BRANCH":      ctx.ParentContext.ParentContext.Opts.ComponentRepoRevision,
+			"REPOURL":	   ctx.ParentContext.ParentContext.ComponentRepoUrl,
 		}
 
 		// Skip what we do not care about


### PR DESCRIPTION
# Changes

- Introduce new env variable in Github Action Runner `USER_START_INDEX` to control the starting user to test from users.json
- Add template variable `REPOURL` to replace Git URL for the forked repository.


## Issue ticket number and link
https://issues.redhat.com/browse/KONFLUX-7535

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested in RH01 Konflux Staging with Github Action

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
