### PR TITLE
fix: enable tekton results test for downstream

### DIFF
--- a/magefiles/rulesengine/repos/infra_deployments.go
+++ b/magefiles/rulesengine/repos/infra_deployments.go
@@ -19,6 +19,7 @@ var InfraDeploymentsDefaultRule = rulesengine.Rule{Name: "Infra Deployments Defa
 		&InfraDeploymentsReleaseServiceComponentChangeRule,
 		&InfraDeploymentsEnterpriseControllerComponentChangeRule,
 		&InfraDeploymentsJVMComponentChangeRule,
+		&InfraDeploymentsPipelineServiceComponentChangeRule,
 		rulesengine.ConditionFunc(CheckNoFilesChanged)},
 
 	Actions: []rulesengine.Action{rulesengine.ActionFunc(ExecuteInfraDeploymentsDefaultTestAction)}}
@@ -40,6 +41,7 @@ var InfraDeploymentsComponentsRule = rulesengine.Rule{Name: "Infra-deployments P
 		&InfraDeploymentsBuildServiceComponentChangeRule,
 		&InfraDeploymentsReleaseServiceComponentChangeRule,
 		&InfraDeploymentsEnterpriseControllerComponentChangeRule,
+		&InfraDeploymentsPipelineServiceComponentChangeRule,
 		&InfraDeploymentsJVMComponentChangeRule},
 	Actions: []rulesengine.Action{rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
 		// Adding "konflux" to the label filter when component is updated
@@ -127,6 +129,19 @@ var InfraDeploymentsBuildServiceComponentChangeRule = rulesengine.Rule{Name: "In
 	Actions: []rulesengine.Action{
 		rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
 			AddLabelToLabelFilter(rctx, "build-service")
+			return nil
+		}),
+	},
+}
+
+var InfraDeploymentsPipelineServiceComponentChangeRule = rulesengine.Rule{Name: "Infra-deployments PR Pipeline Service component File Change Rule",
+	Description: "Map pipeline service tests files when files in pipeline-service are changed",
+	Condition: rulesengine.ConditionFunc(func(rctx *rulesengine.RuleCtx) (bool, error) {
+		return len(rctx.DiffFiles.FilterByDirGlob("components/pipeline-service/**/*")) != 0, nil
+	}),
+	Actions: []rulesengine.Action{
+		rulesengine.ActionFunc(func(rctx *rulesengine.RuleCtx) error {
+			AddLabelToLabelFilter(rctx, "pipeline-service")
 			return nil
 		}),
 	},


### PR DESCRIPTION
# Description

This test was disabled [here](https://github.com/konflux-ci/e2e-tests/pull/1642/files#diff-420007369ea2e1a8133dc8c9a8fc032202afa2a4fc08e7f8753701ae4ab87333R468) after toolchain was removed from e2e-tests

We had to change the way this test works, it now uses the tekton results API directly instead of toolchain API

This PR also enabled this test to run on pipeline-service updates in infra-deployments

## Issue ticket number and link
[KFLUXDP-373](https://issues.redhat.com//browse/KFLUXDP-373)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

```
ginkgo build ./cmd && ginkgo -v --label-filter "pipeline-service" ./cmd/cmd.test
```

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
