### PR TITLE
Revert "feat: Enable debug mode for ginkgo tests to detect Sealights issues"

### DIFF
--- a/magefiles/rulesengine/repos/common.go
+++ b/magefiles/rulesengine/repos/common.go
@@ -84,7 +84,6 @@ func ExecuteTestAction(rctx *rulesengine.RuleCtx) error {
 	if err != nil {
 		klog.Error(err)
 	}
-	argsToRun = append(argsToRun, "-vv")
 	argsToRun = append(argsToRun, "./cmd", "--")
 	return sh.RunV("ginkgo", argsToRun...)
 


### PR DESCRIPTION
Reverts konflux-ci/e2e-tests#1548

we needed this just for a temporary debugging, it is no longer needed now