### PR TITLE
fix: label tenant namespaces

### DIFF
--- a/pkg/clients/common/namespace.go
+++ b/pkg/clients/common/namespace.go
@@ -119,8 +119,11 @@ func (s *SuiteController) CreateTestNamespace(name string) (*corev1.Namespace, e
 			// Create the E2E test namespace if it doesn't exist
 			nsTemplate := corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:   name,
-					Labels: map[string]string{constants.ArgoCDLabelKey: constants.ArgoCDLabelValue},
+					Name: name,
+					Labels: map[string]string{
+						constants.ArgoCDLabelKey: constants.ArgoCDLabelValue,
+						constants.TenantLabelKey: constants.ArgoCDLabelValue,
+					},
 				}}
 			ns, err = s.KubeInterface().CoreV1().Namespaces().Create(context.Background(), &nsTemplate, metav1.CreateOptions{})
 			if err != nil {

--- a/pkg/clients/common/namespace.go
+++ b/pkg/clients/common/namespace.go
@@ -122,7 +122,7 @@ func (s *SuiteController) CreateTestNamespace(name string) (*corev1.Namespace, e
 					Name: name,
 					Labels: map[string]string{
 						constants.ArgoCDLabelKey: constants.ArgoCDLabelValue,
-						constants.TenantLabelKey: constants.ArgoCDLabelValue,
+						constants.TenantLabelKey: constants.TenantLabelValue,
 					},
 				}}
 			ns, err = s.KubeInterface().CoreV1().Namespaces().Create(context.Background(), &nsTemplate, metav1.CreateOptions{})

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -145,6 +145,9 @@ const (
 	// Test namespace's required labels
 	ArgoCDLabelKey   string = "argocd.argoproj.io/managed-by"
 	ArgoCDLabelValue string = "gitops-service-argocd"
+	// Label for marking a namespace as a tenant namespace
+	TenantLabelKey   string = "konflux-ci.dev/type"
+	TenantLabelValue string = "tenant"
 
 	BuildPipelinesConfigMapDefaultNamespace = "build-templates"
 


### PR DESCRIPTION
Some Konflux components use namespace label for finding namespaces which are used by Konflux tenants.

Add the labels for namespaces which are created as part of the e2e-tests.