### PR TITLE
ci: disable icm-injection-scripts test in build-tasks-dockerfiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ setup-multi-platform-tests:
 setup-bundle-for-build-tasks-dockerfiles-group-build:
 # whether to build bundle with changes for source-container-build, sbom-utility-scripts, icm-injection-scripts components
 # need to pass true/false as mage target arguments respectively
-	./mage -v SetupBundleForBuildTasksDockerfilesRepo true true true
+	./mage -v SetupBundleForBuildTasksDockerfilesRepo true true false
 
 setup-only-source-build:
 	./mage -v SetupBundleForBuildTasksDockerfilesRepo true false false


### PR DESCRIPTION
icm-injection-scripts were moved from build-tasks-dockerfles to buildah image

(commit ref: buildah commit ref: https://github.com/konflux-ci/buildah-container/commit/36236360f7b794a446828a02108592413e4e9ba4) 

we don't want to run the test in build-tasks-dockerfiles