### PR TITLE
chore: deploy konflux failed with tekton components missing

### DIFF
--- a/magefiles/rulesengine/repos/release_service_catalog.go
+++ b/magefiles/rulesengine/repos/release_service_catalog.go
@@ -71,7 +71,9 @@ var ReleaseServiceCatalogRepoSetDefaultSettingsRule = rulesengine.Rule{Name: "Ge
 		} else {
 			os.Setenv(fmt.Sprintf("%s_CATALOG_REVISION", rctx.ComponentEnvVarPrefix), rctx.PrCommitSha)
 		}
-		os.Setenv("DEPLOY_ONLY", "application-api dev-sso enterprise-contract has pipeline-service integration internal-services release")
+
+		// Failed at https://github.com/redhat-appstudio/infra-deployments/blob/2228e063a7fd8af4a95b24bb13ce7360cdc229f0/hack/preview.sh#L293C16-L293C38
+		//os.Setenv("DEPLOY_ONLY", "application-api dev-sso enterprise-contract has pipeline-service integration internal-services release")
 
 		if rctx.IsPaired && !strings.Contains(rctx.JobName, "rehearse") {
 			os.Setenv(fmt.Sprintf("%s_IMAGE_REPO", rctx.ComponentEnvVarPrefix),


### PR DESCRIPTION
With DEPLOY_ONLY set, konflux deployment often hang at [line](https://github.com/redhat-appstudio/infra-deployments/blob/2228e063a7fd8af4a95b24bb13ce7360cdc229f0/hack/preview.sh#L293C16-L293C38). 

This PR is to avoid the issue.

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
