### PR TITLE
fix: remove build note check in integration gitlab reporting

### DIFF
--- a/tests/integration-service/gitlab-integration-reporting.go
+++ b/tests/integration-service/gitlab-integration-reporting.go
@@ -164,11 +164,6 @@ var _ = framework.IntegrationServiceSuiteDescribe("Gitlab Status Reporting of In
 				Expect(f.AsKubeAdmin.HasController.WaitForComponentPipelineToBeFinished(component, "", "", "",
 					f.AsKubeAdmin.TektonController, &has.RetryOptions{Retries: 2, Always: true}, nil)).To(Succeed())
 			})
-
-			It("eventually leads to the build PipelineRun's status reported at MR notes", func() {
-				expectedNote := fmt.Sprintf("%s-on-pull-request** has successfully validated your commit", componentName)
-				f.AsKubeAdmin.HasController.GitLab.ValidateNoteInMergeRequestComment(projectID, expectedNote, mrID)
-			})
 		})
 
 		When("the PaC build pipelineRun run succeeded", func() {


### PR DESCRIPTION
* This note doesn't consistently show up in gitLab MRs even though the build pipelines do get triggered eventually

Signed-off-by: dirgim <kpavic@redhat.com>

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue ticket number and link

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
