### PR TITLE
fix: configure ginkgo procs based on env var

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,6 +52,7 @@ require (
 	golang.org/x/tools v0.23.0
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.29.7
+	k8s.io/apiextensions-apiserver v0.29.7
 	k8s.io/apimachinery v0.29.7
 	k8s.io/cli-runtime v0.29.4
 	k8s.io/client-go v1.5.2
@@ -293,7 +294,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/apiextensions-apiserver v0.29.7 // indirect
 	k8s.io/apiserver v0.29.4 // indirect
 	k8s.io/component-base v0.29.7 // indirect
 	k8s.io/component-helpers v0.29.4 // indirect

--- a/magefiles/rulesengine/repos/common.go
+++ b/magefiles/rulesengine/repos/common.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -42,7 +43,12 @@ func ExecuteTestAction(rctx *rulesengine.RuleCtx) error {
 		rctx.Parallel = false
 	} else {
 		// Set the number of parallel test processes
-		rctx.CLIConfig.Procs = 20
+		procs := utils.GetEnv("GINKGO_PROCS", "20")
+		procsInt, err := strconv.Atoi(procs)
+		if err != nil {
+			return fmt.Errorf("can't convert %q to an int to configure the amount of ginkgo procs", procs)
+		}
+		rctx.CLIConfig.Procs = procsInt
 		rctx.NoColor = true
 	}
 


### PR DESCRIPTION
# Description

parse the amount of ginkgo procs passed to e2e via [this env var](https://github.com/konflux-ci/e2e-tests/blob/fb1e7653b7f550e005161d46c71bfc5476d48010/integration-tests/tasks/konflux-e2e-tests/0.2/konflux-e2e-tests.yaml#L136)


## Issue ticket number and link
N/A

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
in [this PR](https://github.com/konflux-ci/e2e-tests/pull/1656/files)

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
