### PR TITLE
fix(tests): change PaC pull request branch prefix

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -194,7 +194,7 @@ const (
 	DefaultPipelineServiceAccountRoleBinding = "appstudio-pipelines-runner-rolebinding"
 	DefaultPipelineServiceAccountClusterRole = "appstudio-pipelines-runner"
 
-	PaCPullRequestBranchPrefix = "appstudio-"
+	PaCPullRequestBranchPrefix = "konflux-"
 
 	// Expiration for image tags
 	IMAGE_TAG_EXPIRATION_ENV  string = "IMAGE_TAG_EXPIRATION"

--- a/tests/konflux-demo/konflux-demo.go
+++ b/tests/konflux-demo/konflux-demo.go
@@ -105,7 +105,7 @@ var _ = framework.KonfluxDemoSuiteDescribe(Label(devEnvTestLabel), func() {
 
 				// Component config
 				componentName = fmt.Sprintf("%s-%s", appSpec.ComponentSpec.Name, util.GenerateRandomString(4))
-				pacBranchName = fmt.Sprintf("appstudio-%s", componentName)
+				pacBranchName = fmt.Sprintf("%s%s", constants.PaCPullRequestBranchPrefix, componentName)
 				componentRepositoryName = utils.ExtractGitRepositoryNameFromURL(appSpec.ComponentSpec.GitSourceUrl)
 
 				// Secrets config


### PR DESCRIPTION
There is a change in konflux-ci/build-service to reduce confusion when onboarding new components to Konflux (branch prefix from "appstudio" to "konflux").

# Description
New component branch prefix should be changed from "appstudio" to "konflux". This change should fix failing e2e tests in a build-service pipeline.

Related PR in build-services:
https://github.com/konflux-ci/build-service/pull/427

## Issue ticket number and link
https://issues.redhat.com/browse/KONFLUX-7681

# How Has This Been Tested?
I've made the change in my fork and ran the pipeline in build-services.
Tested in this PR: https://github.com/konflux-ci/build-service/pull/427
Link to the pipeline run: https://console.redhat.com/application-pipeline/workspaces/rhtap-build/applications/build-service/pipelineruns/konflux-e2e-build-service-dwpck