### PR TITLE
fix: integration-service e2e case improvement

### DIFF
--- a/pkg/clients/has/components.go
+++ b/pkg/clients/has/components.go
@@ -528,7 +528,7 @@ func (h *HasController) CheckImageRepositoryExists(namespace, componentName stri
 			return false, fmt.Errorf("more than one image repositories found for component %s", componentName)
 		}
 		if imageRepositoryList.Items[0].Status.State != "ready" {
-			GinkgoWriter.Printf("Image repository for component %s in namespace %s do not have right state ('%s' != 'ready') yet.\n", componentName, namespace, imageRepositoryList.Items[0].Status.State)
+			GinkgoWriter.Printf("Image repository for component %s in namespace %s do not have right state ('%s' != 'ready') yet but it has status %v.\n", componentName, namespace, imageRepositoryList.Items[0].Status.State, imageRepositoryList.Items[0].Status)
 			return false, nil
 		}
 		return true, nil

--- a/pkg/clients/integration/pipelineruns.go
+++ b/pkg/clients/integration/pipelineruns.go
@@ -272,6 +272,8 @@ func (i *IntegrationController) WaitForBuildPipelineRunToGetAnnotated(testNamesp
 // It exposes the error message from the failed task to the end user when the pipelineRun failed.
 func (i *IntegrationController) WaitForBuildPipelineToBeFinished(testNamespace, applicationName, componentName, sha string) (error, string) {
 	var logs string
+	// sllep 5 mins before starting to get build PLR's final state since one build PLR need at 6 mins to reduce the useless calls
+	time.Sleep(5 * time.Minute)
 	return wait.PollUntilContextTimeout(context.Background(), constants.PipelineRunPollingInterval, 30*time.Minute, true, func(ctx context.Context) (done bool, err error) {
 		pipelineRun, err := i.GetBuildPipelineRun(componentName, applicationName, testNamespace, false, sha)
 		if err != nil {

--- a/tests/integration-service/group-snapshots-tests.go
+++ b/tests/integration-service/group-snapshots-tests.go
@@ -26,7 +26,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Creation of group snapshots f
 	var err error
 
 	var prNumber int
-	var timeout, interval time.Duration
+	var timeout time.Duration
 	var prHeadSha, mergeResultSha, mergeMultiResultSha, secondFileSha string
 	var pacBranchNames []string
 	var componentNames []string
@@ -132,7 +132,6 @@ var _ = framework.IntegrationServiceSuiteDescribe("Creation of group snapshots f
 
 			It(fmt.Sprintf("triggers a Build PipelineRun for componentA %s", multiComponentContextDirs[0]), func() {
 				timeout = time.Second * 600
-				interval = time.Second * 1
 				Eventually(func() error {
 					pipelineRun, err = f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentA.Name, applicationName, testNamespace, "")
 					if err != nil {
@@ -157,7 +156,6 @@ var _ = framework.IntegrationServiceSuiteDescribe("Creation of group snapshots f
 
 			It(fmt.Sprintf("should lead to a PaC PR creation for componentA %s", multiComponentContextDirs[0]), func() {
 				timeout = time.Second * 300
-				interval = time.Second * 1
 
 				Eventually(func() bool {
 					prs, err := f.AsKubeAdmin.CommonController.Github.ListPullRequests(multiComponentRepoNameForGroupSnapshot)
@@ -171,7 +169,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Creation of group snapshots f
 						}
 					}
 					return false
-				}, timeout, interval).Should(BeTrue(), fmt.Sprintf("timed out when waiting for init PaC PR (branch name '%s') to be created in %s repository", pacBranchNames[0], multiComponentRepoNameForGroupSnapshot))
+				}, timeout, constants.PipelineRunPollingInterval).Should(BeTrue(), fmt.Sprintf("timed out when waiting for init PaC PR (branch name '%s') to be created in %s repository", pacBranchNames[0], multiComponentRepoNameForGroupSnapshot))
 
 				// in case the first pipelineRun attempt has failed and was retried, we need to update the value of pipelineRun variable
 				pipelineRun, err = f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentA.Name, applicationName, testNamespace, prHeadSha)
@@ -199,7 +197,6 @@ var _ = framework.IntegrationServiceSuiteDescribe("Creation of group snapshots f
 
 			It("integration pipeline should end up with success", func() {
 				timeout = time.Second * 600
-				interval = time.Second * 1
 				Eventually(func() error {
 					integrationPipelineRun, err := f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentA.Name, applicationName, testNamespace, "")
 					if err != nil {
@@ -244,7 +241,6 @@ var _ = framework.IntegrationServiceSuiteDescribe("Creation of group snapshots f
 
 			It(fmt.Sprintf("triggers a Build PipelineRun for component %s", multiComponentContextDirs[1]), func() {
 				timeout = time.Second * 600
-				interval = time.Second * 1
 				Eventually(func() error {
 					pipelineRun, err = f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentB.Name, applicationName, testNamespace, "")
 					if err != nil {
@@ -269,7 +265,6 @@ var _ = framework.IntegrationServiceSuiteDescribe("Creation of group snapshots f
 
 			It(fmt.Sprintf("should lead to a PaC PR creation for component %s", multiComponentContextDirs[1]), func() {
 				timeout = time.Second * 300
-				interval = time.Second * 1
 
 				Eventually(func() bool {
 					prs, err := f.AsKubeAdmin.CommonController.Github.ListPullRequests(multiComponentRepoNameForGroupSnapshot)
@@ -283,7 +278,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Creation of group snapshots f
 						}
 					}
 					return false
-				}, timeout, interval).Should(BeTrue(), fmt.Sprintf("timed out when waiting for init PaC PR (branch name '%s') to be created in %s repository", pacBranchNames[1], multiComponentRepoNameForGroupSnapshot))
+				}, timeout, constants.PipelineRunPollingInterval).Should(BeTrue(), fmt.Sprintf("timed out when waiting for init PaC PR (branch name '%s') to be created in %s repository", pacBranchNames[1], multiComponentRepoNameForGroupSnapshot))
 
 				// in case the first pipelineRun attempt has failed and was retried, we need to update the value of pipelineRun variable
 				pipelineRun, err = f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentB.Name, applicationName, testNamespace, prHeadSha)
@@ -311,7 +306,6 @@ var _ = framework.IntegrationServiceSuiteDescribe("Creation of group snapshots f
 
 			It("integration pipeline should end up with success", func() {
 				timeout = time.Second * 600
-				interval = time.Second * 1
 				Eventually(func() error {
 					integrationPipelineRun, err := f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentB.Name, applicationName, testNamespace, "")
 					if err != nil {
@@ -356,7 +350,6 @@ var _ = framework.IntegrationServiceSuiteDescribe("Creation of group snapshots f
 
 			It(fmt.Sprintf("triggers a Build PipelineRun for componentC %s", componentRepoNameForGroupIntegration), func() {
 				timeout = time.Second * 900
-				interval = time.Second * 1
 				Eventually(func() error {
 					pipelineRun, err = f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentC.Name, applicationName, testNamespace, "")
 					if err != nil {
@@ -381,7 +374,6 @@ var _ = framework.IntegrationServiceSuiteDescribe("Creation of group snapshots f
 
 			It(fmt.Sprintf("should lead to a PaC PR creation for componentC %s", componentRepoNameForGroupIntegration), func() {
 				timeout = time.Second * 300
-				interval = time.Second * 1
 
 				Eventually(func() bool {
 					prs, err := f.AsKubeAdmin.CommonController.Github.ListPullRequests(componentRepoNameForGroupIntegration)
@@ -395,7 +387,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Creation of group snapshots f
 						}
 					}
 					return false
-				}, timeout, interval).Should(BeTrue(), fmt.Sprintf("timed out when waiting for init PaC PR (branch name '%s') to be created in %s repository", pacBranchNames[2], componentRepoNameForGroupIntegration))
+				}, timeout, constants.PipelineRunPollingInterval).Should(BeTrue(), fmt.Sprintf("timed out when waiting for init PaC PR (branch name '%s') to be created in %s repository", pacBranchNames[2], componentRepoNameForGroupIntegration))
 
 				// in case the first pipelineRun attempt has failed and was retried, we need to update the value of pipelineRun variable
 				pipelineRun, err = f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentC.Name, applicationName, testNamespace, prHeadSha)
@@ -423,7 +415,6 @@ var _ = framework.IntegrationServiceSuiteDescribe("Creation of group snapshots f
 
 			It("integration pipeline should end up with success", func() {
 				timeout = time.Second * 600
-				interval = time.Second * 1
 				Eventually(func() error {
 					integrationPipelineRun, err := f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentC.Name, applicationName, testNamespace, "")
 					if err != nil {


### PR DESCRIPTION
* Update resolution e2e case steps
* Reduce the calls: 
   add sleep before getting build PLR state since a build PLR need at least 6+ mins to complete
   enlarge the interval when getting build/integration PLR, especially for integration resolution e2e case when getting final integration test

[STONEINTG-1332](https://issues.redhat.com/browse/STONEINTG-1332)

Signed-off-by: Hongwei Liu <hongliu@redhat.com>
# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
