### PR TITLE
fix: panic in StoreRelease when Release CR is nil

### DIFF
--- a/pkg/clients/release/releases.go
+++ b/pkg/clients/release/releases.go
@@ -106,22 +106,25 @@ func (r *ReleaseController) GetReleases(namespace string) (*releaseApi.ReleaseLi
 
 // StoreRelease stores a given Release as an artifact.
 func (r *ReleaseController) StoreRelease(release *releaseApi.Release) error {
-	artifacts := make(map[string][]byte)
+	if release == nil {
+		return fmt.Errorf("release CR is nil")
+	}
 
+	artifacts := make(map[string][]byte)
 	releaseConditionStatus, err := r.GetReleaseConditionStatusMessages(release.Name, release.Namespace)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get release condition status: %w", err)
 	}
 	artifacts["release-condition-status-"+release.Name+".log"] = []byte(strings.Join(releaseConditionStatus, "\n"))
 
 	releaseYaml, err := yaml.Marshal(release)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to marshal release YAML: %w", err)
 	}
 	artifacts["release-"+release.Name+".yaml"] = releaseYaml
 
 	if err := logs.StoreArtifacts(artifacts); err != nil {
-		return err
+		return fmt.Errorf("failed to store artifacts: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
When Release CR failed to be create, StoreRelease function will panic when it is called in AfterAll part. The PR is to fix the issue by moving the function in other place.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
