### PR TITLE
feat(RELEASE_1316): enable periodic job for release_service_catalog

### DIFF
--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -119,6 +119,9 @@ func (ci CI) init() error {
 		if err != nil {
 			return err
 		}
+	} else if konfluxCiSpec.KonfluxGitRefs.EventType == "push" && konfluxCiSpec.KonfluxGitRefs.GitRepo == "release-service-catalog" {
+		pr.RemoteName = "konflux-ci"
+		pr.BranchName = "staging"
 	}
 
 	rctx = rulesengine.NewRuleCtx()

--- a/magefiles/rulesengine/repos/release_service_catalog.go
+++ b/magefiles/rulesengine/repos/release_service_catalog.go
@@ -59,7 +59,11 @@ var ReleaseServiceCatalogRepoSetDefaultSettingsRule = rulesengine.Rule{Name: "Ge
 
 		//This is env variable is specified for release service catalog
 		os.Setenv(fmt.Sprintf("%s_CATALOG_URL", rctx.ComponentEnvVarPrefix), fmt.Sprintf("https://github.com/%s/%s", rctx.PrRemoteName, rctx.RepoName))
-		os.Setenv(fmt.Sprintf("%s_CATALOG_REVISION", rctx.ComponentEnvVarPrefix), rctx.PrCommitSha)
+		if rctx.PrRemoteName == "konflux-ci" {
+			os.Setenv(fmt.Sprintf("%s_CATALOG_REVISION", rctx.ComponentEnvVarPrefix), rctx.PrBranchName)
+		} else {
+			os.Setenv(fmt.Sprintf("%s_CATALOG_REVISION", rctx.ComponentEnvVarPrefix), rctx.PrCommitSha)
+		}
 		os.Setenv("DEPLOY_ONLY", "application-api dev-sso enterprise-contract has pipeline-service integration internal-services release")
 
 		if rctx.IsPaired && !strings.Contains(rctx.JobName, "rehearse") {


### PR DESCRIPTION
Release-service-catalog periodic test is triggered by adding label to an "on-push" snapshot, the PR is to add handling for "push" event of release-service-catalog repo. The "staging" branch in `https://github.com/konflux-ci/release-service-catalog` repo is expected to be tested.  
 
## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
