### PR TITLE
fix: component image env name

### DIFF
--- a/magefiles/rulesengine/repos/common.go
+++ b/magefiles/rulesengine/repos/common.go
@@ -538,7 +538,7 @@ func SetupMultiPlatformTests() error {
 }
 
 func SetEnvVarsForComponentImageDeployment(rctx *rulesengine.RuleCtx) error {
-	componentImage := os.Getenv("COMPONENT_IMAGE")
+	componentImage := os.Getenv("COMPONENT_CONTAINER_IMAGE")
 
 	tag := rctx.ComponentImageTag
 


### PR DESCRIPTION
# Description

CI is failing [here](https://github.com/konflux-ci/image-controller/pull/215), there is no COMPONENT_IMAGE env now, we are instead setting `COMPONENT_CONTAINER_IMAGE` env 

## Issue ticket number and link
N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
