### PR TITLE
chore: no test case will be ran when it's expected

### DIFF
--- a/magefiles/rulesengine/scripts/find_release_pipelines_from_pr.sh
+++ b/magefiles/rulesengine/scripts/find_release_pipelines_from_pr.sh
@@ -137,7 +137,7 @@ find_release_pipelines_from_pr() {
   if (( ${#SELECTED_TESTCASES[@]} > 0 )); then
     echo -n "${SELECTED_TESTCASES[*]}"
   else
-    echo -n "happy-path"
+    echo -n "no-test-case"
   fi
    
   cleanup_workspace


### PR DESCRIPTION
Signed-off-by: Jing Qi <jinqi@redhat.com>

When there is no test case related to the PR under test, it returns "no-test-case" instead of "happy-path".

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
