### PR TITLE
feat(STONEINTG-852): add coverage for commit push event

### DIFF
--- a/tests/integration-service/README.md
+++ b/tests/integration-service/README.md
@@ -55,6 +55,13 @@ Checkpoints:
 - Asserting the correct status reporting for the Build PipelineRun in the PR's CheckRun.
 - Verifying that the successful Integration PipelineRun is reported correctly in the CheckRun.
 
+Push Event Tests:
+- Creating a test commit on the main branch.
+- Verifying build pipeline triggers and completes for the push event.
+- Checking integration test results are reported to the commit's status checks:
+  * Success status for passing test scenario
+  * Failure status for failing test scenario
+- Ensuring proper cleanup of test artifacts.
 ### 3. Happy Path Tests within `gitlab-integration-reporting.go`
 Checkpoints:
 - Creating two IntegrationTestScenarios: one expected to pass.
@@ -94,9 +101,14 @@ Checkpoints:
 
 ### 2. Negative Test Cases within `status-reporting-to-pullrequest.go`
 Checkpoints:
+Checkpoints:
 - Creating two IntegrationTestScenarios: one that should fail.
 - Verifying that failed Integration PipelineRuns are reported correctly in the PR's CheckRun.
 - Checking that snapshots are marked as 'failed' if any test fails.
+- For push events:
+  * Verifying failed tests are properly reported in commit status checks
+  * Ensuring snapshots are marked as failed for failing tests
+  * Validating error handling for invalid commits or failed builds
 
 ### 3. Negative Test Cases within `gitlab-integration-reporting.go`
 Checkpoints:


### PR DESCRIPTION
Add suite to cover the push event integration test results  reporting in main 

  - add a new suite in status-reporting-to-pullrequest to cover push event to main
 - Updated the README with the new suite


[STONEINTG-852](https://issues.redhat.com/browse/STONEINTG-852)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
