### PR TITLE
fix: SA per component test changes

### DIFF
--- a/pkg/utils/build/git.go
+++ b/pkg/utils/build/git.go
@@ -6,7 +6,8 @@ import (
 	"strconv"
 	"strings"
 
-	"k8s.io/api/core/v1"
+	. "github.com/onsi/ginkgo/v2"
+	v1 "k8s.io/api/core/v1"
 
 	"github.com/konflux-ci/e2e-tests/pkg/clients/github"
 	"github.com/konflux-ci/e2e-tests/pkg/constants"
@@ -68,7 +69,7 @@ func CleanupWebhooks(f *framework.Framework, repoName string) error {
 	for _, h := range hooks {
 		hookUrl := h.Config["url"].(string)
 		if strings.Contains(hookUrl, f.ClusterAppDomain) {
-			fmt.Printf("removing webhook URL: %s\n", hookUrl)
+			GinkgoWriter.Printf("removing webhook URL: %s\n", hookUrl)
 			err = f.AsKubeAdmin.CommonController.Github.DeleteWebhook(repoName, h.GetID())
 			if err != nil {
 				return err

--- a/tests/build/build.go
+++ b/tests/build/build.go
@@ -952,7 +952,10 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build-ser
 			}
 
 			// Delete created webhook from GitHub
-			Expect(build.CleanupWebhooks(f, secretLookupGitSourceRepoTwoName)).ShouldNot(HaveOccurred())
+			err = build.CleanupWebhooks(f, secretLookupGitSourceRepoTwoName)
+			if err != nil {
+				Expect(err.Error()).To(ContainSubstring("404 Not Found"))
+			}
 
 		})
 		When("two secrets are created", func() {

--- a/tests/build/build.go
+++ b/tests/build/build.go
@@ -18,7 +18,6 @@ import (
 	pipeline "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	v1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/konflux-ci/e2e-tests/pkg/clients/git"
@@ -27,7 +26,6 @@ import (
 	"github.com/konflux-ci/e2e-tests/pkg/framework"
 	"github.com/konflux-ci/e2e-tests/pkg/utils"
 	"github.com/konflux-ci/e2e-tests/pkg/utils/build"
-	"github.com/konflux-ci/e2e-tests/pkg/utils/tekton"
 )
 
 var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build-service"), func() {
@@ -188,6 +186,10 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build-ser
 					}
 					return nil
 				}, timeout, constants.PipelineRunPollingInterval).Should(Succeed(), fmt.Sprintf("timed out when waiting for the PipelineRun to start for the component %s/%s", customBranchComponentName, testNamespace))
+			})
+			It("build pipeline uses the correct serviceAccount", func() {
+				serviceAccountName := "build-pipeline-" + customDefaultComponentName
+				Expect(plr.Spec.TaskRunTemplate.ServiceAccountName).Should(Equal(serviceAccountName))
 			})
 			It("component build status is set correctly", func() {
 				var buildStatus *controllers.BuildStatus
@@ -1213,133 +1215,6 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build-ser
 				Expect(err).To(HaveOccurred())
 				return strings.Contains(err.Error(), "no pipelinerun found")
 			}, timeout, constants.PipelineRunPollingInterval).Should(BeTrue(), fmt.Sprintf("expected no PipelineRun to be triggered for the component %s in %s namespace", componentName, testNamespace))
-		})
-	})
-
-	Describe("A secret with dummy quay.io credentials is created in the testing namespace", Ordered, func() {
-
-		var applicationName, componentName, testNamespace, pacBranchName, componentBaseBranchName string
-		var timeout time.Duration
-		var err error
-		var pr *pipeline.PipelineRun
-		var buildPipelineAnnotation map[string]string
-		var serviceAccountName, secretName string
-
-		BeforeAll(func() {
-
-			f, err = framework.NewFramework(utils.GetGeneratedNamespace("build-e2e"))
-			Expect(err).NotTo(HaveOccurred())
-			testNamespace = f.UserNamespace
-
-			applicationName = fmt.Sprintf("test-app-%s", util.GenerateRandomString(4))
-
-			_, err = f.AsKubeAdmin.HasController.CreateApplication(applicationName, testNamespace)
-			Expect(err).NotTo(HaveOccurred())
-
-			timeout = time.Minute * 5
-
-			componentName = "build-suite-test-secret-overriding"
-			pacBranchName = constants.PaCPullRequestBranchPrefix + componentName
-			componentBaseBranchName = fmt.Sprintf("base-%s", util.GenerateRandomString(6))
-			err = f.AsKubeAdmin.CommonController.Github.CreateRef(helloWorldComponentGitSourceCloneRepoName, "main", helloWorldComponentCloneRevision, componentBaseBranchName)
-			Expect(err).ShouldNot(HaveOccurred())
-
-			// get the build pipeline bundle annotation
-			buildPipelineAnnotation = build.GetBuildPipelineBundleAnnotation(constants.DockerBuild)
-
-			componentObj := appservice.ComponentSpec{
-				ComponentName: componentName,
-				Application:   applicationName,
-				Source: appservice.ComponentSource{
-					ComponentSourceUnion: appservice.ComponentSourceUnion{
-						GitSource: &appservice.GitSource{
-							URL:           helloWorldComponentGitHubCloneURL,
-							Revision:      componentBaseBranchName,
-							DockerfileURL: constants.DockerFilePath,
-						},
-					},
-				},
-			}
-			_, err = f.AsKubeAdmin.HasController.CreateComponent(componentObj, testNamespace, "", "", applicationName, true, utils.MergeMaps(constants.ComponentPaCRequestAnnotation, buildPipelineAnnotation))
-			Expect(err).NotTo(HaveOccurred())
-
-			serviceAccountName = "build-pipeline-" + componentName
-			secretName = "imagerepository-for-" + applicationName + "-" + componentName + "-image-push"
-			// Unlink the ImageRepository Push Secret from component SA
-			Eventually(func() error {
-				err = f.AsKubeAdmin.CommonController.UnlinkSecretFromServiceAccount(testNamespace, secretName, serviceAccountName, true)
-				if err != nil {
-					GinkgoWriter.Printf("failed to unlink secret %s from service account %s\n", secretName, serviceAccountName)
-					return err
-				}
-				return nil
-			}, 2*time.Minute, 10*time.Second).Should(Succeed(), fmt.Sprintf("timed out when waiting for secret %s to unlink from service account %s", secretName, serviceAccountName))
-
-			// Delete the image repository push secret
-			if err = f.AsKubeAdmin.CommonController.DeleteSecret(testNamespace, secretName); err != nil {
-				Fail(fmt.Sprintf("Failed to delete image repository secret from namespace: %s\n", err))
-			}
-
-			// Create the dummy secret
-			dummySecret := &v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{Name: "dummy-secret"},
-				Type:       v1.SecretTypeDockerConfigJson,
-				Data:       map[string][]byte{".dockerconfigjson": []byte("{\"auths\":{\"quay.io\":{\"username\":\"test\",\"password\":\"test\",\"auth\":\"dGVzdDp0ZXN0\",\"email\":\"\"}}}")},
-			}
-
-			_, err = f.AsKubeAdmin.CommonController.CreateSecret(testNamespace, dummySecret)
-			Expect(err).ToNot(HaveOccurred())
-			err = f.AsKubeAdmin.CommonController.LinkSecretToServiceAccount(testNamespace, dummySecret.Name, serviceAccountName, false)
-			Expect(err).ToNot(HaveOccurred())
-		})
-
-		AfterAll(func() {
-			if !CurrentSpecReport().Failed() {
-				Expect(f.AsKubeAdmin.HasController.DeleteApplication(applicationName, testNamespace, false)).To(Succeed())
-				Expect(f.AsKubeAdmin.HasController.DeleteComponent(componentName, testNamespace, false)).To(Succeed())
-				Expect(f.AsKubeAdmin.TektonController.DeleteAllPipelineRunsInASpecificNamespace(testNamespace)).To(Succeed())
-				Expect(f.SandboxController.DeleteUserSignup(f.UserName)).To(BeTrue())
-			}
-			// Delete new branches created by PaC and a testing branch used as a component's base branch
-			err = f.AsKubeAdmin.CommonController.Github.DeleteRef(helloWorldComponentGitSourceCloneRepoName, pacBranchName)
-			if err != nil {
-				Expect(err.Error()).To(ContainSubstring("Reference does not exist"))
-			}
-			err = f.AsKubeAdmin.CommonController.Github.DeleteRef(helloWorldComponentGitSourceCloneRepoName, componentBaseBranchName)
-			if err != nil {
-				Expect(err.Error()).To(ContainSubstring("Reference does not exist"))
-			}
-			// Delete created webhook from GitHub
-			Expect(build.CleanupWebhooks(f, helloWorldComponentGitSourceCloneRepoName)).ShouldNot(HaveOccurred())
-		})
-
-		It("pipeline should use the component sa", func() {
-			Eventually(func() error {
-				pr, err = f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, "")
-				if err != nil {
-					GinkgoWriter.Printf("PipelineRun has not been created yet for the component %s/%s\n", testNamespace, componentName)
-					return err
-				}
-				if !pr.HasStarted() {
-					return fmt.Errorf("pipelinerun %s/%s hasn't started yet", pr.GetNamespace(), pr.GetName())
-				}
-				return nil
-			}, timeout, constants.PipelineRunPollingInterval).Should(Succeed(), fmt.Sprintf("timed out when waiting for the PipelineRun to start for the component %s/%s", testNamespace, componentName))
-
-			pr, err = f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, "")
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(pr.Spec.TaskRunTemplate.ServiceAccountName).Should(Equal(serviceAccountName))
-		})
-
-		It("should not be possible to push to quay.io repo (PipelineRun should fail)", func() {
-			pipelineRunTimeout := int(time.Duration(20) * time.Minute)
-
-			Expect(f.AsKubeAdmin.TektonController.WatchPipelineRun(pr.Name, testNamespace, pipelineRunTimeout)).To(Succeed())
-			pr, err = f.AsKubeAdmin.TektonController.GetPipelineRun(pr.GetName(), pr.GetNamespace())
-			Expect(err).NotTo(HaveOccurred())
-			tr, err := f.AsKubeAdmin.TektonController.GetTaskRunStatus(f.AsKubeAdmin.CommonController.KubeRest(), pr, constants.BuildTaskRunName)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(tekton.DidTaskRunSucceed(tr)).To(BeFalse())
 		})
 	})
 

--- a/tests/build/const.go
+++ b/tests/build/const.go
@@ -23,9 +23,6 @@ const (
 	helloWorldComponentDefaultBranch     = "default"
 	helloWorldComponentRevision          = "d2d03e69de912e3827c29b4c5b71ffe8bcb5dad8"
 
-	helloWorldComponentGitSourceCloneRepoName = "devfile-sample-hello-world-clone"
-	helloWorldComponentCloneRevision          = "bb1d243a9c030e715ac2a7829973d226816446c3"
-
 	multiComponentGitSourceRepoName = "sample-multi-component"
 	multiComponentDefaultBranch     = "main"
 	multiComponentGitRevision       = "0d1835404efb8ab7bb1ab5b5b82cda1ebfda4b25"
@@ -69,7 +66,6 @@ var (
 	multiComponentGitHubURL            = fmt.Sprintf(githubUrlFormat, githubOrg, multiComponentGitSourceRepoName)
 	multiComponentContextDirs          = []string{"go-component", "python-component"}
 	pythonComponentGitHubURL           = fmt.Sprintf(githubUrlFormat, githubOrg, pythonComponentRepoName)
-	helloWorldComponentGitHubCloneURL  = fmt.Sprintf(githubUrlFormat, githubOrg, helloWorldComponentGitSourceCloneRepoName)
 
 	secretLookupComponentOneGitSourceURL = fmt.Sprintf(githubUrlFormat, noAppOrgName, secretLookupGitSourceRepoOneName)
 	secretLookupComponentTwoGitSourceURL = fmt.Sprintf(githubUrlFormat, noAppOrgName, secretLookupGitSourceRepoTwoName)

--- a/tests/integration-service/const.go
+++ b/tests/integration-service/const.go
@@ -18,6 +18,7 @@ const (
 	targetReleaseNamespace         = "default"
 
 	componentRepoNameForGeneralIntegration    = "konflux-test-integration"
+	componentRepoNameForGroupIntegration      = "konflux-test-integration-clone"
 	componentRepoNameForIntegrationWithEnv    = "konflux-test-integration-with-env"
 	componentRepoNameForStatusReporting       = "konflux-test-integration-status-report"
 	multiComponentRepoNameForGroupSnapshot    = "group-snapshot-multi-component"
@@ -50,6 +51,7 @@ const (
 
 var (
 	componentGitSourceURLForGeneralIntegration    = fmt.Sprintf("https://github.com/%s/%s", utils.GetEnv(constants.GITHUB_E2E_ORGANIZATION_ENV, "redhat-appstudio-qe"), componentRepoNameForGeneralIntegration)
+	componentGitSourceURLForGroupIntegration      = fmt.Sprintf("https://github.com/%s/%s", utils.GetEnv(constants.GITHUB_E2E_ORGANIZATION_ENV, "redhat-appstudio-qe"), componentRepoNameForGroupIntegration)
 	componentGitSourceURLForIntegrationWithEnv    = fmt.Sprintf("https://github.com/%s/%s", utils.GetEnv(constants.GITHUB_E2E_ORGANIZATION_ENV, "redhat-appstudio-qe"), componentRepoNameForIntegrationWithEnv)
 	componentGitSourceURLForStatusReporting       = fmt.Sprintf("https://github.com/%s/%s", utils.GetEnv(constants.GITHUB_E2E_ORGANIZATION_ENV, "redhat-appstudio-qe"), componentRepoNameForStatusReporting)
 	multiComponentGitSourceURLForGroupSnapshotA   = fmt.Sprintf("https://github.com/%s/%s", utils.GetEnv(constants.GITHUB_E2E_ORGANIZATION_ENV, "redhat-appstudio-qe"), multiComponentRepoNameForGroupSnapshot)


### PR DESCRIPTION
# Description

This PR fixes the buid test which used `appstudio-pipeline` SA, replaced it by component SA, also the temporary change of creating `use-new-sa` will be removed when the migration is complete.

commit 5cd18330e8c9f72363748985d62177890205140b addresses two intermittent CI issues in the e2e-tests.

## Issue ticket number and link
https://issues.redhat.com/browse/STONEBLD-3263

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Locally deployed dev cluster

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
