### PR TITLE
feat(CLOUDDST-27896): added pyxis secrets to fbc release

### DIFF
--- a/tests/release/pipelines/fbc_release.go
+++ b/tests/release/pipelines/fbc_release.go
@@ -387,6 +387,10 @@ func createFBCReleasePlanAdmission(fbcRPAName string, managedFw framework.Framew
 		"sign": map[string]interface{}{
 			"configMapName": "hacbs-signing-pipeline-config-redhatbeta2",
 		},
+		"pyxis": map[string]interface{}{
+			"server": "stage",
+			"secret": "pyxis",
+		},
 	})
 	Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
Secrets are needed for new sign-index-images task
which controls whether signature already exists in pyxis store or not and based on that sign only new containers.

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
