### PR TITLE
ci: Drop update-infra-deployments task usage

### DIFF
--- a/.tekton/konflux-e2e-tests-push.yaml
+++ b/.tekton/konflux-e2e-tests-push.yaml
@@ -27,12 +27,6 @@ spec:
     value: quay.io/redhat-user-workloads/konflux-qe-team-tenant/konflux-e2e/konflux-e2e-tests:{{revision}}
   - name: dockerfile
     value: Dockerfile
-  - name: build-definitions-update-script
-    value: |
-      sed -i -E 's/[0-9a-f]{40}/{{ revision }}/g' .tekton/tasks/e2e-test.yaml
-  - name: update-build-tasks-dockerfiles-script
-    value: |
-      sed -i -E 's/[0-9a-f]{40}/{{ revision }}/g' integration-tests/tasks/e2e-test.yaml
   - name: build-platforms
     value:
       - "linux/x86_64"
@@ -138,10 +132,6 @@ spec:
         set of values is determined by the configuration of the multi-platform-controller.
       name: build-platforms
       type: array
-    - default: ""
-      name: build-definitions-update-script
-    - default: ""
-      name: update-build-tasks-dockerfiles-script
     results:
     - description: ""
       name: IMAGE_URL
@@ -470,54 +460,6 @@ spec:
       workspaces:
       - name: workspace
         workspace: workspace
-    - name: update-build-definitions-repo
-      runAfter:
-      - build-image-index
-      params:
-        - name: ORIGIN_REPO
-          value: $(params.git-url)
-        - name: REVISION
-          value: $(params.revision)
-        - name: SCRIPT
-          value: $(params.build-definitions-update-script)
-        - name: TARGET_GH_REPO
-          value: konflux-ci/build-definitions
-        # https://github.com/apps/rh-tap-build-team in https://github.com/konflux-ci
-        - name: GITHUB_APP_INSTALLATION_ID
-          value: "51073377"
-      taskRef:
-        params:
-        - name: name
-          value: update-infra-deployments
-        - name: bundle
-          value: quay.io/redhat-appstudio-tekton-catalog/task-update-infra-deployments:0.1
-        - name: kind
-          value: task
-        resolver: bundles
-    - name: update-build-tasks-dockerfiles-repo
-      runAfter:
-      - build-image-index
-      params:
-        - name: ORIGIN_REPO
-          value: $(params.git-url)
-        - name: REVISION
-          value: $(params.revision)
-        - name: SCRIPT
-          value: $(params.update-build-tasks-dockerfiles-script)
-        - name: TARGET_GH_REPO
-          value: konflux-ci/build-tasks-dockerfiles
-        # https://github.com/apps/rh-tap-build-team in https://github.com/konflux-ci
-        - name: GITHUB_APP_INSTALLATION_ID
-          value: "51073377"
-      taskRef:
-        params:
-        - name: name
-          value: update-infra-deployments
-        - name: bundle
-          value: quay.io/redhat-appstudio-tekton-catalog/task-update-infra-deployments:0.1
-        - name: kind
-          value: task
-        resolver: bundles
     workspaces:
     - name: workspace
     - name: git-auth


### PR DESCRIPTION
Follow-up work after
https://github.com/konflux-ci/build-definitions/pull/3759.

The build-tasks-dockerfiles repo will be deprecated very soon, so no update there.

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue ticket number and link

https://redhat.atlassian.net/browse/STONEBLD-4928

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [x] I have updated labels (if needed)
