### PR TITLE
fix: panic when s.Terminated is nil

### DIFF
--- a/pkg/utils/tekton/pipelineruns.go
+++ b/pkg/utils/tekton/pipelineruns.go
@@ -263,7 +263,7 @@ func GetFailedPipelineRunDetails(c crclient.Client, pipelineRun *pipeline.Pipeli
 				d.FailedTaskRunName = taskRun.Name
 				d.PodName = taskRun.Status.PodName
 				for _, s := range taskRun.Status.TaskRunStatusFields.Steps {
-					if s.Terminated.Reason == "Error" || strings.Contains(s.Terminated.Reason, "Failed") {
+					if s.Terminated != nil && (s.Terminated.Reason == "Error" || strings.Contains(s.Terminated.Reason, "Failed")) {
 						d.FailedContainerName = s.Container
 						return d, nil
 					}


### PR DESCRIPTION
It's to fix the panic issue - one [example](https://app-artifact-browser.apps.rosa.konflux-qe.zmr9.p3.openshiftapps.com/release-service-catalog/konflux-e2e-tests-catalog-l468n/e2e-tests.log)


## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
