### PR TITLE
fix: remove retriggering of PLR from upstream test

### DIFF
--- a/tests/konflux-demo/konflux-demo.go
+++ b/tests/konflux-demo/konflux-demo.go
@@ -321,7 +321,7 @@ var _ = framework.KonfluxDemoSuiteDescribe(Label(devEnvTestLabel), func() {
 				})
 			})
 
-			When("push pipelinerun is retriggered", Label(upstreamKonfluxTestLabel), func() {
+			When("push pipelinerun is retriggered", func() {
 				It("should eventually succeed", func() {
 					Expect(fw.AsKubeAdmin.HasController.SetComponentAnnotation(component.GetName(), controllers.BuildRequestAnnotationName, controllers.BuildRequestTriggerPaCBuildAnnotationValue, userNamespace)).To(Succeed())
 					// Check the pipelinerun is triggered


### PR DESCRIPTION
TTSIA

Reason is that this test case dramatically increases the test duration in sanity-test job in konflux-ci repo (which has lot less cluster resources available compared to infra-deployments clusters)