### PR TITLE
fix: remove tests for show-sbom Task

### DIFF
--- a/tests/build/build_templates.go
+++ b/tests/build/build_templates.go
@@ -336,44 +336,11 @@ var _ = framework.BuildSuiteDescribe("Build templates E2E test", Label("build", 
 					f.AsKubeAdmin.TektonController, &has.RetryOptions{Retries: pipelineCompletionRetries, Always: true}, nil)).To(Succeed())
 			})
 
-			It(fmt.Sprintf("should ensure SBOM is shown for component with Git source URL %s and Pipeline %s", scenario.GitURL, pipelineBundleName), Label(buildTemplatesTestLabel), func() {
+			It("should push Dockerfile to registry", Label(buildTemplatesTestLabel), func() {
 				pr, err = f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, "")
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(pr).ToNot(BeNil(), fmt.Sprintf("PipelineRun for the component %s/%s not found", testNamespace, componentName))
 
-				logs, err := f.AsKubeAdmin.TektonController.GetTaskRunLogs(pr.GetName(), "show-sbom", testNamespace)
-				Expect(err).ShouldNot(HaveOccurred())
-				Expect(logs).To(HaveLen(1))
-				var sbomTaskLog string
-				for _, log := range logs {
-					sbomTaskLog = log
-				}
-
-				sbom, err := build.UnmarshalSbom([]byte(sbomTaskLog))
-				Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed to parse SBOM from show-sbom task output from %s/%s PipelineRun", pr.GetNamespace(), pr.GetName()))
-
-				switch s := sbom.(type) {
-				case *build.SbomCyclonedx:
-					Expect(s.BomFormat).ToNot(BeEmpty())
-					Expect(s.SpecVersion).ToNot(BeEmpty())
-				case *build.SbomSpdx:
-					Expect(s.SPDXID).ToNot(BeEmpty())
-					Expect(s.SpdxVersion).ToNot(BeEmpty())
-				default:
-					Fail(fmt.Sprintf("unknown SBOM type: %T", s))
-				}
-
-				if !strings.Contains(scenario.GitURL, "from-scratch") {
-					packages := sbom.GetPackages()
-					Expect(packages).ToNot(BeEmpty())
-					for i := range packages {
-						Expect(packages[i].GetName()).ToNot(BeEmpty(), "expecting package name to be non empty, but got empty value")
-						Expect(packages[i].GetPurl()).ToNot(BeEmpty(), fmt.Sprintf("expecting purl to be non empty, but got empty value for pkg: %s", packages[i].GetName()))
-					}
-				}
-			})
-
-			It("should push Dockerfile to registry", Label(buildTemplatesTestLabel), func() {
 				if pipelineBundleName != constants.FbcBuilder {
 					ensureOriginalDockerfileIsPushed(f.AsKubeAdmin, pr)
 				}


### PR DESCRIPTION
# Description

The show-sbom Task is now optional and no longer included within the default build pipelines. This removes the tests that require that Task to be present.

## Issue ticket number and link

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
