### PR TITLE
fix(STONEINTG-1332-1): integration e2e case improvement

### DIFF
--- a/tests/integration-service/const.go
+++ b/tests/integration-service/const.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/konflux-ci/e2e-tests/pkg/constants"
 	"github.com/konflux-ci/e2e-tests/pkg/utils"
@@ -49,6 +50,10 @@ const (
 	snapshotCreationReport                   = "test.appstudio.openshift.io/snapshot-creation-report"
 
 	chainsSignedAnnotation = "chains.tekton.dev/signed"
+
+	shortTimeout = time.Duration(10 * time.Minute)
+	longTimeout = time.Duration(15 * time.Minute)
+	superLongTimeout = time.Duration(20 * time.Minute)
 )
 
 var (

--- a/tests/integration-service/integration.go
+++ b/tests/integration-service/integration.go
@@ -105,9 +105,6 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 			})
 
 			It("should have a related PaC init PR created", func() {
-				timeout = time.Second * 300
-				interval = time.Second * 1
-
 				Eventually(func() bool {
 					prs, err := f.AsKubeAdmin.CommonController.Github.ListPullRequests(componentRepoNameForGeneralIntegration)
 					Expect(err).ShouldNot(HaveOccurred())
@@ -119,7 +116,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 						}
 					}
 					return false
-				}, timeout, interval).Should(BeTrue(), fmt.Sprintf("timed out when waiting for init PaC PR (branch name '%s') to be created in %s repository", pacBranchName, componentRepoNameForStatusReporting))
+				}, shortTimeout, constants.PipelineRunPollingInterval).Should(BeTrue(), fmt.Sprintf("timed out when waiting for init PaC PR (branch name '%s') to be created in %s repository", pacBranchName, componentRepoNameForStatusReporting))
 
 				// in case the first pipelineRun attempt has failed and was retried, we need to update the value of pipelineRun variable
 				pipelineRun, err = f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, prHeadSha)
@@ -159,8 +156,6 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 			})
 
 			It("checks if the passed status of integration test is reported in the Snapshot", func() {
-				timeout = time.Second * 240
-				interval = time.Second * 5
 				Eventually(func() error {
 					snapshot, err = f.AsKubeAdmin.IntegrationController.GetSnapshot(snapshot.Name, "", "", testNamespace)
 					Expect(err).ShouldNot(HaveOccurred())
@@ -172,7 +167,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 						return fmt.Errorf("test status for scenario: %s, doesn't have expected value %s, within the snapshot: %s", integrationTestScenario.Name, intgteststat.IntegrationTestStatusTestPassed, snapshot.Name)
 					}
 					return nil
-				}, timeout, interval).Should(Succeed())
+				}, longTimeout, constants.PipelineRunPollingInterval).Should(Succeed())
 			})
 
 			It("checks if the skipped integration test is absent from the Snapshot's status annotation", func() {
@@ -208,8 +203,6 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 
 		When("An snapshot of push event is created", func() {
 			It("checks if the global candidate is updated after push event", func() {
-				timeout = time.Second * 600
-				interval = time.Second * 10
 				Eventually(func() error {
 					snapshotPush, err = f.AsKubeAdmin.IntegrationController.GetSnapshot(snapshotPush.Name, "", "", testNamespace)
 					Expect(err).ShouldNot(HaveOccurred())
@@ -219,7 +212,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 					Expect(component.Spec.ContainerImage).ToNot(Equal(originalComponent.Spec.ContainerImage))
 					return nil
 
-				}, timeout, interval).Should(Succeed(), fmt.Sprintf("time out when waiting for updating the global candidate in %s namespace", testNamespace))
+				}, shortTimeout, constants.PipelineRunPollingInterval).Should(Succeed(), fmt.Sprintf("time out when waiting for updating the global candidate in %s namespace", testNamespace))
 			})
 
 			It("checks if all of the integrationPipelineRuns created by push event passed", Label("slow"), func() {
@@ -278,9 +271,6 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 		})
 
 		It("should have a related PaC init PR created", func() {
-			timeout = time.Second * 300
-			interval = time.Second * 1
-
 			Eventually(func() bool {
 				prs, err := f.AsKubeAdmin.CommonController.Github.ListPullRequests(componentRepoNameForGeneralIntegration)
 				Expect(err).ShouldNot(HaveOccurred())
@@ -292,7 +282,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 					}
 				}
 				return false
-			}, timeout, interval).Should(BeTrue(), fmt.Sprintf("timed out when waiting for init PaC PR (branch name '%s') to be created in %s repository", pacBranchName, componentRepoNameForStatusReporting))
+			}, shortTimeout, constants.PipelineRunPollingInterval).Should(BeTrue(), fmt.Sprintf("timed out when waiting for init PaC PR (branch name '%s') to be created in %s repository", pacBranchName, componentRepoNameForStatusReporting))
 
 			// in case the first pipelineRun attempt has failed and was retried, we need to update the value of pipelineRun variable
 			pipelineRun, err = f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, prHeadSha)
@@ -328,7 +318,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 					return fmt.Errorf("test status doesn't have expected value %s", intgteststat.IntegrationTestStatusTestFail)
 				}
 				return nil
-			}, timeout, interval).Should(Succeed())
+			}, shortTimeout, constants.PipelineRunPollingInterval).Should(Succeed())
 		})
 
 		It("checks if the skipped integration test is absent from the Snapshot's status annotation", func() {

--- a/tests/integration-service/pipelinerun-resolution.go
+++ b/tests/integration-service/pipelinerun-resolution.go
@@ -20,7 +20,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
-
+// Temporarily disabled to improve the case
 var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests ITS PipelineRun Resolution", Label("integration-service", "pipelinerun-resolution"), func() {
 	defer GinkgoRecover()
 
@@ -74,8 +74,6 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 
 		When("a new Component is created", func() {
 			It("should have a related PaC init PR created", func() {
-				timeout = time.Second * 600
-
 				Eventually(func() bool {
 					prs, err := f.AsKubeAdmin.CommonController.Github.ListPullRequests(componentRepoNameForResolution)
 					Expect(err).ShouldNot(HaveOccurred())
@@ -90,7 +88,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 						}
 					}
 					return false
-				}, timeout, constants.PipelineRunPollingInterval).Should(BeTrue(), fmt.Sprintf("timed out when waiting for init PaC PR (branch name '%s') to be created in %s repository", pacBranchName, componentRepoNameForStatusReporting))
+				}, longTimeout, constants.PipelineRunPollingInterval).Should(BeTrue(), fmt.Sprintf("timed out when waiting for init PaC PR (branch name '%s') to be created in %s repository", pacBranchName, componentRepoNameForStatusReporting))
 
 				// in case the first pipelineRun attempt has failed and was retried, we need to update the value of pipelineRun variable
 	
@@ -135,7 +133,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 			})
 
 			It("verifies that the finalizer has been removed from the build pipelinerun", func() {
-				timeout = time.Second * 60
+				timeout = time.Second * 300
 				interval = time.Second * 5
 				Eventually(func() error {
 					pipelineRun, err = f.AsKubeDeveloper.IntegrationController.GetBuildPipelineRun(componentName, applicationName, testNamespace, false, "")
@@ -152,7 +150,6 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 			})
 
 			It("checks if the passed status of integration test is reported in the Snapshot", func() {
-				timeout = time.Second * 900
 				Eventually(func() error {
 					snapshot, err = f.AsKubeAdmin.IntegrationController.GetSnapshot(snapshot.Name, "", "", testNamespace)
 					Expect(err).ShouldNot(HaveOccurred())
@@ -165,7 +162,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 						return fmt.Errorf("test status for scenario: %s, doesn't have expected value %s with timeout %s, within the snapshot: %s, has actual result %s", integrationTestScenario.Name, intgteststat.IntegrationTestStatusTestPassed, timeout, snapshot.Name, statusDetail.Status)
 					}
 					return nil
-				}, timeout, constants.PipelineRunPollingInterval).Should(Succeed())
+				}, longTimeout, constants.PipelineRunPollingInterval).Should(Succeed())
 			})
 
 			It("checks if the finalizer was removed from all of the related Integration pipelineRuns", func() {
@@ -263,7 +260,6 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 
 			// TODO: After STONEINTG-1166 is done, we can remove the Pending label
 			It("verifies that ResolutionRequest is deleted after pipeline resolution", Pending, func() {
-				timeout = time.Second * 120
 				interval = time.Second * 5
 
 				Eventually(func() error {
@@ -283,7 +279,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 					}
 
 					return nil
-				}, timeout, interval).Should(Succeed(), "ResolutionRequest objects should be cleaned up after pipeline resolution is complete")
+				}, shortTimeout, interval).Should(Succeed(), "ResolutionRequest objects should be cleaned up after pipeline resolution is complete")
 			})
 
 			// TODO: After STONEINTG-1166 is done, we can remove the Pending label


### PR DESCRIPTION
    * enlarge the timeout and interval when polling plr status change
    * don't use has.WaitForComponentPipelineToBeFinished to get build plr
      status because it retrigger build plr sometimes
    * disable resolution e2e case temporarily to improve it

Signed-off-by: Hongwei Liu <hongliu@redhat.com>
# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
