### PR TITLE
fix: e2e test runner permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,8 @@ WORKDIR /konflux-e2e
 ENV GOBIN=$HOME/bin
 ENV E2E_BIN_PATH=/konflux-e2e/konflux-e2e.test
 
+RUN chmod -R 775 $HOME
+
 RUN dnf -y install skopeo
 
 COPY --from=builder /usr/local/bin/jq /usr/local/bin/jq


### PR DESCRIPTION
# Description

follow-up on https://github.com/konflux-ci/e2e-tests/pull/1612

fixes this issue
```
exec: go "install" "-mod=mod" "github.com/onsi/ginkgo/v2/ginkgo"
go: downloading github.com/go-task/slim-sprig/v3 v3.0.0
go: downloading github.com/google/pprof v0.0.0-20240424215950-a892ee059fd6
github.com/onsi/ginkgo/v2/ginkgo: go install github.com/onsi/ginkgo/v2/ginkgo: mkdir /opt/app-root/src/bin/: permission denied
```

tested locally