### PR TITLE
chore: increase e2e_timeout to 150m

### DIFF
--- a/integration-tests/tasks/konflux-e2e-tests-task.yaml
+++ b/integration-tests/tasks/konflux-e2e-tests-task.yaml
@@ -57,7 +57,7 @@ spec:
       default: "false"
     - name: e2e-timeout
       description: "Timeout value for running E2E script (cluster bootstrap + E2E tests)"
-      default: "90m"
+      default: "150m"
     - name: enable-sl-plugin
       description: "Enable Sealights ginkgo plugin to scan the e2e tests that will report to Sealights."
       default: "false"


### PR DESCRIPTION
It's to avoid  "[ERROR] The process for bootstrapping the cluster and running tests timed out after 90m"

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
