### PR TITLE
fix: use tkn-bundle 0.2 in tkn-bunde test

### DIFF
--- a/tests/build/tkn-bundle.go
+++ b/tests/build/tkn-bundle.go
@@ -41,7 +41,7 @@ var _ = framework.TknBundleSuiteDescribe("tkn bundle task", Label("build-templat
 	var kubeClient *framework.ControllerHub
 	var fwk *framework.Framework
 	var taskName string = "tkn-bundle"
-	var pathInRepo string = fmt.Sprintf("task/%s/0.1/%s.yaml", taskName, taskName)
+	var pathInRepo string = fmt.Sprintf("task/%s/0.2/%s.yaml", taskName, taskName)
 	var pvcName string = "source-pvc"
 	var pvcAccessMode corev1.PersistentVolumeAccessMode = "ReadWriteOnce"
 	var baseTaskRun *pipeline.TaskRun
@@ -107,6 +107,29 @@ var _ = framework.TknBundleSuiteDescribe("tkn bundle task", Label("build-templat
 		}
 		// get a new taskRun on each Entry
 		baseTaskRun = taskRunTemplate(taskName, pvcName, bundleImg, resolverRef)
+		baseTaskRun.Spec.Params	= []pipeline.Param{
+			{
+				Name: "URL",
+				Value: pipeline.ParamValue{
+					Type:      "string",
+					StringVal: gitURL,
+				},
+			},
+			{
+				Name: "REVISION",
+				Value: pipeline.ParamValue{
+					Type:      "string",
+					StringVal: gitRevision,
+				},
+			},
+			{
+				Name: "IMAGE",
+				Value: pipeline.ParamValue{
+					Type:      "string",
+					StringVal: qeBundleRepo,
+				},
+			},
+		}
 	})
 
 	DescribeTable("creates Tekton bundles with different params",


### PR DESCRIPTION
* task/0.1/tkn-bundle.yaml is archived in https://github.com/konflux-ci/build-definitions/pull/2344 which causes tkn-bundle case fail with "task/tkn-bundle/0.1/ tkn-bundle.yaml": file does not exist'" in tkn-bundle test
* user task/0.2/tkn-bundle task

Signed-off-by: Hongwei Liu <hongliu@redhat.com>
# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
