### PR TITLE
fix: ec-rule used during in build-definitions CI

### DIFF
--- a/pkg/utils/contract/policy.go
+++ b/pkg/utils/contract/policy.go
@@ -1,6 +1,8 @@
 package contract
 
-import ecp "github.com/enterprise-contract/enterprise-contract-controller/api/v1alpha1"
+import (
+	ecp "github.com/enterprise-contract/enterprise-contract-controller/api/v1alpha1"
+)
 
 // PolicySpecWithSourceConfig returns a new EnterpriseContractPolicySpec which is a deep copy of
 // the provided spec with each source config updated.
@@ -9,6 +11,21 @@ func PolicySpecWithSourceConfig(spec ecp.EnterpriseContractPolicySpec, sourceCon
 	for _, s := range spec.Sources {
 		source := s.DeepCopy()
 		source.Config = sourceConfig.DeepCopy()
+		sources = append(sources, *source)
+	}
+
+	newSpec := *spec.DeepCopy()
+	newSpec.Sources = sources
+	return newSpec
+}
+
+// PolicySpecWithSource returns a new EnterpriseContractPolicySpec which is a deep copy of the provided spec with each source updated.
+func PolicySpecWithSource(spec ecp.EnterpriseContractPolicySpec, ecpSource ecp.Source) ecp.EnterpriseContractPolicySpec {
+	var sources []ecp.Source
+	for _, s := range spec.Sources {
+		source := s.DeepCopy()
+		source.Config = ecpSource.Config
+		source.RuleData = ecpSource.RuleData
 		sources = append(sources, *source)
 	}
 


### PR DESCRIPTION
# Description

This PR adds `@redhat` ec rule collection with some exceptions to be used while running tests in build-definitions CI

## Issue ticket number and link
https://issues.redhat.com/browse/STONEBLD-3188

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

In build-definitions CI by creating custom image

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
