### PR TITLE
fix: GOBIN location

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM quay.io/konflux-ci/tekton-integration-catalog/sealights-go:latest as sealights-agents
 FROM registry.access.redhat.com/ubi9/go-toolset:1.22.9 AS builder
-ENV GOBIN=$GOPATH/bin
+ENV GOBIN=$HOME/bin
 
 USER root
 
@@ -56,7 +56,7 @@ USER root
 
 WORKDIR /konflux-e2e
 
-ENV GOBIN=$GOPATH/bin
+ENV GOBIN=$HOME/bin
 ENV E2E_BIN_PATH=/konflux-e2e/konflux-e2e.test
 
 RUN dnf -y install skopeo


### PR DESCRIPTION
# Description

after openshift-ci started to use this repository's dockerfile for building the e2e-tests image, we ran into permission issues due to $GOBIN directory location in the filesystem

$GOPATH env var is in fact empty, so the $GOBIN then points to `/bin` which openshift-ci SA does not have write permissions to

This PR should fix it