### PR TITLE
fix: Permanently delete stale GitLab e2e forks during periodic cleanup.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,8 +57,11 @@ local/template/generate-test-suite:
 local/template/generate-test-spec:
 	./mage -v local:generateTestSpecFile
 
-clean-gitops-repositories:
+clean-github-repos:
 	DRY_RUN=false ./mage -v local:cleanupGithubOrg
+
+# Deprecated alias; Prow still calls this name.
+clean-gitops-repositories: clean-github-repos
 
 clean-github-webhooks:
 	./mage -v cleanGitHubWebHooks

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ local/template/generate-test-spec:
 clean-github-repos:
 	DRY_RUN=false ./mage -v local:cleanupGithubOrg
 
-# Deprecated alias; Prow still calls this name.
+# Deprecated alias - Prow still calls this name.
 clean-gitops-repositories: clean-github-repos
 
 clean-github-webhooks:

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -910,11 +910,13 @@ func CleanupGitLabRepos() error {
 		if dryRun {
 			klog.Infof("\t%s", projectPath)
 		} else if strings.Contains(projectPath, "-deletion_scheduled-") || strings.Contains(projectPath, "-deleted-") {
+			klog.Infof("deleting project %s", projectPath)
 			err := gc.DeleteRepositoryReally(projectPath)
 			if err != nil {
 				klog.Warningf("error deleting project: %s\n", err)
 			}
 		} else {
+			klog.Infof("deleting project %s", projectPath)
 			err := gc.DeleteRepositoryIfExists(projectPath)
 			if err != nil {
 				klog.Warningf("error deleting project: %s\n", err)

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -884,7 +884,7 @@ func CleanupGitLabRepos() error {
 		return err
 	}
 	// Filter repos by regex
-	projectsToBeDeletedRegexp := "^devfile-sample-hello-world-\\S{6}$|^build-nudge-parent-\\S{6}$|^build-nudge-child-\\S{6}$"
+	projectsToBeDeletedRegexp := "^devfile-sample-hello-world-\\S{6}(-deletion_scheduled-\\d+|-deleted-\\d+)?$|^build-nudge-parent-\\S{6}(-deletion_scheduled-\\d+|-deleted-\\d+)?$|^build-nudge-child-\\S{6}(-deletion_scheduled-\\d+|-deleted-\\d+)?$"
 	r, err := regexp.Compile(projectsToBeDeletedRegexp)
 	if err != nil {
 		return fmt.Errorf("unable to compile regex: %s", err)
@@ -897,7 +897,7 @@ func CleanupGitLabRepos() error {
 		if time.Since(*project.CreatedAt) > dayDuration {
 			// Add only repos matching the regex
 			if r.MatchString(project.Name) {
-				projectsToBeDeleted = append(projectsToBeDeleted, project.Name)
+				projectsToBeDeleted = append(projectsToBeDeleted, project.PathWithNamespace)
 			}
 		}
 	}
@@ -906,11 +906,16 @@ func CleanupGitLabRepos() error {
 	}
 
 	// Delete projects
-	for _, projectName := range projectsToBeDeleted {
+	for _, projectPath := range projectsToBeDeleted {
 		if dryRun {
-			klog.Infof("\t%s", projectName)
+			klog.Infof("\t%s", projectPath)
+		} else if strings.Contains(projectPath, "-deletion_scheduled-") || strings.Contains(projectPath, "-deleted-") {
+			err := gc.DeleteRepositoryReally(projectPath)
+			if err != nil {
+				klog.Warningf("error deleting project: %s\n", err)
+			}
 		} else {
-			err := gc.DeleteRepositoryOnlyIfExists(projectName)
+			err := gc.DeleteRepositoryIfExists(projectPath)
 			if err != nil {
 				klog.Warningf("error deleting project: %s\n", err)
 			}

--- a/pkg/clients/gitlab/git.go
+++ b/pkg/clients/gitlab/git.go
@@ -498,14 +498,18 @@ func (gc *GitlabClient) GetAllProjects() ([]*gitlab.Project, error) {
 	}
 	var allProjects []*gitlab.Project
 	for {
+		// Get the current page of projects
 		projects, resp, err := gc.client.Groups.ListGroupProjects(gc.groupID, listProjectsOptions)
 		if err != nil {
 			return allProjects, fmt.Errorf("failed to list projects in group %s: %v", gc.groupID, err)
 		}
 		allProjects = append(allProjects, projects...)
+		// Check if there are more pages. If not, break the loop.
 		if resp.NextPage == 0 {
 			break
 		}
+
+		// Update the page number to fetch the next page in the next iteration
 		listProjectsOptions.Page = resp.NextPage
 	}
 

--- a/pkg/clients/gitlab/git.go
+++ b/pkg/clients/gitlab/git.go
@@ -486,27 +486,26 @@ func (gc *GitlabClient) EnsureBranchExists(projectID, branchName, fallbackBranch
 }
 
 func (gc *GitlabClient) GetAllProjects() ([]*gitlab.Project, error) {
-	listProjectsOptions := &gitlab.ListProjectsOptions{
-		Membership: gitlab.Ptr(true),
+	if gc.groupID == "" {
+		return nil, fmt.Errorf("gitlab group ID is empty")
+	}
+	listProjectsOptions := &gitlab.ListGroupProjectsOptions{
 		ListOptions: gitlab.ListOptions{
 			Page:    1,
 			PerPage: 100,
 		},
+		WithShared: gitlab.Ptr(false),
 	}
 	var allProjects []*gitlab.Project
 	for {
-		// Get the current page of projects
-		projects, resp, err := gc.client.Projects.ListProjects(listProjectsOptions)
+		projects, resp, err := gc.client.Groups.ListGroupProjects(gc.groupID, listProjectsOptions)
 		if err != nil {
-			return allProjects, fmt.Errorf("failed to list projects: %v", err)
+			return allProjects, fmt.Errorf("failed to list projects in group %s: %v", gc.groupID, err)
 		}
 		allProjects = append(allProjects, projects...)
-		// Check if there are more pages. If not, break the loop.
 		if resp.NextPage == 0 {
 			break
 		}
-
-		// Update the page number to fetch the next page in the next iteration
 		listProjectsOptions.Page = resp.NextPage
 	}
 


### PR DESCRIPTION
# Description

Periodic clean-gitlab-repos only soft-deleted forks. GitLab delayed deletion renames them (*-deletion_scheduled-*) and they pile up on konflux-qe. Cleanup now lists group projects, permanently deletes live forks, and hard-deletes delayed-deletion leftovers.

Also rename clean-gitops-repositories to clean-github-repos. The old make target remains as an alias until Prow is updated.

## Issue ticket number and link
 [STONEBLD-4711](https://redhat.atlassian.net/browse/STONEBLD-4711)
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Local group yajgaonk-e2e-test, project build-nudge-child-abc123. Age was modified to 1m for the test as code uses 24h.

`export GITLAB_GROUP_ID=yajgaonk-e2e-test`

Live project: `DRY_RUN=true` listed `yajgaonk-e2e-test/build-nudge-child-abc123`. `DRY_RUN=false` removed it.

Delayed deletion: recreate, perform API soft-delete (202), wait past the age cutoff. `DRY_RUN=true` listed `…/build-nudge-child-abc123-deletion_scheduled-85508498.` `DRY_RUN=false` removed it.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)


[STONEBLD-4711]: https://redhat.atlassian.net/browse/STONEBLD-4711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ