### PR TITLE
fix: scope e2e image update sed to avoid corrupting digests

### DIFF
--- a/.tekton/konflux-e2e-tests-push.yaml
+++ b/.tekton/konflux-e2e-tests-push.yaml
@@ -29,10 +29,10 @@ spec:
     value: Dockerfile
   - name: build-definitions-update-script
     value: |
-      sed -i -E 's/[0-9a-f]{40}/{{ revision }}/g' .tekton/tasks/e2e-test.yaml
+      sed -i -E 's|konflux-e2e-tests:[0-9a-f]{40}|konflux-e2e-tests:{{ revision }}|g' .tekton/tasks/e2e-test.yaml
   - name: update-build-tasks-dockerfiles-script
     value: |
-      sed -i -E 's/[0-9a-f]{40}/{{ revision }}/g' integration-tests/tasks/e2e-test.yaml
+      sed -i -E 's|konflux-e2e-tests:[0-9a-f]{40}|konflux-e2e-tests:{{ revision }}|g' integration-tests/tasks/e2e-test.yaml
   - name: build-platforms
     value:
       - "linux/x86_64"


### PR DESCRIPTION
## Summary

- Scope the post-build SHA replacement in `.tekton/konflux-e2e-tests-push.yaml` so it only rewrites `konflux-e2e-tests:<40-hex>` tags.
- The previous global `s/[0-9a-f]{40}/…/g` also matched the first 40 hex chars of unrelated `@sha256:` digests in the same YAML (e.g. `task-runner`), corrupting downstream update PRs.

Fixes the root cause of konflux-ci/build-definitions#3669 (seen in build-definitions PRs #3601 and #3668).

## Test plan

- [ ] Locally reproduce with a fixture that has a digest whose first 40 hex chars equal the old e2e tag SHA; confirm the new `sed` updates only the e2e image line.
- [ ] After merge: next push to `main` that runs `update-build-definitions-repo` should open an “e2e-tests update” PR that changes only the `konflux-e2e-tests:` tag (digest of `task-runner` unchanged).
- [ ] Same check for the `build-tasks-dockerfiles` update PR (`integration-tests/tasks/e2e-test.yaml`).


Made with [Cursor](https://cursor.com)