### PR TITLE
fix: Align f.AsKubeAdmin to kubeadminClient in build-template

### DIFF
--- a/tests/build/build_templates.go
+++ b/tests/build/build_templates.go
@@ -653,7 +653,7 @@ var _ = framework.BuildSuiteDescribe("Build templates E2E test", Label("build", 
 							PipelineGitPathInRepo:       pathInRepo,
 							PipelinePolicyConfiguration: "ec-policy",
 						}
-						defaultECP, err = f.AsKubeAdmin.TektonController.GetEnterpriseContractPolicy("default", "enterprise-contract-service")
+						defaultECP, err = kubeadminClient.TektonController.GetEnterpriseContractPolicy("default", "enterprise-contract-service")
 						Expect(err).NotTo(HaveOccurred())
 						//exclude the slsa_source_correlated.source_code_reference_provided because snapshot doesn't get the info of source
 						policy := contract.PolicySpecWithSourceConfig(


### PR DESCRIPTION
# Description

change the f.AsKubeAdmin to kubeadminClient in build-template.go([https://github.com/konflux-ci/e2e-tests/blob/83bce4d17de1c212a8dcba7022376b5732f54fba/tests/build/build_templates.go#L656]).

As https://github.com/konflux-ci/e2e-tests/blob/83bce4d17de1c212a8dcba7022376b5732f54fba/tests/build/build_templates.go#L222-L234 shows kubeadminClient is initialized using  f.AsKubeAdmin. To keep the consistent, kubeadminClient is better.

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
