### PR TITLE
fix: match PipelineTask according for test case: Task are trusted

### DIFF
--- a/tests/enterprise-contract/contract.go
+++ b/tests/enterprise-contract/contract.go
@@ -418,7 +418,7 @@ var _ = framework.EnterpriseContractSuiteDescribe("Conforma E2E tests", Label("e
 					reportLog, err := utils.GetContainerLogs(fwk.AsKubeAdmin.CommonController.KubeInterface(), tr.Status.PodName, "step-report-json", namespace)
 					GinkgoWriter.Printf("*** Logs from pod '%s', container '%s':\n----- START -----%s----- END -----\n", tr.Status.PodName, "step-report-json", reportLog)
 					Expect(err).NotTo(HaveOccurred())
-					Expect(reportLog).Should(MatchRegexp(`Pipeline task .* uses an untrusted task reference`))
+					Expect(reportLog).Should(MatchRegexp(`PipelineTask .* uses an untrusted task reference`))
 				})
 
 				It("verifies the release policy: Task references are pinned", func() {


### PR DESCRIPTION
# Description

https://github.com/conforma/policy/commit/f7f1fc327fe120e0713eea19ccb6c8b174d6ef5d changes [‎policy/release/trusted_task/trusted_task.rego](https://github.com/conforma/policy/commit/f7f1fc327fe120e0713eea19ccb6c8b174d6ef5d#diff-6dcf5d6bef661f9aa3b5b8230f6a5a8aa2572da36b38330870bfca1cb803e2fe)
```
error := {
		"msg": sprintf(
			"Pipeline task %q uses an untrusted task reference, %s",
			[tekton.pipeline_task_name(task), _task_info(task)],
		),
		"term": tekton.task_name(task),
	}
```

to 
```
_format_trust_error(task) := error if {
	latest_trusted_ref := tekton.latest_trusted_ref(task)
	untrusted_pipeline_task_name := tekton.pipeline_task_name(task)
	untrusted_task_name := tekton.task_name(task)
	untrusted_task_info := _task_info(task)

	error := {
		"msg": sprintf(
			# regal ignore:line-length
			"PipelineTask %q uses an untrusted task reference: %s. Please upgrade the task version to: %s",
			[untrusted_pipeline_task_name, untrusted_task_info, latest_trusted_ref],
		),
		"term": untrusted_task_name,
```
 tests/enterprise-contract/contract.go the check of Expect(reportLog).Should(MatchRegexp(`Pipeline task .* uses an untrusted task reference`)) should make change accrodingly to reflect https://github.com/conforma/policy/commit/f7f1fc327fe120e0713eea19ccb6c8b174d6ef5d changes [‎policy/release/trusted_task/trusted_task.rego

## Issue ticket number and link
https://issues.redhat.com/browse/EC-1407

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
