### PR TITLE
feat: allow konflux-ci user to access test ns

### DIFF
--- a/pkg/clients/tekton/rekor_hosts.go
+++ b/pkg/clients/tekton/rekor_hosts.go
@@ -12,7 +12,7 @@ import (
 func (t *TektonController) GetRekorHost() (rekorHost string, err error) {
 	var tektonChainsNs = constants.TEKTON_CHAINS_NS
 
-	if os.Getenv("TEST_ENVIRONMENT") == "upstream" {
+	if os.Getenv(constants.TEST_ENVIRONMENT_ENV) == constants.UpstreamTestEnvironment {
 		tektonChainsNs = "tekton-pipelines"
 	}
 	api := t.KubeInterface().CoreV1().ConfigMaps(tektonChainsNs)

--- a/pkg/clients/tekton/tekton_chains_public_keys.go
+++ b/pkg/clients/tekton/tekton_chains_public_keys.go
@@ -12,7 +12,7 @@ import (
 // GetTektonChainsPublicKey returns a TektonChains public key.
 func (t *TektonController) GetTektonChainsPublicKey() ([]byte, error) {
 	namespace := constants.TEKTON_CHAINS_NS
-	if os.Getenv("TEST_ENVIRONMENT") == "upstream" {
+	if os.Getenv(constants.TEST_ENVIRONMENT_ENV) == constants.UpstreamTestEnvironment {
 		namespace = "tekton-pipelines"
 	}
 	secretName := "public-key"

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -142,6 +142,17 @@ const (
 	RELEASE_CATALOG_DEFAULT_URL      = "https://github.com/konflux-ci/release-service-catalog.git"
 	RELEASE_CATALOG_DEFAULT_REVISION = "staging"
 
+	// We are running tests against 2 types of test environments:
+	//
+	// * downstream - Konflux deployed from infra-deployments repo, typically on OCP or ROSA
+	//
+	// * upstream - Konflux deployed from konflux-ci repo, typically running on Kind cluster
+	//
+	// This env var is meant to be used in the framework to apply a different framework init
+	// or a test configuration based on the provided value
+	// By default it should use "downstream"
+	TEST_ENVIRONMENT_ENV = "TEST_ENVIRONMENT"
+
 	// Test namespace's required labels
 	ArgoCDLabelKey   string = "argocd.argoproj.io/managed-by"
 	ArgoCDLabelValue string = "gitops-service-argocd"
@@ -252,6 +263,14 @@ const (
 	// Test environments
 	DownstreamTestEnvironment string = "downstream"
 	UpstreamTestEnvironment   string = "upstream"
+
+	// A cluster role used to be bound to a user that has admin access to all Konflux resources in a specific namespace
+	// https://github.com/konflux-ci/konflux-ci/blob/2772e3b648ce1c1ae05f31e77732063c4103de09/konflux-ci/rbac/core/konflux-admin-user-actions.yaml
+	KonfluxAdminUserActionsClusterRoleName = "konflux-admin-user-actions"
+	// Default role binding name
+	DefaultKonfluxAdminRoleBindingName = "user2-konflux-admin"
+	// Default user name available after deploying upstream version of konflux-ci
+	DefaultKonfluxCIUserName = "user2@konflux.dev"
 )
 
 var (

--- a/pkg/framework/framework.go
+++ b/pkg/framework/framework.go
@@ -129,7 +129,7 @@ func newFrameworkWithTimeout(userName string, timeout time.Duration, options ...
 
 		}
 
-		if os.Getenv("TEST_ENVIRONMENT") == "upstream" {
+		if os.Getenv(constants.TEST_ENVIRONMENT_ENV) == constants.UpstreamTestEnvironment {
 			// Get cluster domain (IP address) from kubeconfig
 			kubeconfig, err := config.GetConfig()
 			if err != nil {

--- a/tests/enterprise-contract/contract.go
+++ b/tests/enterprise-contract/contract.go
@@ -36,7 +36,7 @@ var _ = framework.EnterpriseContractSuiteDescribe("Conforma E2E tests", Label("e
 		Expect(fwk.UserNamespace).NotTo(BeEmpty(), "failed to create sandbox user")
 		namespace = fwk.UserNamespace
 
-		if os.Getenv("TEST_ENVIRONMENT") == "upstream" {
+		if os.Getenv(constants.TEST_ENVIRONMENT_ENV) == constants.UpstreamTestEnvironment {
 			tektonChainsNs = "tekton-pipelines"
 		}
 	})


### PR DESCRIPTION
# Description

During test namespace creation, create also a rolebinding that allows default konflux-ci user to access test namespaces via konflux-ui:

<img width="1501" height="320" alt="Screenshot 2025-08-19 at 18 42 08" src="https://github.com/user-attachments/assets/b32a9baf-f46d-496e-8df0-b9d112a432e2" />

This could be helpful when debugging tests, because konflux-ci doesn't offer kubernetest dashboard (UI) by default

## Issue ticket number and link
https://issues.redhat.com/browse/KFLUXDP-377

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

locally after running an integration-service test (see the screenshot above)

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
