### PR TITLE
fix: OverrideMediaType to properly update BUILDAH_FORMAT

### DIFF
--- a/tests/build/build_templates.go
+++ b/tests/build/build_templates.go
@@ -823,7 +823,19 @@ func enableDockerMediaTypeInPipelineBundle(customDockerBuildBundle string, pipel
 	for i := range dockerPipelineObject.PipelineSpec().Tasks {
 		t := &dockerPipelineObject.PipelineSpec().Tasks[i]
 		if t.Name == "build-container" || t.Name == "build-image-index" || t.Name == "sast-coverity-check" || t.Name == "build-images" {
-			t.Params = append(t.Params, tektonpipeline.Param{Name: "BUILDAH_FORMAT", Value: *tektonpipeline.NewStructuredValues(mediaType)})
+			exist := false
+			for param_idx := range t.Params {
+				param := &t.Params[param_idx]
+				if param.Name == "BUILDAH_FORMAT" {
+					param.Value = *tektonpipeline.NewStructuredValues(mediaType)
+					exist = true
+					break
+				}
+			}
+			if !exist {
+				// param wasn't updated, add it as new param
+				t.Params = append(t.Params, tektonpipeline.Param{Name: "BUILDAH_FORMAT", Value: *tektonpipeline.NewStructuredValues(mediaType)})
+			}
 		}
 	}
 	if newPipelineYaml, err = yaml.Marshal(dockerPipelineObject); err != nil {

--- a/tests/build/build_templates_scenarios.go
+++ b/tests/build/build_templates_scenarios.go
@@ -36,6 +36,7 @@ func (s ComponentScenarioSpec) DeepCopy() ComponentScenarioSpec {
 		PrefetchInput:       s.PrefetchInput,
 		CheckAdditionalTags: s.CheckAdditionalTags,
 		ManifestMediaType:   s.ManifestMediaType,
+		OverrideMediaType:   s.OverrideMediaType,
 		WorkingDirMount:     s.WorkingDirMount,
 	}
 }


### PR DESCRIPTION
# Description
First commit was accidentally reverted
Second commit is fixing missing OverrideMediaType in DeepCopy implementation

## Issue ticket number and link

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
