### PR TITLE
fix(STONEINTG-853): Increasing PLR wait timeout

### DIFF
--- a/tests/integration-service/README.md
+++ b/tests/integration-service/README.md
@@ -63,6 +63,7 @@ Checkpoints:
 - Verifying that the Build PipelineRun is reflected correctly in the MR's CommitStatus.
 - Ensuring the successful Integration PipelineRun is reported as "Pass" in the MR's CommitStatus.
 - Ensuring that the MR notes show the successful status of the integration test.
+- Merge MR and repeat three tests above.
 
 ### 4. Happy Path Tests within `integration-with-env.go`
 Checkpoints:
@@ -104,6 +105,7 @@ Checkpoints:
 - Verifying that the failing Integration PipelineRun is reflected as "Fail" in the MR's CommitStatus.
 - Ensuring that MR notes show the failure status of the integration test.
 - Asserting that no releases are triggered if any integration test fails.
+- Merge MR and repeat three tests above.
 
 ### 4. Negative Test Cases within `integration-with-env.go`
 Checkpoints:

--- a/tests/integration-service/gitlab-integration-reporting.go
+++ b/tests/integration-service/gitlab-integration-reporting.go
@@ -211,7 +211,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Gitlab Status Reporting of In
 			})
 
 			It("validates the Integration test scenario PipelineRun is reported to merge request CommitStatus, and it pass", func() {
-				timeout = time.Second * 300
+				timeout = time.Second * 420
 				interval = time.Second * 1
 
 				Eventually(func() string {
@@ -236,7 +236,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Gitlab Status Reporting of In
 			})
 
 			It("validates the Integration test scenario PipelineRun is reported to merge request CommitStatus, and it fails", func() {
-				timeout = time.Second * 300
+				timeout = time.Second * 420
 				interval = time.Second * 1
 
 				Eventually(func() string {


### PR DESCRIPTION
# Description

As reported, pipelineruns are still running by the time they are expected to be finished, this could be caused by slower gitlab instance on cluster(higher traffic). Increasing timeouts could reduce this issue.
See log below as an example.
https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-redhat-appstudio-infra-deployments-main-appstudio-e2e-tests-periodic/1920630229852753920
Also updating readme.md file with added content from [STONEINTG-853](https://issues.redhat.com//browse/STONEINTG-853)

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
