### PR TITLE
fix: forgejo fork repo using local clone

### DIFF
--- a/pkg/clients/forgejo/git.go
+++ b/pkg/clients/forgejo/git.go
@@ -352,7 +352,7 @@ func (fc *ForgejoClient) ForkRepositoryUsingLocalClone(sourceProjectID, targetPr
 	pushCmd := exec.Command("git", "push", "--mirror", targetURL)
 	pushCmd.Dir = clonePath // Run the push from inside the bare clone directory
 	if output, err := pushCmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("failed to push to the target repo %q with: %s\n", targetRepo, string(output))
+		return fmt.Errorf("failed to push to the target repo %q with: %s", targetRepo, string(output))
 	}
 	return nil
 }

--- a/pkg/clients/forgejo/git.go
+++ b/pkg/clients/forgejo/git.go
@@ -4,6 +4,9 @@ import (
 	"encoding/base64"
 	"fmt"
 	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -305,6 +308,53 @@ func (fc *ForgejoClient) ForkRepository(sourceProjectID, targetProjectID string)
 	}
 
 	return migratedRepo, nil
+}
+
+// ForkRepositoryUsingLocalClone clones the source repository locally under a temp direcotry and pushes it to the target repo
+func (fc *ForgejoClient) ForkRepositoryUsingLocalClone(sourceProjectID, targetProjectID string) error {
+	sourceOrg, sourceRepo := splitProjectID(sourceProjectID)
+	targetOrg, targetRepo := splitProjectID(targetProjectID)
+	// Using the token directly in the HTTPS URL guarantees authentication
+	sourceURL := fmt.Sprintf("https://oauth2:%s@codeberg.org/%s/%s.git", fc.token, sourceOrg, sourceRepo)
+	targetURL := fmt.Sprintf("https://oauth2:%s@codeberg.org/%s/%s.git", fc.token, targetOrg, targetRepo)
+
+	// Create a temporary directory for the bare clone
+	tmpDir, err := os.MkdirTemp("", "forgejo-fork-*")
+	if err != nil {
+		return fmt.Errorf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir) // Clean up when finished
+
+	clonePath := filepath.Join(tmpDir, "repo.git")
+
+	fmt.Println("downloading source repository...")
+	cloneCmd := exec.Command("git", "clone", "--bare", sourceURL, clonePath)
+	if output, err := cloneCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("cloning source repo failed with: %s", string(output))
+	}
+
+	fmt.Printf("creating empty repository %q in org %q...\n", targetRepo, targetOrg)
+	opts := forgejo.CreateRepoOption{
+		Name:          targetRepo,
+		Description:   "Repository created using Golang SDK.",
+		Private:       false,
+		AutoInit:      false, // CRITICAL: Ensures no README or .gitignore is generated
+		DefaultBranch: "main",
+	}
+	repo, _, err := fc.client.CreateOrgRepo(targetOrg, opts)
+	if err != nil {
+		return fmt.Errorf("failed to create empty target repository: %v", err)
+	}
+	fmt.Printf("Successfully created empty target repository! Clone URL: %s\n", repo.CloneURL)
+
+	//Mirror-push to the new repository destination
+	fmt.Println("pushing to target repository...")
+	pushCmd := exec.Command("git", "push", "--mirror", targetURL)
+	pushCmd.Dir = clonePath // Run the push from inside the bare clone directory
+	if output, err := pushCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to push to the target repo %q with: %s\n", targetRepo, string(output))
+	}
+	return nil
 }
 
 // DeleteRepository deletes a repository if it exists

--- a/pkg/clients/forgejo/git.go
+++ b/pkg/clients/forgejo/git.go
@@ -311,6 +311,9 @@ func (fc *ForgejoClient) ForkRepository(sourceProjectID, targetProjectID string)
 }
 
 // ForkRepositoryUsingLocalClone clones the source repository locally under a temp direcotry and pushes it to the target repo
+// Using local clone approach has an advantage of avoiding server side clone
+// which MigrateRepo uses internally inside `ForkRepository` method above and has chances of failing with 500 internal server errors
+// This approach will flush out any errors occuring during the repo cloning step
 func (fc *ForgejoClient) ForkRepositoryUsingLocalClone(sourceProjectID, targetProjectID string) error {
 	sourceOrg, sourceRepo := splitProjectID(sourceProjectID)
 	targetOrg, targetRepo := splitProjectID(targetProjectID)

--- a/pkg/clients/git/forgejo.go
+++ b/pkg/clients/git/forgejo.go
@@ -127,7 +127,7 @@ func (f *ForgejoClient) DeleteBranchAndClosePullRequest(repository string, prNum
 }
 
 func (f *ForgejoClient) ForkRepository(sourceRepoName, targetRepoName string) error {
-	err := f.ForgejoClient.ForkRepositoryUsingLocalClone(sourceRepoName, targetRepoName)
+	err := f.ForkRepositoryUsingLocalClone(sourceRepoName, targetRepoName)
 	return err
 }
 

--- a/pkg/clients/git/forgejo.go
+++ b/pkg/clients/git/forgejo.go
@@ -127,7 +127,7 @@ func (f *ForgejoClient) DeleteBranchAndClosePullRequest(repository string, prNum
 }
 
 func (f *ForgejoClient) ForkRepository(sourceRepoName, targetRepoName string) error {
-	_, err := f.ForgejoClient.ForkRepository(sourceRepoName, targetRepoName)
+	err := f.ForgejoClient.ForkRepositoryUsingLocalClone(sourceRepoName, targetRepoName)
 	return err
 }
 
@@ -144,4 +144,3 @@ func (f *ForgejoClient) DeleteBranch(repository, branchName string) error {
 func (f *ForgejoClient) GetCommitStatusConclusion(statusName, projectID, commitSHA string, prNumber int) string {
 	return f.ForgejoClient.GetCommitStatusConclusion(statusName, projectID, commitSHA, int64(prNumber))
 }
-

--- a/pkg/clients/git/forgejo.go
+++ b/pkg/clients/git/forgejo.go
@@ -127,6 +127,7 @@ func (f *ForgejoClient) DeleteBranchAndClosePullRequest(repository string, prNum
 }
 
 func (f *ForgejoClient) ForkRepository(sourceRepoName, targetRepoName string) error {
+	// Use `ForkRepositoryUsingLocalClone` instead of `ForkRepository` to avoid server side errors during repo cloning
 	err := f.ForkRepositoryUsingLocalClone(sourceRepoName, targetRepoName)
 	return err
 }


### PR DESCRIPTION
# Description

ForkRepository failing to fork repository and creating an empty repository instead.
Instead of using MigrateRepo method from forgejo-sdk, locally clone the repo and push to the new target repo.

## Issue ticket number and link
CI failure [here](https://github.com/konflux-ci/build-service/pull/709#issuecomment-5493394604)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested locally.

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
